### PR TITLE
Added functionality to be able to click message scroll options

### DIFF
--- a/Underworld.tscn
+++ b/Underworld.tscn
@@ -69,7 +69,6 @@ follow_viewport_enabled = true
 stream = SubResource("AudioStreamWAV_tkk82")
 
 [node name="UW1" type="CanvasLayer" parent="UI"]
-visible = false
 
 [node name="WeaponAnimationUW1" type="TextureRect" parent="UI/UW1"]
 anchors_preset = -1
@@ -105,20 +104,26 @@ offset_bottom = 484.0
 mouse_filter = 0
 texture = ExtResource("8_mis7n")
 
-[node name="MessageScrollBackgroundUW1" type="TextureRect" parent="UI/UW1"]
+[node name="MessageScrollPanelUW1" type="Panel" parent="UI/UW1"]
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="MessageScrollBackgroundUW1" type="TextureRect" parent="UI/UW1/MessageScrollPanelUW1"]
+layout_mode = 0
 offset_left = 64.0
 offset_top = 676.0
 offset_right = 1224.0
 offset_bottom = 796.0
-mouse_filter = 2
 texture = ExtResource("7_qiq8a")
 
-[node name="MessageScrollUW1" type="RichTextLabel" parent="UI/UW1"]
+[node name="MessageScrollUW1" type="RichTextLabel" parent="UI/UW1/MessageScrollPanelUW1"]
 texture_filter = 1
+layout_mode = 0
 offset_left = 64.0
 offset_top = 651.0
 offset_right = 1224.0
 offset_bottom = 791.0
+mouse_filter = 1
 theme_override_colors/default_color = Color(0.2, 0.109804, 0.0745098, 1)
 theme_override_constants/line_separation = -24
 theme_override_fonts/normal_font = ExtResource("4_pfbet")
@@ -637,7 +642,6 @@ offset_right = 140.0
 offset_bottom = 604.0
 
 [node name="UW2" type="CanvasLayer" parent="UI"]
-visible = false
 
 [node name="WeaponAnimUW2" type="TextureRect" parent="UI/UW2"]
 offset_left = 60.0
@@ -670,20 +674,24 @@ offset_bottom = 476.0
 mouse_filter = 0
 texture = ExtResource("8_mis7n")
 
-[node name="messageScrollBackgroundUW2" type="TextureRect" parent="UI/UW2"]
+[node name="MessageScrollPanelUW2" type="Panel" parent="UI/UW2"]
+
+[node name="messageScrollBackgroundUW2" type="TextureRect" parent="UI/UW2/MessageScrollPanelUW2"]
+layout_mode = 0
 offset_left = 64.0
 offset_top = 676.0
 offset_right = 904.0
 offset_bottom = 792.0
-mouse_filter = 2
 texture = ExtResource("22_vajvs")
 
-[node name="messageScrollUW2" type="RichTextLabel" parent="UI/UW2"]
+[node name="messageScrollUW2" type="RichTextLabel" parent="UI/UW2/MessageScrollPanelUW2"]
 texture_filter = 1
+layout_mode = 0
 offset_left = 73.0
 offset_top = 656.0
 offset_right = 913.0
 offset_bottom = 796.0
+mouse_filter = 1
 theme_override_colors/default_color = Color(0, 0, 0, 1)
 theme_override_constants/line_separation = -24
 theme_override_fonts/normal_font = ExtResource("4_pfbet")
@@ -905,7 +913,6 @@ offset_right = 580.0
 offset_bottom = 639.0
 
 [node name="CutsceneSmallUW2" type="TextureRect" parent="UI/UW2"]
-visible = false
 offset_left = -384.0
 offset_top = -268.0
 offset_right = 896.0
@@ -974,6 +981,7 @@ offset_right = 508.0
 offset_bottom = 624.0
 
 [node name="ConversationUW2" type="Panel" parent="UI/UW2"]
+visible = false
 offset_right = 40.0
 offset_bottom = 40.0
 
@@ -2028,7 +2036,6 @@ offset_bottom = 624.0
 texture = ExtResource("28_uj0ag")
 
 [node name="HealthFlask" type="Panel" parent="UI/Common"]
