### PR TITLE
Adding git lfs tracking for binary files to reduce repo bloat.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This is just the config to track new binary files being created in the repo of types already present.
I can try to do a basic migration of the current files so new versions of them get handled by the tool, but converting them properly requires rewriting the whole git history (not something you can really do in a PR).

In case you're not familiar with Git LFS, git isn't able to calculate differences between binary files enough to effectively compress them across commits.
This means that any non-sparse repo checkouts will be forced to download every single version of every binary file ever committed to the history.

Git LFS avoids that by having git store a reference in the object database instead of the file itself. The files are actually stored using a different mechanism that only downloads them when needed. GitHub has native support for this (might need to tick a box, though).