### PR TITLE
Fix for scene array reference issues

### DIFF
--- a/LaunchScene.tscn
+++ b/LaunchScene.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://ba5m1urf788ey"]
+
+[ext_resource type="Script" path="res://src/utility/LaunchScene.cs" id="1_ukjsy"]
+
+[node name="LaunchScene" type="Node2D"]
+script = ExtResource("1_ukjsy")

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ No exe builds yet. This is just a glorified map viewer at this point that you wi
 See [https://godotengine.org/](https://godotengine.org/) for engine runtime downloads.
 
 1. Clone the repository
-2. Install the Godot engine dev  https://godotengine.org/ and run it.
+2. Install the Godot engine (version 4.1.1) dev  https://godotengine.org/ and run it.
 3. Save a file called ``uwsettings.json`` in the Godot Folder. See below for format of the file
-4. Open the Project scene file ``Underworld.tscn`` in Godot.
+4. Godot project will open at ``LaunchScene.tscn``. IMPORTANT: Make sure you run BUILD on the project before continuing.
 5. Run. It might work
 
 This project is developed using VSCode using the C# Tools for Godot extensions.

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Underworld"
-run/main_scene="res://Underworld.tscn"
+run/main_scene="res://LaunchScene.tscn"
 config/features=PackedStringArray("4.1", "C#", "Forward Plus")
 config/icon="res://resources/icon/dragon.png"
 

--- a/src/utility/LaunchScene.cs
+++ b/src/utility/LaunchScene.cs
@@ -1,0 +1,20 @@
+using Godot;
+using System;
+
+namespace Underworld
+{
+	public partial class LaunchScene : Node
+	{
+		// Called when the node enters the scene tree for the first time.
+		public override void _Ready()
+		{
+			GD.Print("Launch scene now loading Underworld.tscn.");
+			GetTree().ChangeSceneToFile("res://Underworld.tscn");
+		}
+
+		// Called every frame. 'delta' is the elapsed time since the previous frame.
+		public override void _Process(double delta)
+		{
+		}
+	}
+}


### PR DESCRIPTION
I'm sure it's a Godot bug, but this update will fix the array referencing issues. 

1. A new scene has been created called "LaunchScene.tscn" which is set as the default starting scene
2. It has a script which will load Underworld.tscn in the `_Ready()` function

I've updated the README.md to reflect the required steps, but basically you need to ensure that you always run build right after opening the project at LaunchScene.tscn. For some reason, Godot is having a problem with Underworld.tscn being the default scene when you open the project. 