-visible = false
 offset_right = 40.0
 offset_bottom = 40.0
 
@@ -2144,7 +2151,6 @@ offset_bottom = 532.0
 mouse_filter = 2
 
 [node name="ManaFlask" type="Panel" parent="UI/Common"]
-visible = false
 offset_left = 144.0
 offset_right = 184.0
 offset_bottom = 40.0
@@ -2520,7 +2526,6 @@ middle_mouse_paste_enabled = false
 selecting_enabled = false
 
 [node name="PositionLabel" type="RichTextLabel" parent="UI/Common"]
-visible = false
 texture_filter = 1
 offset_left = 28.0
 offset_top = -9.0
@@ -2651,9 +2656,9 @@ AutomapBG = NodePath("../Common/Automap/MapBackground")
 AutomapImage = NodePath("../Common/Automap/MapImage")
 NotesPanel = NodePath("../Common/Automap/MapNotes")
 AutomapNumberLabel = NodePath("../Common/Automap/MapNo")
-AutomapWorldGem = [NodePath("../Common/Automap/Gem/World0"), NodePath("../Common/Automap/Gem/World1"), NodePath("../Common/Automap/Gem/World2"), NodePath("../Common/Automap/Gem/World3"), NodePath("../Common/Automap/Gem/World4"), NodePath("../Common/Automap/Gem/World5"), NodePath("../Common/Automap/Gem/World7"), NodePath("../Common/Automap/Gem/World6"), NodePath("../Common/Automap/Gem/World8")]
-messageScrollUW1 = NodePath("../UW1/MessageScrollUW1")
-messageScrollUW2 = NodePath("../UW2/messageScrollUW2")
+AutomapWorldGem = [NodePath("../Common/Automap/Gem/World0"), NodePath("../Common/Automap/Gem/World1"), NodePath("../Common/Automap/Gem/World2"), NodePath("../Common/Automap/Gem/World3"), NodePath("../Common/Automap/Gem/World4"), NodePath("../Common/Automap/Gem/World5"), NodePath("../Common/Automap/Gem/World6"), NodePath("../Common/Automap/Gem/World7"), NodePath("../Common/Automap/Gem/World8")]
+messageScrollUW1 = NodePath("../UW1/MessageScrollPanelUW1/MessageScrollUW1")
+messageScrollUW2 = NodePath("../UW2/MessageScrollPanelUW2/messageScrollUW2")
 TypedInput = NodePath("../Common/TypedInput")
 GameOptionButtonsUW1 = [NodePath("../UW1/GameOptionsUW1_0"), NodePath("../UW1/GameOptionsUW1_1"), NodePath("../UW1/GameOptionsUW1_2"), NodePath("../UW1/GameOptionsUW1_3"), NodePath("../UW1/GameOptionsUW1_4"), NodePath("../UW1/GameOptionsUW1_5"), NodePath("../UW1/GameOptionsUW1_6")]
 GameOptionButtonsUW2 = [NodePath("../UW2/GameOptionsUW2_0"), NodePath("../UW2/GameOptionsUW2_1"), NodePath("../UW2/GameOptionsUW2_2"), NodePath("../UW2/GameOptionsUW2_3"), NodePath("../UW2/GameOptionsUW2_4"), NodePath("../UW2/GameOptionsUW2_5"), NodePath("../UW2/GameOptionsUW2_6")]
@@ -2741,6 +2746,8 @@ PowerGemUW2 = NodePath("../UW2/PowerGemUW2")
 
 [node name="tilemap" type="Node3D" parent="."]
 
+[connection signal="mouse_entered" from="UI/UW1/MessageScrollPanelUW1" to="UI/uiManager" method="_on_message_scroll_mouse_entered"]
+[connection signal="mouse_exited" from="UI/UW1/MessageScrollPanelUW1" to="UI/uiManager" method="_on_message_scroll_mouse_exit"]
 [connection signal="gui_input" from="UI/UW1/CompassUW1/CompassClickArea" to="UI/uiManager" method="_on_compass_click"]
 [connection signal="gui_input" from="UI/UW1/ConversationUW1/PlayerTradeSelectedUW1_0" to="UI/uiManager" method="_on_player_trade_selected" binds= [0]]
 [connection signal="gui_input" from="UI/UW1/ConversationUW1/PlayerTradeSelectedUW1_1" to="UI/uiManager" method="_on_player_trade_selected" binds= [1]]
