### PR TITLE
Updating godot engine to 4.3-stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Backup files
+*.old
+*.old.*
+
 # User-specific files
 *.rsuser
 *.suo

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ No exe builds yet. This is just a glorified map viewer at this point that you wi
 See [https://godotengine.org/](https://godotengine.org/) for engine runtime downloads.
 
 1. Clone the repository
-2. Install the Godot engine (version 4.1.1) dev  https://godotengine.org/ and run it.
+2. Install the Godot engine (version 4.3-stable) from https://godotengine.org/ and run it.
 3. Save a file called ``uwsettings.json`` in the Godot Folder. See below for format of the file
 4. Godot project will open at ``LaunchScene.tscn``. IMPORTANT: Make sure you run BUILD on the project before continuing.
 5. Run. It might work

--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.1.1">
+<Project Sdk="Godot.NET.Sdk/4.3.0">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Underworld"
 run/main_scene="res://LaunchScene.tscn"
-config/features=PackedStringArray("4.1", "C#", "Forward Plus")
+config/features=PackedStringArray("4.3", "C#", "Forward Plus")
 config/icon="res://resources/icon/dragon.png"
 
 [display]

--- a/src/World/automaprender.cs
+++ b/src/World/automaprender.cs
@@ -138,7 +138,7 @@ namespace Underworld
         public static ImageTexture MapImage(int levelno)
         {
             //rnd = new System.Random();
-            var OutputTileMapImage = Image.Create(64 * TileSize, 64 * TileSize, false, Image.Format.Rgba8);
+            var OutputTileMapImage = Image.CreateEmpty(64 * TileSize, 64 * TileSize, false, Image.Format.Rgba8);
             mapToRender = automap.automaps[levelno];
 
             //Fills in the tile background colour first

--- a/src/loaders/artloader.cs
+++ b/src/loaders/artloader.cs
@@ -105,7 +105,7 @@ namespace Underworld
                 }
             }
 
-            var img = Godot.Image.Create(width, height, false, imgformat);
+            var img = Godot.Image.CreateEmpty(width, height, false, imgformat);
             for (int iRow = 0; iRow < height; iRow++)
             {
                 int iCol = 0;
@@ -263,7 +263,7 @@ namespace Underworld
 
         public static ImageTexture CropImage(Image src, Rect2I rect)
         {
-            var img = Godot.Image.Create(rect.Size.X, rect.Size.Y, false, src.GetFormat());
+            var img = Godot.Image.CreateEmpty(rect.Size.X, rect.Size.Y, false, src.GetFormat());
             img.BlitRect(src, rect, Vector2I.Zero);
             var tex = new ImageTexture();
             tex.SetImage(img);

--- a/src/loaders/shadesdatloader.cs
+++ b/src/loaders/shadesdatloader.cs
@@ -34,7 +34,7 @@ namespace Underworld
         public static Godot.ImageTexture GetFullShadingImage(Palette pal, lightmap[] maps, int index, string filename)
         {
             int BandSize = Math.Max(uwsettings.instance.shaderbandsize,1);
-            var img = Godot.Image.Create(256, BandSize * 15, false, Godot.Image.Format.Rgba8);
+            var img = Godot.Image.CreateEmpty(256, BandSize * 15, false, Godot.Image.Format.Rgba8);
             var arr = shadesdata[index].ExtractShadeArray();
             //int y = 0;
             lightmap basemap = maps[0];
@@ -218,7 +218,7 @@ namespace Underworld
             var AllShades = ExtractShadingTable(shadearray);
             var width = AllShades.GetUpperBound(0);
             var height = AllShades.GetUpperBound(1);
-            var img = Godot.Image.Create(width, height, false, Godot.Image.Format.R8);
+            var img = Godot.Image.CreateEmpty(width, height, false, Godot.Image.Format.R8);
 
             for (int x = 0; x < width; x++)
             {

--- a/src/ui/uimanager_cuts.cs
+++ b/src/ui/uimanager_cuts.cs
@@ -94,7 +94,7 @@ namespace Underworld
         {
             var palette = PaletteLoader.Palettes[0];
             var width = 2; var height = 2;
-            var img = Image.Create(width, height, false, Image.Format.Rgb8);
+            var img = Image.CreateEmpty(width, height, false, Image.Format.Rgb8);
             for (int iRow = 0; iRow < height; iRow++)
             {
                 int iCol = 0;

--- a/src/utility/palette.cs
+++ b/src/utility/palette.cs
@@ -93,7 +93,7 @@ namespace Underworld
         //Returns a 2x2 texture representing the pixel index for use in rendering a single colour on a model.
         public static ImageTexture IndexToImage(byte index)
         {
-            var img = Image.Create(2,2,false,Image.Format.R8);
+            var img = Image.CreateEmpty(2,2,false,Image.Format.R8);
             var c = new Color(
                     g: 0,
                     r: index / 255f,


### PR DESCRIPTION
* Updated version mentioned in `README`.
* Added annoying backup file patterns to `.gitignore`.
* Updated all deprecated functions to their replacements.

NOTE: 4.3 is the last version compatible with dotnet 6.