@@ -2771,6 +2778,8 @@ PowerGemUW2 = NodePath("../UW2/PowerGemUW2")
 [connection signal="gui_input" from="UI/UW1/GameOptionsUW1_4" to="UI/uiManager" method="_on_game_options_input" binds= [4]]
 [connection signal="gui_input" from="UI/UW1/GameOptionsUW1_5" to="UI/uiManager" method="_on_game_options_input" binds= [5]]
 [connection signal="gui_input" from="UI/UW1/GameOptionsUW1_6" to="UI/uiManager" method="_on_game_options_input" binds= [6]]
+[connection signal="mouse_entered" from="UI/UW2/MessageScrollPanelUW2" to="UI/uiManager" method="_on_message_scroll_mouse_entered"]
+[connection signal="mouse_exited" from="UI/UW2/MessageScrollPanelUW2" to="UI/uiManager" method="_on_message_scroll_mouse_exit"]
 [connection signal="gui_input" from="UI/UW2/OptionsButtonUW2" to="UI/uiManager" method="_on_interactionoptions_button" binds= [0]]
 [connection signal="gui_input" from="UI/UW2/TalkButtonUW2" to="UI/uiManager" method="_on_interactionoptions_button" binds= [1]]
 [connection signal="gui_input" from="UI/UW2/PickupButtonUW2" to="UI/uiManager" method="_on_interactionoptions_button" binds= [2]]

--- a/main.cs
+++ b/main.cs
@@ -393,18 +393,43 @@ public partial class main : Node3D
 			&& !uimanager.MessageScrollIsTemporary
 			&& !MessageDisplay.WaitingForTypedInput)
 		{
-			if (@event is InputEventKey keyinput)
+			switch (@event)
 			{
-				if (keyinput.Pressed)
-				{
-					if (int.TryParse(keyinput.AsText(), out int result))
+				//Click to select options in conversation. Ensure we only allow left &right click to adhere to the original UW implementation. 
+				case InputEventMouseButton mouseEvent:
+					if (uimanager.CursorOverMessageScroll)
 					{
-						if ((result > 0) && (result <= ConversationVM.MaxAnswer))
+						if (mouseEvent.Pressed && (mouseEvent.ButtonIndex == MouseButton.Left || mouseEvent.ButtonIndex == MouseButton.Right))
 						{
-							ConversationVM.PlayerNumericAnswer = result;
-							ConversationVM.WaitingForInput = false;
+							int result = uimanager.instance.HandleMessageScrollClick(mouseEvent);
+							if ((result > 0) && (result <= ConversationVM.MaxAnswer))
+							{
+								ConversationVM.PlayerNumericAnswer = result;
+								ConversationVM.WaitingForInput = false;
+							}
+							//GD.Print("Mouse Clicked in conversation");
 						}
 					}
+	
+					break;
+				
+				//Using keyboard numbers to select options in conversation
+				case InputEventKey keyinput:
+				{
+
+					if (keyinput.Pressed)
+					{
+						if (int.TryParse(keyinput.AsText(), out int result))
+						{
+							if ((result > 0) && (result <= ConversationVM.MaxAnswer))
+							{
+								ConversationVM.PlayerNumericAnswer = result;
+								ConversationVM.WaitingForInput = false;
+							}
+						}
+					}
+
+					break;
 				}
 			}
 		}

--- a/src/ui/uimanager_messagescroll.cs
+++ b/src/ui/uimanager_messagescroll.cs
@@ -2,155 +2,204 @@ using Godot;
 
 namespace Underworld
 {
-    public partial class uimanager : Node2D
-    {
-        [ExportGroup("Messagescroll")]
-        [Export] public RichTextLabel messageScrollUW1;
-        [Export] public RichTextLabel messageScrollUW2;
+	public partial class uimanager : Node2D
+	{
+		[ExportGroup("Messagescroll")]
+		[Export] public RichTextLabel messageScrollUW1;
+		[Export] public RichTextLabel messageScrollUW2;
 
-        /// <summary>
-        /// Any typed content, eg "other text" in conversations, quantities to be picked up.
-        /// Will auto replace the special text {TYPEDINPUT} in the scrolls.
-        /// </summary>
+		/// <summary>
+		/// Any typed content, eg "other text" in conversations, quantities to be picked up.
+		/// Will auto replace the special text {TYPEDINPUT} in the scrolls.
+		/// </summary>
 
-        [Export] public LineEdit TypedInput;
+		[Export] public LineEdit TypedInput;
 
-        public MessageDisplay scroll = new();
+		public MessageDisplay scroll = new();
 
-        public MessageDisplay convo = new();
+		public MessageDisplay convo = new();
 
-        public static bool MessageScrollIsTemporary = false;
+		public static bool MessageScrollIsTemporary = false;
 
-        /// <summary>
-        /// forces text to appear in front of the next string outputed. Used to display messages like The sign says
-        /// </summary>
-        public static string NextOutputPrependedString = "";
+		public static bool CursorOverMessageScroll = false; //Used to determine where cursor is when clicking conversation options
 
-        public static void InitMessageScrolls()
-        {
-            instance.scroll = new();
-            for (int i = 0; i <= instance.scroll.Lines.GetUpperBound(0); i++)
-            {
-                instance.scroll.Lines[i] = new();
-            }
-            instance.scroll.OutputControl = new RichTextLabel[] { MessageScroll };
+		/// <summary>
+		/// forces text to appear in front of the next string outputed. Used to display messages like The sign says
+		/// </summary>
+		public static string NextOutputPrependedString = "";
 
-            instance.convo = new();
-            if (UWClass._RES == UWClass.GAME_UW2)
-            {
-                instance.convo.Lines = new MessageScrollLine[12];
-                instance.convo.Rows = 12;
-                instance.convo.Columns = 40;
+		public static void InitMessageScrolls()
+		{
+			instance.scroll = new();
+			for (int i = 0; i <= instance.scroll.Lines.GetUpperBound(0); i++)
+			{
+				instance.scroll.Lines[i] = new();
+			}
+			instance.scroll.OutputControl = new RichTextLabel[] { MessageScroll };
 
-                instance.scroll.Columns = 50;
-            }
-            else
-            {
-                instance.convo.Lines = new MessageScrollLine[13];
-                instance.convo.Rows = 13;
-                instance.convo.Columns = 36;
-            }
+			instance.convo = new();
+			if (UWClass._RES == UWClass.GAME_UW2)
+			{
+				instance.convo.Lines = new MessageScrollLine[12];
+				instance.convo.Rows = 12;
+				instance.convo.Columns = 40;
 
-            for (int i = 0; i <= instance.convo.Lines.GetUpperBound(0); i++)
-            {
-                instance.convo.Lines[i] = new();
-            }
-            instance.convo.OutputControl = new RichTextLabel[] { ConversationText };
-        }
+				instance.scroll.Columns = 50;
+			}
+			else
+			{
+				instance.convo.Lines = new MessageScrollLine[13];
+				instance.convo.Rows = 13;
+				instance.convo.Columns = 36;
+			}
 
-        public static RichTextLabel MessageScroll
-        {
-            get
-            {
-                switch (UWClass._RES)
-                {
-                    case UWClass.GAME_UW2:
-                        return instance.messageScrollUW2;
-                    default:
-                        return instance.messageScrollUW1;
-                }
-            }
-        }
+			for (int i = 0; i <= instance.convo.Lines.GetUpperBound(0); i++)
+			{
+				instance.convo.Lines[i] = new();
+			}
+			instance.convo.OutputControl = new RichTextLabel[] { ConversationText };
+		}
 
-        /// <summary>
-        /// Adds to the bottom scroll
-        /// </summary>
-        /// <param name="stringToAdd"></param>
-        /// <param name="option"></param>
-        /// <param name="colour"></param>
-        public static void AddToMessageScroll(string stringToAdd, int option = 0, int colour = 0, MessageDisplay.MessageDisplayMode mode = MessageDisplay.MessageDisplayMode.NormalMode)
-        {
-            if (MessageScrollIsTemporary)
-            {//don't allow any overwriting when a message is already being displayed temporarily.
-                return;
-            }
+		public static RichTextLabel MessageScroll
+		{
+			get
+			{
+				switch (UWClass._RES)
+				{
+					case UWClass.GAME_UW2:
+						return instance.messageScrollUW2;
+					default:
+						return instance.messageScrollUW1;
+				}
+			}
+		}
 
-            if (NextOutputPrependedString!="")
-            {//forces messages to include text like "the sign says"
-                stringToAdd = NextOutputPrependedString + stringToAdd;
-                NextOutputPrependedString = "";
-            }
+		/// <summary>
+		/// Adds to the bottom scroll
+		/// </summary>
+		/// <param name="stringToAdd"></param>
+		/// <param name="option"></param>
+		/// <param name="colour"></param>
+		public static void AddToMessageScroll(string stringToAdd, int option = 0, int colour = 0, MessageDisplay.MessageDisplayMode mode = MessageDisplay.MessageDisplayMode.NormalMode)
+		{
+			if (MessageScrollIsTemporary)
+			{//don't allow any overwriting when a message is already being displayed temporarily.
+				return;
+			}
 
-            switch (mode)
-            {
-                // case MessageDisplay.MessageDisplayMode.TypedInput:
-                //     //TODO.
-                //     break;
-                case MessageDisplay.MessageDisplayMode.TemporaryMessage:
-                    {
-                        //back up lines
-                        var backup = BackupLines(instance.scroll.Lines, 5);
-                        MessageScrollIsTemporary = true;
-                        instance.scroll.Clear();
-                        _ = Peaky.Coroutines.Coroutine.Run(
-                            instance.scroll.AddText(newText: stringToAdd, option: option, colour: colour),
-                            main.instance
-                            );
+			if (NextOutputPrependedString!="")
+			{//forces messages to include text like "the sign says"
+				stringToAdd = NextOutputPrependedString + stringToAdd;
+				NextOutputPrependedString = "";
+			}
 
-                        _ = Peaky.Coroutines.Coroutine.Run(
-                            instance.scroll.RestoreLinesAfterWait(backup, 2f),
-                            main.instance
-                            );
-                        break;
-                    }
-                case MessageDisplay.MessageDisplayMode.NormalMode:
-                case MessageDisplay.MessageDisplayMode.TypedInput:
-                default:
-                    {
-                        _ = Peaky.Coroutines.Coroutine.Run(
-                                instance.scroll.AddText(newText: stringToAdd, option: option, colour: colour),
-                                main.instance
-                                );
-                        break;
-                    }
-            }
-        }
+			switch (mode)
+			{
+				// case MessageDisplay.MessageDisplayMode.TypedInput:
+				//     //TODO.
+				//     break;
+				case MessageDisplay.MessageDisplayMode.TemporaryMessage:
+					{
+						//back up lines
+						var backup = BackupLines(instance.scroll.Lines, 5);
+						MessageScrollIsTemporary = true;
+						instance.scroll.Clear();
+						_ = Peaky.Coroutines.Coroutine.Run(
+							instance.scroll.AddText(newText: stringToAdd, option: option, colour: colour),
+							main.instance
+							);
 
-        public static MessageScrollLine[] BackupLines(MessageScrollLine[] toBackup, int size)
-        {
-            var existingLines = new MessageScrollLine[size];
-            for (int i = 0; i <= existingLines.GetUpperBound(0); i++)
-            {
-                existingLines[i] = new MessageScrollLine(toBackup[i].OptionNo, toBackup[i].LineText);
-            }
-            return existingLines;
-        }
+						_ = Peaky.Coroutines.Coroutine.Run(
+							instance.scroll.RestoreLinesAfterWait(backup, 2f),
+							main.instance
+							);
+						break;
+					}
+				case MessageDisplay.MessageDisplayMode.NormalMode:
+				case MessageDisplay.MessageDisplayMode.TypedInput:
+				default:
+					{
+						_ = Peaky.Coroutines.Coroutine.Run(
+								instance.scroll.AddText(newText: stringToAdd, option: option, colour: colour),
+								main.instance
+								);
+						break;
+					}
+			}
+		}
+
+		public static MessageScrollLine[] BackupLines(MessageScrollLine[] toBackup, int size)
+		{
+			var existingLines = new MessageScrollLine[size];
+			for (int i = 0; i <= existingLines.GetUpperBound(0); i++)
+			{
+				existingLines[i] = new MessageScrollLine(toBackup[i].OptionNo, toBackup[i].LineText);
+			}
+			return existingLines;
+		}
 
 
-        /// <summary>
-        /// Adds the text to the conversation scroll
-        /// </summary>
-        /// <param name="stringToAdd"></param>
-        /// <param name="colour"></param>
-        public static void AddToConvoScroll(string stringToAdd, int colour = 0)
-        {
-            //MessageScroll.Text = stringToAdd;
-            _ = Peaky.Coroutines.Coroutine.Run(
-                instance.convo.AddText(newText: stringToAdd, colour: colour),
-                main.instance
-                );
-        }
+		/// <summary>
+		/// Adds the text to the conversation scroll
+		/// </summary>
+		/// <param name="stringToAdd"></param>
+		/// <param name="colour"></param>
+		public static void AddToConvoScroll(string stringToAdd, int colour = 0)
+		{
+			//MessageScroll.Text = stringToAdd;
+			_ = Peaky.Coroutines.Coroutine.Run(
+				instance.convo.AddText(newText: stringToAdd, colour: colour),
+				main.instance
+				);
+		}
+		
+		/// <summary>
+		/// Sets CursorOverMessageScroll to true when cursor enters the message scroll panel
+		/// </summary>
+		public void _on_message_scroll_mouse_entered()
+		{
+			GD.Print("Cursor on scroll");
+			CursorOverMessageScroll = true;
+		}
+		
+		/// <summary>
+		/// Sets CursorOverMessageScroll to false when cursor exits the message scroll panel
+		/// </summary>
+		public void _on_message_scroll_mouse_exit()
+		{
+			GD.Print("Cursor exited scroll");
+			CursorOverMessageScroll = false;
+		}
 
-    } //end class
+		/// <summary>
+		/// When presented with a list of options in the message scroll, this determines which option is clicked.
+		/// </summary>
+		/// <param name="mouseButton">Mouse click event if clicked in scroll message panel during conversation</param>
+		public int HandleMessageScrollClick(InputEventMouseButton mouseButton)
+		{
+			//Calculate the height of a line in the rich text box
+			int lineHeight = (int)MessageScroll.Size.Y / MessageScroll.GetLineCount();
+			
+			//Get the clicked position within the message scroll panel
+			Vector2 localClickPosition = mouseButton.Position - MessageScroll.Position;
+			
+			//Calculate the clicked line
+			int clickedLine = (int)(localClickPosition.Y / lineHeight);
+
+			// Validate the clicked line index
+			if (clickedLine >= 0 && clickedLine < MessageScroll.GetLineCount())
+			{
+				GD.Print($"Clicked line: {clickedLine + 1}");
+				return clickedLine + 1;
+
+			}
+			else
+			{
+				GD.Print("Click was outside of valid lines.");
+				return -1;
+			}
+		}
+		
+	} //end class
 
 }//end namespace


### PR DESCRIPTION
Added functionality to click options within the message scroll window when presented with choices (such as conversation responses), so that control is no longer keyboard exclusive and adheres to the original game.

A new panel node was created for UW1 and UW2, with their respective "MessageScrollBackground" TextureRect and "MessageScroll" RichText placed as children so that mouse events can be intercepted 

Signals were added to these two panels for "mouseEnter" and "mouseExit" so we know when the cursor is over the scroll message window.

**main.cs:**
- Added new functionality to look for mouse clicks when waiting for player selection during conversation

**uimanager_messagescroll.cs:**
- Added the functions for mouse over and to handle clicking to determine which line/option was selected
