### PR TITLE
Real-time music synthesis: CM-32L, MT-32, SoundFont, OPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,7 @@ export.cfg
 data_*/
 mono_crash.*.json
 tmp/
+
+# Only the bundled default.sf2 is committed; other soundfonts are user-supplied
+soundfonts/*.sf2
+!soundfonts/default.sf2

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Requires game files for either UW1 or UW2. GOG versions need to be extracted usi
 * NPC Combat Actions
 * Player movement and collision (with a lot of jank attached incl framerate/speed issues)
 * Speech from VOC files
-* Real-time music synthesis from XMI via four selectable synth engines (CM-32L/MT-32 via mt32emu, SoundFont via MeltySynth, or AdLib/OPL).
+* Real-time music synthesis from XMI via four selectable synth engines (CM-32L/MT-32 via mt32emu, SoundFont via MeltySynth, or AdLib/OPL via AdlMidi).
 
 ## Whats missing
 
@@ -185,21 +185,31 @@ F12 Debug process SCD.ARK events
 Tilde (~) Give all runestones, 30 mana and maximise mage skills.
 
 ## Music
-Music themes can now be loaded. This relies on the Ùnderworld project referencing libADLMIDI via the AdlMidi wrapper project at https://github.com/csinkers/AdlMidi.NET for Opl/Adlib style or MUNT.NET https://github.com/abedegno/Munt.NET for MT-32
-Music is rendered in real time via one of four synth engines: Roland CM-32L or MT-32 (via mt32emu, requires user-supplied ROM files), SoundFont (via MeltySynth, ships with a bundled GeneralUser GS soundfont), or AdLib/OPL (via AdlMidi.NET). The synth engine is selected by the `synth` setting in `uwsettings.json`. Themes are played via the `XMIMusic.ChangeTheme` function, which delegates to the `MusicStreamPlayer` node.
+Music is rendered in real time via one of four synth engines, selected by the `synth` setting in `uwsettings.json`:
 
-To use OPL set the synth setting in settings.json to ``opl``
-To use MT-32 set the synth setting in settings.json to ``cm32l``
+* `cm32l` or `mt32` — authentic Roland CM-32L/MT-32 emulation via [Munt.NET](https://github.com/abedegno/Munt.NET), requires user-supplied ROM files
+* `soundfont` (default) — [MeltySynth](https://github.com/sinshu/meltysynth) with a bundled GeneralUser GS SoundFont, works out of the box
+* `opl` — AdLib/OPL FM synthesis via [AdlMidi.NET](https://github.com/csinkers/AdlMidi.NET)
 
-To use MT-32 you will need to have a suitable MT-32 Rom files (see list below) stored in either the ``%appdata%\Roaming\Godot\app_userdata\Underworld`` folder or the underworld ``SOUND`` folder
+Themes are played via the `XMIMusic.ChangeTheme` function, which delegates to the `MusicStreamPlayer` node. No pre-rendering or WAV caching — audio is synthesised on demand.
+
+### ROM files (cm32l / mt32 only)
+
+If you use `cm32l` or `mt32`, set `synthpath` to a directory containing the ROM files. Standard and MAME-style filenames are both recognised:
 
 ```
-    "CM32L_CONTROL.ROM", "CM32L_PCM.ROM",
-    "cm32l_ctrl_1_02.rom", "cm32l_pcm.rom"
-    "cm32l_ctrl_1_00.rom", "cm32l_pcm.rom"
+    CM32L_CONTROL.ROM   / CM32L_PCM.ROM
+    cm32l_ctrl_1_02.rom / cm32l_pcm.rom
+    cm32l_ctrl_1_00.rom / cm32l_pcm.rom
+    MT32_CONTROL.ROM    / MT32_PCM.ROM
+    mt32_ctrl_1_07.rom  / mt32_pcm.rom  (and 1.04/1.05/1.06)
 ```
 
-In order to switch between ``opl`` and ``cm32l`` settings the files will need to be deleted/removed from the ``%appdata%\Roaming\Godot\app_userdata\Underworld\SOUND\{1 or 2}`` folder
+If the selected engine fails to initialise (missing ROMs, bad soundfont, etc.) the system silently falls back to OPL. Changing the `synth` setting requires a game restart.
+
+### Conceptual inspiration
+
+The real-time synthesis approach was inspired by [Kweepa](https://github.com/Kweepa)'s Unity-based Ultima Underworld port, which demonstrated that playing XMI music through a MIDI sequencer in real time (rather than pre-rendering to WAV) gives gapless looping and avoids startup conversion delay.
 
 
 ## Code Contributions

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Requires game files for either UW1 or UW2. GOG versions need to be extracted usi
 * NPC Combat Actions
 * Player movement and collision (with a lot of jank attached incl framerate/speed issues)
 * Speech from VOC files
-* Music conversion from XMI to WAV for runtime loading of music. (partial implementation currently of just the main intro themes)
+* Real-time music synthesis from XMI via four selectable synth engines (CM-32L/MT-32 via mt32emu, SoundFont via MeltySynth, or AdLib/OPL).
 
 ## Whats missing
 
@@ -186,7 +186,7 @@ Tilde (~) Give all runestones, 30 mana and maximise mage skills.
 
 ## Music
 Music themes can now be loaded. This relies on the Ùnderworld project referencing libADLMIDI via the AdlMidi wrapper project at https://github.com/csinkers/AdlMidi.NET for Opl/Adlib style or MUNT.NET https://github.com/abedegno/Munt.NET for MT-32
-Themes are converted at runtime into .wav files which can them be loaded via the XMIMusic class ``ChangeTheme`` function.
+Music is rendered in real time via one of four synth engines: Roland CM-32L or MT-32 (via mt32emu, requires user-supplied ROM files), SoundFont (via MeltySynth, ships with a bundled GeneralUser GS soundfont), or AdLib/OPL (via AdlMidi.NET). The synth engine is selected by the `synth` setting in `uwsettings.json`. Themes are played via the `XMIMusic.ChangeTheme` function, which delegates to the `MusicStreamPlayer` node.
 
 To use OPL set the synth setting in settings.json to ``opl``
 To use MT-32 set the synth setting in settings.json to ``cm32l``
@@ -198,8 +198,6 @@ To use MT-32 you will need to have a suitable MT-32 Rom files (see list below) s
     "cm32l_ctrl_1_02.rom", "cm32l_pcm.rom"
     "cm32l_ctrl_1_00.rom", "cm32l_pcm.rom"
 ```
-
-The .wav files are generated at game start up. The first time they are created game start-up will be slower. 
 
 In order to switch between ``opl`` and ``cm32l`` settings the files will need to be deleted/removed from the ``%appdata%\Roaming\Godot\app_userdata\Underworld\SOUND\{1 or 2}`` folder
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Tilde (~) Give all runestones, 30 mana and maximise mage skills.
 Music is rendered in real time via one of four synth engines, selected by the `synth` setting in `uwsettings.json`:
 
 * `cm32l` or `mt32` — authentic Roland CM-32L/MT-32 emulation via [Munt.NET](https://github.com/abedegno/Munt.NET), requires user-supplied ROM files
-* `soundfont` (default) — [MeltySynth](https://github.com/sinshu/meltysynth) with a bundled GeneralUser GS SoundFont, works out of the box
+* `soundfont` (default) — [MeltySynth](https://github.com/sinshu/meltysynth) with a bundled [Phoenix MT-32 SoundFont](https://musical-artifacts.com/artifacts/1481) (6 MB, CC BY 3.0). Works out of the box, approximates MT-32 character. For best quality, point `synthpath` at a larger MT-32 soundfont (e.g. Hedsound) or use the `cm32l`/`mt32` engines with actual ROMs.
 * `opl` — AdLib/OPL FM synthesis via [AdlMidi.NET](https://github.com/csinkers/AdlMidi.NET)
 
 Themes are played via the `XMIMusic.ChangeTheme` function, which delegates to the `MusicStreamPlayer` node. No pre-rendering or WAV caching — audio is synthesised on demand.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you use `cm32l` or `mt32`, set `synthpath` to a directory containing the ROM 
 
 If the selected engine fails to initialise (missing ROMs, bad soundfont, etc.) the system silently falls back to OPL. Changing the `synth` setting requires a game restart.
 
-### Conceptual inspiration
+### Design inspiration
 
 The real-time synthesis approach was inspired by [Kweepa](https://github.com/Kweepa)'s Unity-based Ultima Underworld port, which demonstrated that playing XMI music through a MIDI sequencer in real time (rather than pre-rendering to WAV) gives gapless looping and avoids startup conversion delay.
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ If you use `cm32l` or `mt32`, set `synthpath` to a directory containing the ROM 
 
 If the selected engine fails to initialise (missing ROMs, bad soundfont, etc.) the system silently falls back to OPL. Changing the `synth` setting requires a game restart.
 
+See [docs/audio-architecture.md](docs/audio-architecture.md) for a detailed walkthrough of the audio system (data flow, components, threading model, design rationale).
+
 ### Design inspiration
 
 The real-time synthesis approach was inspired by [Kweepa](https://github.com/Kweepa)'s Unity-based Ultima Underworld port, which demonstrated that playing XMI music through a MIDI sequencer in real time (rather than pre-rendering to WAV) gives gapless looping and avoids startup conversion delay.

--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -4,8 +4,9 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\AdlMidi.NET\src\ADLMidi.NET\ADLMidi.NET.csproj" />
+    <ProjectReference Include="..\..\AdlMidi.NET\src\ADLMidi.NET\ADLMidi.NET.csproj" />
     <ProjectReference Include="..\Mt32Emu.NET\src\Munt.NET\Munt.NET.csproj" />
+    <PackageReference Include="MeltySynth" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Munt.NET" Version="0.1.0" />

--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -2,13 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AdlMidi.NET\src\ADLMidi.NET\ADLMidi.NET.csproj" />
     <ProjectReference Include="..\Mt32Emu.NET\src\Munt.NET\Munt.NET.csproj" />
     <PackageReference Include="MeltySynth" Version="2.4.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Munt.NET" Version="0.1.0" />
   </ItemGroup>
 </Project>

--- a/docs/audio-architecture.md
+++ b/docs/audio-architecture.md
@@ -1,0 +1,206 @@
+# Audio architecture
+
+How the music system works, end to end.
+
+## Overview
+
+Music in UnderworldGodot is synthesised in real time from the game's original XMI
+files. There's no pre-rendering, no WAV cache, no startup conversion delay. Four
+synth engines are supported, selected by the `synth` setting in `uwsettings.json`:
+
+| Setting | Engine | Notes |
+|---------|--------|-------|
+| `cm32l` | [mt32emu](https://github.com/munt/munt) via [Munt.NET](https://github.com/abedegno/Munt.NET) | Circuit-level Roland CM-32L emulation. Requires ROM files. Authentic Ultima Underworld sound. |
+| `mt32`  | mt32emu via Munt.NET | Same engine, MT-32 ROMs instead of CM-32L. |
+| `soundfont` (default) | [MeltySynth](https://github.com/sinshu/meltysynth) | Pure C# SoundFont synth. Bundled GeneralUser GS works out of the box. |
+| `opl`   | [AdlMidi.NET](https://github.com/csinkers/AdlMidi.NET) | OPL3 FM synthesis. AdLib/SoundBlaster-era sound. |
+
+## Data flow
+
+```
+ XMI file (UWA01.XMI etc.)                          [game data on disk]
+      │
+      ▼
+ XmiSequencer.ParseXmi()                            [Munt.NET — one-shot parse]
+      │  List<MidiEvent> (tick, bytes)
+      ▼
+ XmiPlayer (stateful, re-renders on each call)      [Munt.NET]
+      │  MIDI events fired at sample boundaries
+      ▼
+ ISynthEngine.PlayMsg / PlaySysex / Render          [Munt.NET / UnderworldGodot]
+      │  short[] stereo PCM
+      ▼
+ MusicStreamPlayer.AudioThreadLoop (producer thread) [UnderworldGodot]
+      │  Vector2[] frames
+      ▼
+ AudioStreamGeneratorPlayback.PushBuffer            [Godot]
+      │  ring buffer, lock-free between threads
+      ▼
+ Godot audio thread (consumer)                      [Godot engine internals]
+      │
+      ▼
+ Speakers / AudioBus
+```
+
+## Components
+
+### `Munt.NET` (NuGet, separate repo)
+
+Contains the cross-platform, Godot-independent pieces:
+
+- **`ISynthEngine`** — interface: `PlayMsg`, `PlaySysex`, `Render`, `Reset`, `Dispose`.
+  Packed MIDI message format: `status | (data1 << 8) | (data2 << 16)`. Render writes
+  interleaved 16-bit stereo PCM.
+- **`Mt32EmuSynth`** — existing P/Invoke wrapper around libmt32emu.
+- **`Mt32EmuEngine`** — `ISynthEngine` impl wrapping `Mt32EmuSynth`. Handles ROM
+  discovery (standard + MAME-style filenames).
+- **`XmiSequencer`** — XMI parser. Produces a `List<MidiEvent>` of `(tick, byte[])`
+  pairs. Understands XMI's note-duration encoding (Note On with inline duration
+  generates a deferred Note Off at `tick + duration`).
+- **`XmiPlayer`** — stateful real-time player. Owns an `ISynthEngine`, advances
+  a current-tick cursor in step with audio rendering, fires MIDI events as the
+  cursor crosses their tick, loops when the event list is exhausted.
+
+### `UnderworldGodot` (this repo)
+
+Godot-specific audio plumbing:
+
+- **`src/audio/MusicStreamPlayer.cs`** — the Godot `Node`. Owns the synth engine,
+  the `XmiPlayer`, and an `AudioStreamGenerator`. Runs a dedicated producer thread
+  that fills the ring buffer.
+- **`src/audio/MeltySynthEngine.cs`** — `ISynthEngine` over MeltySynth. Soundfont
+  discovery order: explicit `synthpath` → `{BasePath}/SOUND/default.sf2` →
+  `res://soundfonts/default.sf2` (bundled).
+- **`src/audio/AdlMidiEngine.cs`** — `ISynthEngine` over AdlMidi.NET's real-time
+  API. Loads the game's proprietary OPL bank (`UW.OPL` for UW2, `UW.AD` for UW1)
+  and converts it to WOPL format for AdlMidi.
+- **`src/loaders/xmimusic.cs`** — static `XMIMusic` class, now a thin facade:
+  resolves theme numbers to XMI filenames (octal-encoded per original engine)
+  and delegates playback to `MusicStreamPlayer.Instance.PlayXmi`.
+- **`soundfonts/default.sf2`** — bundled GeneralUser GS soundfont (MIT license),
+  used by MeltySynthEngine when no override is given.
+
+## Why a dedicated producer thread
+
+Godot 4's C# API does not expose a pull-based audio callback equivalent to Unity's
+`OnAudioFilterRead` — that would require a GDExtension in C++. The pragmatic
+alternative is the push model: the consumer calls `GetFramesAvailable()` and pushes
+PCM via `PushBuffer`.
+
+The naive approach is to push from `_Process()`, which runs on the main thread at
+the game's frame rate. This breaks down during main-thread hitches — cutscene
+panorama scrolls, texture loads, anything that stalls the main thread for longer
+than the audio buffer. The ring buffer drains, the audio thread mixes silence,
+playback pauses audibly.
+
+A dedicated `System.Threading.Thread` that polls `GetFramesAvailable()` at a high
+rate decouples audio production from main-thread frame pacing. The thread sleeps
+5ms when the buffer is full (cheap poll, no tight spin). This is the pattern used
+by FluidSynthGodot and similar Godot 4 C# audio projects.
+
+### Thread safety
+
+One shared piece of state: the `XmiPlayer`. Main thread calls `PlayXmi` / `Stop`;
+producer thread calls `Render`. Protected by a single `_playerLock` mutex. The
+lock holds only for the duration of one `Render` call (microseconds at 44.1 kHz),
+so contention is negligible. `XmiPlayer` and the synth engines themselves remain
+single-threaded internally — the lock ensures they're only accessed from one
+thread at a time.
+
+## Why real-time synthesis
+
+The earlier pipeline rendered every XMI to a WAV file on startup and played the
+WAV via `AudioStreamWav`. That approach had three problems:
+
+1. **Startup delay** — first run rendered every track before the game could start,
+   noticeable with CM-32L's reverb tail rendering.
+2. **Loop gap** — pre-rendered WAVs baked in the reverb-decay silence at the end,
+   producing an audible gap between loop iterations. The original DOS engine
+   loops MIDI events with no gap: notes from the end of the track blend naturally
+   into the start via the synth's own release envelopes.
+3. **Pipeline complexity** — separate code paths for OPL and CM-32L rendering,
+   WAV cache invalidation on settings changes, tail trimming heuristics, etc.
+
+Real-time synthesis matches the original DOS engine architecture: MIDI events
+stream to the synth, the synth produces audio on demand. No startup delay, no
+loop gap, one unified code path across all four backends.
+
+### Design inspiration
+
+[Kweepa](https://github.com/Kweepa)'s Unity-based Ultima Underworld port
+([repo](https://github.com/Kweepa/Underground)) demonstrated that real-time XMI
+synthesis via MeltySynth is practical. That project uses Unity's
+`OnAudioFilterRead` callback (runs on the audio thread automatically, no
+threading concerns) and a soundfont for MT-32-ish sound. Our implementation
+differs in two key ways: the threading model (managed producer thread instead of
+engine callback) required by Godot's C# audio API, and the choice to support
+mt32emu for authentic CM-32L/MT-32 emulation alongside the soundfont fallback.
+
+## Theme selection and looping
+
+Ultima Underworld's music is state-driven, not track-driven:
+
+- Theme changes are triggered by game state events (enter combat, change level,
+  enter menu, cutscene command 25).
+- Tracks loop indefinitely once started — there is no "pick a new theme when the
+  current one ends" logic in the original engine (confirmed from disassembly).
+
+`XmiPlayer.Loop` is set to `true` by default in `XMIMusic.ChangeTheme`. The
+`UW2WorldThemes` table provides three variants per world; one is picked at random
+by `PickLevelThemeMusic()` when the world changes, not when a track ends.
+
+## Settings
+
+```json
+{
+    "synth": "soundfont",
+    "synthpath": ""
+}
+```
+
+- `synth`: one of `cm32l`, `mt32`, `soundfont`, `opl`. Default `soundfont`.
+- `synthpath`: path to ROM directory (for cm32l/mt32) or `.sf2` file (for
+  soundfont). Empty = use defaults (bundled soundfont, or no ROMs available).
+- Legacy `rompath` is still honoured — if set and `synthpath` is empty, it's
+  promoted to `synthpath` with a deprecation warning.
+
+Changing the `synth` setting requires a game restart. The synth engine is
+instantiated once in `MusicStreamPlayer._Ready` and lives for the lifetime of
+the node.
+
+## Fallback behaviour
+
+If the primary synth engine fails to initialise (missing ROMs, corrupt soundfont,
+missing native library) the system falls back to `AdlMidiEngine`. If that also
+fails, music is silently disabled — the game continues to run. All failures are
+logged to the Godot console.
+
+## Native library resolution
+
+`libmt32emu` (for mt32emu) and `libADLMIDI` (for OPL) ship as platform-specific
+native libraries inside their respective NuGet packages under
+`runtimes/{rid}/native/`. .NET's default native library loader doesn't look
+there, so `MusicStreamPlayer.SetupMuntDllLoader` and
+`AdlMidiEngine.SetupDllLoader` register `NativeLibrary.SetDllImportResolver`
+callbacks that probe the runtime-specific paths.
+
+Munt.NET is netstandard2.0 and can't register the resolver itself (no
+`NativeLibrary` API), so `MusicStreamPlayer` does it on Munt.NET's behalf
+before constructing `Mt32EmuEngine`.
+
+## File index
+
+| File | Purpose |
+|------|---------|
+| `src/audio/MusicStreamPlayer.cs` | Godot node, producer thread, synth selection, fallback |
+| `src/audio/MeltySynthEngine.cs` | SoundFont backend |
+| `src/audio/AdlMidiEngine.cs` | OPL/AdLib backend (includes OPL→WOPL bank conversion) |
+| `src/loaders/xmimusic.cs` | Theme-number facade (thin) |
+| `soundfonts/default.sf2` | Bundled GeneralUser GS soundfont |
+| `soundfonts/LICENSE.txt` | GeneralUser GS license |
+
+External dependencies:
+
+- `Munt.NET` (NuGet or ProjectReference) — XmiPlayer, ISynthEngine, Mt32EmuEngine, Mt32EmuSynth
+- `MeltySynth` (NuGet) — SoundFont synth engine
+- `AdlMidi.NET` (ProjectReference, abedegno fork) — OPL synth engine

--- a/docs/audio-architecture.md
+++ b/docs/audio-architecture.md
@@ -12,7 +12,7 @@ synth engines are supported, selected by the `synth` setting in `uwsettings.json
 |---------|--------|-------|
 | `cm32l` | [mt32emu](https://github.com/munt/munt) via [Munt.NET](https://github.com/abedegno/Munt.NET) | Circuit-level Roland CM-32L emulation. Requires ROM files. Authentic Ultima Underworld sound. |
 | `mt32`  | mt32emu via Munt.NET | Same engine, MT-32 ROMs instead of CM-32L. |
-| `soundfont` (default) | [MeltySynth](https://github.com/sinshu/meltysynth) | Pure C# SoundFont synth. Bundled GeneralUser GS works out of the box. |
+| `soundfont` (default) | [MeltySynth](https://github.com/sinshu/meltysynth) | Pure C# SoundFont synth. Bundled Phoenix MT-32 soundfont works out of the box. |
 | `opl`   | [AdlMidi.NET](https://github.com/csinkers/AdlMidi.NET) | OPL3 FM synthesis. AdLib/SoundBlaster-era sound. |
 
 ## Data flow
@@ -77,7 +77,7 @@ Godot-specific audio plumbing:
 - **`src/loaders/xmimusic.cs`** — static `XMIMusic` class, now a thin facade:
   resolves theme numbers to XMI filenames (octal-encoded per original engine)
   and delegates playback to `MusicStreamPlayer.Instance.PlayXmi`.
-- **`soundfonts/default.sf2`** — bundled GeneralUser GS soundfont (MIT license),
+- **`soundfonts/default.sf2`** — bundled Phoenix MT-32 soundfont (CC BY 3.0),
   used by MeltySynthEngine when no override is given.
 
 ## Why a dedicated producer thread
@@ -196,8 +196,8 @@ before constructing `Mt32EmuEngine`.
 | `src/audio/MeltySynthEngine.cs` | SoundFont backend |
 | `src/audio/AdlMidiEngine.cs` | OPL/AdLib backend (includes OPL→WOPL bank conversion) |
 | `src/loaders/xmimusic.cs` | Theme-number facade (thin) |
-| `soundfonts/default.sf2` | Bundled GeneralUser GS soundfont |
-| `soundfonts/LICENSE.txt` | GeneralUser GS license |
+| `soundfonts/default.sf2` | Bundled Phoenix MT-32 soundfont (CC BY 3.0) |
+| `soundfonts/LICENSE.txt` | Phoenix MT-32 attribution and license |
 
 External dependencies:
 

--- a/main.cs
+++ b/main.cs
@@ -1162,25 +1162,5 @@ public partial class main : Node3D
 	}
 
 
-	public static void _on_music_player_finished()
-	{
-		Debug.Print("Music finished, picking next theme");
-		
-		if (XMIMusic.LoopTheme)
-		{
-			main.instance.MusicPlayer.Play();//restart the playing theme, used mainly for the armed theme
-		}
-		else
-		{
-			if (!uimanager.InGame)
-			{
-				main.instance.MusicPlayer.Play();//restart the playing theme, if we are not in game and it is not possible to pick a different level theme.
-			}
-			else
-			{
-				XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic());
-			}			
-		}
-	}
 
 }//end class

--- a/main.cs
+++ b/main.cs
@@ -43,7 +43,6 @@ public partial class main : Node3D
 	[Export] public Camera3D cam;
 	public static Camera3D gamecam; //static ref to the above camera
 	[Export] public AudioStreamPlayer DigitalAudioPlayer;
-	[Export] public AudioStreamPlayer MusicPlayer;
 	[Export] public RichTextLabel lblPositionDebug;
 	//[Export] public uimanager uwUI;
 

--- a/main.cs
+++ b/main.cs
@@ -110,16 +110,6 @@ public partial class main : Node3D
 				Debug.Print("UIManager is still null!!");
 			}
 		}
-		//Init Music
-		try
-		{
-			XMIMusic.ConvertXMIMusic();
-		}
-		catch (System.PlatformNotSupportedException)
-		{
-			Debug.Print("XMI music not available on this platform (AdlMidi native library missing)");
-		}
-
 		gamecam.Fov = Math.Max(50, uwsettings.instance.FOV);
 		uimanager.EnableDisable(instance.lblPositionDebug, EnablePositionDebug);
 		ObjectCreator.grObjects = new GRLoader(GRLoader.OBJECTS_GR, GRLoader.GRShaderMode.BillboardSpriteShader);

--- a/scenes/Underworld.tscn
+++ b/scenes/Underworld.tscn
@@ -20,6 +20,7 @@
 [ext_resource type="Texture2D" uid="uid://51go53yqj8oq" path="res://resources/placeholder_art/panels/panelsstats.png" id="24_filpa"]
 [ext_resource type="Texture2D" uid="uid://1ecbe7htlqun" path="res://resources/placeholder_art/spellicon.png" id="28_uj0ag"]
 [ext_resource type="Texture2D" uid="uid://dlhf0nj7vj1o2" path="res://resources/placeholder_art/PanelBlack.jpg" id="29_aiei8"]
+[ext_resource type="Script" path="res://src/audio/MusicStreamPlayer.cs" id="N_music_stream"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_1c8r5"]
 
@@ -32,6 +33,9 @@ shader = ExtResource("6_x6exc")
 [sub_resource type="Theme" id="Theme_i11v8"]
 
 [node name="Underworld" type="Node3D"]
+
+[node name="MusicStreamPlayer" type="Node" parent="."]
+script = ExtResource("N_music_stream")
 
 [node name="main" type="Node3D" parent="." node_paths=PackedStringArray("cam", "DigitalAudioPlayer", "MusicPlayer", "lblPositionDebug", "secondarycameras")]
 script = ExtResource("6_3y8oy")

--- a/scenes/Underworld.tscn
+++ b/scenes/Underworld.tscn
@@ -37,11 +37,10 @@ shader = ExtResource("6_x6exc")
 [node name="MusicStreamPlayer" type="Node" parent="."]
 script = ExtResource("N_music_stream")
 
-[node name="main" type="Node3D" parent="." node_paths=PackedStringArray("cam", "DigitalAudioPlayer", "MusicPlayer", "lblPositionDebug", "secondarycameras")]
+[node name="main" type="Node3D" parent="." node_paths=PackedStringArray("cam", "DigitalAudioPlayer", "lblPositionDebug", "secondarycameras")]
 script = ExtResource("6_3y8oy")
 cam = NodePath("../WorldViewContainer/SubViewport/Camera3D")
 DigitalAudioPlayer = NodePath("../UI/DigitalAudioPlayer")
-MusicPlayer = NodePath("../UI/MusicPlayer")
 lblPositionDebug = NodePath("../UI/Common/PositionLabel")
 secondarycameras = NodePath("../WorldViewContainer/SubViewport")
 
@@ -70,10 +69,6 @@ follow_viewport_enabled = true
 
 [node name="DigitalAudioPlayer" type="AudioStreamPlayer" parent="UI"]
 stream = SubResource("AudioStreamWAV_tkk82")
-
-[node name="MusicPlayer" type="AudioStreamPlayer" parent="UI"]
-stream = SubResource("AudioStreamWAV_tkk82")
-playback_type = 1
 
 [node name="UW1" type="CanvasLayer" parent="UI"]
 visible = false

--- a/scenes/Underworld.tscn
+++ b/scenes/Underworld.tscn
@@ -2886,7 +2886,6 @@ PowerGemUW2 = NodePath("../UW2/PowerGemUW2")
 
 [node name="tilemap" type="Node3D" parent="."]
 
-[connection signal="finished" from="UI/MusicPlayer" to="main" method="_on_music_player_finished"]
 [connection signal="mouse_entered" from="UI/UW1/MessageScrollPanelUW1" to="UI/uiManager" method="_on_message_scroll_mouse_entered"]
 [connection signal="mouse_exited" from="UI/UW1/MessageScrollPanelUW1" to="UI/uiManager" method="_on_message_scroll_mouse_exit"]
 [connection signal="gui_input" from="UI/UW1/CompassUW1/CompassClickArea" to="UI/uiManager" method="_on_compass_click"]

--- a/soundfonts/LICENSE.txt
+++ b/soundfonts/LICENSE.txt
@@ -1,0 +1,47 @@
+*** GeneralUser GS v2.0.3 ***
+***      License v2.0     ***
+
+** License of the complete work **
+You may use GeneralUser GS without restriction for your own music creation,
+private or commercial. This SoundFont bank is provided to the community free of
+charge. Please feel free to use it in your software projects, and to modify the
+SoundFont bank or its packaging to suit your needs.
+
+** License of contained samples **
+GeneralUser GS inherits the usage rights of the samples contained within, all of
+which allow full use in music production, including the ability to make profit
+from musical recordings created with GeneralUser GS.
+
+Many of the samples are original, but some were taken from other banks freely
+(and legally) available on the Internet from various SoundFont websites. Because
+GeneralUser GS originated as a personal project with no intention for
+publication, I cannot be 100% sure where all of the samples originated, although
+I do know that none of them came from commercially published SoundFont packages
+or sample CDs. Regardless, many "free" SoundFonts available on the web may
+indeed contain samples of questionable origin. My understanding of the
+copyrights of all samples is only as good as the information provided by the
+original sources. If you become aware of any restricted samples being used in
+GeneralUser GS, please let me know so I can replace them.
+
+This uncertainty may concern you if you intend to use GeneralUser GS in a
+commercial software product. That being said, I have never received any
+complaint regarding sample ownership since I published the original GeneralUser
+GS back in 2000, and as far as I am aware, neither have any of the companies
+creating commercial software products using GeneralUser GS.
+
+** More info **
+If you plan to feature GeneralUser GS on your own website, please do not link
+directly to my download files. Either link to my website, or provide your own
+local copy instead.
+
+I hope you enjoy GeneralUser GS! This SoundFont bank is the product of many
+years of hard work.
+
+You can find updates to GeneralUser GS and more of my virtual instruments at:
+http://www.schristiancollins.com
+
+I can be reached via the contact page on my website here:
+https://www.schristiancollins.com/contact
+
+Thank you!
+-~Chris

--- a/soundfonts/LICENSE.txt
+++ b/soundfonts/LICENSE.txt
@@ -1,47 +1,17 @@
-*** GeneralUser GS v2.0.3 ***
-***      License v2.0     ***
+default.sf2 — Phoenix MT-32 SoundFont
+=====================================
 
-** License of the complete work **
-You may use GeneralUser GS without restriction for your own music creation,
-private or commercial. This SoundFont bank is provided to the community free of
-charge. Please feel free to use it in your software projects, and to modify the
-SoundFont bank or its packaging to suit your needs.
+Author: Duwindu Tharinda
+Based on Jexu's Phoenix-XG SoundFont (MT-32 presets extracted from bank 127
+and remapped to bank 0).
 
-** License of contained samples **
-GeneralUser GS inherits the usage rights of the samples contained within, all of
-which allow full use in music production, including the ability to make profit
-from musical recordings created with GeneralUser GS.
+Source: https://musical-artifacts.com/artifacts/1481
+License: CC BY 3.0 (https://creativecommons.org/licenses/by/3.0/)
 
-Many of the samples are original, but some were taken from other banks freely
-(and legally) available on the Internet from various SoundFont websites. Because
-GeneralUser GS originated as a personal project with no intention for
-publication, I cannot be 100% sure where all of the samples originated, although
-I do know that none of them came from commercially published SoundFont packages
-or sample CDs. Regardless, many "free" SoundFonts available on the web may
-indeed contain samples of questionable origin. My understanding of the
-copyrights of all samples is only as good as the information provided by the
-original sources. If you become aware of any restricted samples being used in
-GeneralUser GS, please let me know so I can replace them.
+You are free to share and adapt this soundfont for any purpose, including
+commercially, provided you give appropriate credit, provide a link to the
+license, and indicate if changes were made.
 
-This uncertainty may concern you if you intend to use GeneralUser GS in a
-commercial software product. That being said, I have never received any
-complaint regarding sample ownership since I published the original GeneralUser
-GS back in 2000, and as far as I am aware, neither have any of the companies
-creating commercial software products using GeneralUser GS.
-
-** More info **
-If you plan to feature GeneralUser GS on your own website, please do not link
-directly to my download files. Either link to my website, or provide your own
-local copy instead.
-
-I hope you enjoy GeneralUser GS! This SoundFont bank is the product of many
-years of hard work.
-
-You can find updates to GeneralUser GS and more of my virtual instruments at:
-http://www.schristiancollins.com
-
-I can be reached via the contact page on my website here:
-https://www.schristiancollins.com/contact
-
-Thank you!
--~Chris
+Attribution for distribution:
+    "Phoenix MT-32 SoundFont by Duwindu Tharinda, based on Phoenix-XG by Jexu,
+     CC BY 3.0 — https://musical-artifacts.com/artifacts/1481"

--- a/src/audio/AdlMidiEngine.cs
+++ b/src/audio/AdlMidiEngine.cs
@@ -9,10 +9,25 @@ using SerdesNet;
 namespace Underworld;
 
 /// <summary>
-/// ISynthEngine backed by AdlMidi.NET (OPL/AdLib FM synthesis).
-/// Uses the game's own OPL bank file (UW.OPL for UW2, UW.AD for UW1) converted
-/// to WOPL format for AdlMidi. Sets up a DllImportResolver on first construction.
+/// ISynthEngine backed by AdlMidi.NET — an OPL3 FM-synthesis emulator that
+/// reproduces the period-authentic Sound Blaster / AdLib soundscape most
+/// DOS players would have heard (MT-32 being the premium alternative).
 /// </summary>
+/// <remarks>
+/// <para>The game ships its own proprietary OPL instrument bank
+/// (<c>UW.OPL</c> for UW2, <c>UW.AD</c> for UW1). That format is not
+/// something libADLMIDI understands directly, so at construction we parse
+/// it with <see cref="GlobalTimbreLibrary"/> and convert each timbre into a
+/// <see cref="WoplInstrument"/>, packaging the result as a WOPL file —
+/// libADLMIDI's native bank format — which we hand to the player as a
+/// byte[] via <see cref="MidiPlayer.OpenBankData"/>.</para>
+/// <para>This means the in-game FM music is driven by the game's own
+/// timbres, not a generic GM bank — so MIDI patch numbers map to the
+/// instruments the original sound designers actually authored for UW.</para>
+/// <para>AdlMidi also serves as the always-available fallback engine
+/// (see <c>MusicStreamPlayer.CreateSynthEngine</c>) because every copy of
+/// the game has the bank file — there are no external assets to install.</para>
+/// </remarks>
 public sealed class AdlMidiEngine : ISynthEngine
 {
     private static bool _dllLoaderSetUp;
@@ -21,6 +36,14 @@ public sealed class AdlMidiEngine : ISynthEngine
     private readonly MidiPlayer _player;
     private bool _disposed;
 
+    /// <summary>
+    /// Construct the engine. Two failure modes can throw:
+    ///   (1) the OPL bank file is missing (wrong BasePath, incomplete install);
+    ///   (2) the bank file exists but fails to parse / convert to WOPL.
+    /// The try/catch ensures <see cref="_player"/> is disposed on either
+    /// failure so we don't leak the unmanaged MidiPlayer handle on the way
+    /// out. Callers should treat any throw as "OPL unavailable".
+    /// </summary>
     public AdlMidiEngine(int sampleRate = 44100)
     {
         SetupDllLoader();
@@ -33,11 +56,13 @@ public sealed class AdlMidiEngine : ISynthEngine
         }
         catch
         {
+            // Don't leak the native player on bank-load failure.
             _player.Dispose();
             throw;
         }
     }
 
+    /// <inheritdoc/>
     public void PlayMsg(uint msg)
     {
         CheckDisposed();
@@ -47,10 +72,17 @@ public sealed class AdlMidiEngine : ISynthEngine
         byte channel = (byte)(status & 0x0F);
         byte command = (byte)(status & 0xF0);
 
+        // Dispatch by MIDI command nibble. Unlike a SoundFont synth we can't
+        // just hand AdlMidi a packed message — libADLMIDI exposes distinct
+        // "real time" entry points per command, so we unpack and route.
         switch (command)
         {
             case 0x80: _player.RealTimeNoteOff(channel, data1); break;
             case 0x90:
+                // MIDI running-status quirk: a NoteOn with velocity 0 is
+                // defined by the spec as equivalent to NoteOff. XMI (and many
+                // MIDI files) exploit this to omit explicit NoteOff status
+                // bytes, so we must honour it here or notes will hang forever.
                 if (data2 == 0)
                     _player.RealTimeNoteOff(channel, data1);
                 else
@@ -60,6 +92,8 @@ public sealed class AdlMidiEngine : ISynthEngine
             case 0xB0: _player.RealTimeControllerChange(channel, data1, data2); break;
             case 0xC0: _player.RealTimePatchChange(channel, data1); break;
             case 0xD0: _player.RealTimeChannelAfterTouch(channel, data1); break;
+            // Pitch bend: data2 is the MSB, data1 the LSB — libADLMIDI takes
+            // (msb, lsb) in that order, so we pass data2 first.
             case 0xE0: _player.RealTimePitchBendML(channel, data2, data1); break;
         }
     }
@@ -98,6 +132,26 @@ public sealed class AdlMidiEngine : ISynthEngine
         if (_disposed) throw new ObjectDisposedException(nameof(AdlMidiEngine));
     }
 
+    /// <summary>
+    /// Read the game's proprietary OPL timbre bank and convert it to a WOPL
+    /// byte[] suitable for <see cref="MidiPlayer.OpenBankData"/>.
+    /// </summary>
+    /// <remarks>
+    /// The source format is a flat <see cref="GlobalTimbreLibrary"/> — each
+    /// entry describes one OPL instrument as two operator blocks (a carrier
+    /// + a modulator, the classic 2-op FM voice) plus a feedback-connection
+    /// byte that wires them together. WOPL is libADLMIDI's container format
+    /// and stores the same operator data plus extra metadata (4-operator
+    /// support, global flags, banking, names, note offsets). We build a
+    /// single melodic bank + single percussion bank in WOPL v3.
+    ///
+    /// Indexing: timbres 0..127 become the melodic patches 0..127. Timbres
+    /// at index 128 and above are percussion instruments; we write them into
+    /// the percussion bank at <c>(i - 128) + 35</c>. The +35 offset follows
+    /// the General MIDI percussion key map, which starts at note 35
+    /// (Acoustic Bass Drum) — the first percussion timbre in the game's
+    /// bank corresponds to GM percussion key 35, and so on.
+    /// </remarks>
     private static byte[] LoadGameBank()
     {
         string bankFilename = UWClass._RES == UWClass.GAME_UW2 ? "UW.OPL" : "UW.AD";
@@ -152,6 +206,14 @@ public sealed class AdlMidiEngine : ISynthEngine
         return ms.ToArray();
     }
 
+    /// <summary>
+    /// One-time DllImportResolver setup for libADLMIDI. Same rationale as
+    /// <c>MusicStreamPlayer.SetupMuntDllLoader</c>: AdlMidi.NET ships as
+    /// netstandard2.0 and cannot self-register a resolver, so the host app
+    /// does it. Native assets are looked up under
+    /// <c>{AppContext.BaseDirectory}/runtimes/{rid}/native/</c>, matching
+    /// the standard NuGet runtimes layout (and our publish scripts).
+    /// </summary>
     private static void SetupDllLoader()
     {
         lock (_dllLoaderLock)

--- a/src/audio/AdlMidiEngine.cs
+++ b/src/audio/AdlMidiEngine.cs
@@ -26,9 +26,16 @@ public sealed class AdlMidiEngine : ISynthEngine
         SetupDllLoader();
 
         _player = AdlMidi.Init(sampleRate);
-
-        var bankData = LoadGameBank();
-        _player.OpenBankData(bankData);
+        try
+        {
+            var bankData = LoadGameBank();
+            _player.OpenBankData(bankData);
+        }
+        catch
+        {
+            _player.Dispose();
+            throw;
+        }
     }
 
     public void PlayMsg(uint msg)

--- a/src/audio/AdlMidiEngine.cs
+++ b/src/audio/AdlMidiEngine.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using ADLMidi.NET;
+using Godot;
+using Munt.NET;
+using SerdesNet;
+
+namespace Underworld;
+
+/// <summary>
+/// ISynthEngine backed by AdlMidi.NET (OPL/AdLib FM synthesis).
+/// Uses the game's own OPL bank file (UW.OPL for UW2, UW.AD for UW1) converted
+/// to WOPL format for AdlMidi. Sets up a DllImportResolver on first construction.
+/// </summary>
+public sealed class AdlMidiEngine : ISynthEngine
+{
+    private static bool _dllLoaderSetUp;
+    private static readonly object _dllLoaderLock = new();
+
+    private readonly MidiPlayer _player;
+    private bool _disposed;
+
+    public AdlMidiEngine(int sampleRate = 44100)
+    {
+        SetupDllLoader();
+
+        _player = AdlMidi.Init(sampleRate);
+
+        var bankData = LoadGameBank();
+        _player.OpenBankData(bankData);
+    }
+
+    public void PlayMsg(uint msg)
+    {
+        CheckDisposed();
+        byte status = (byte)(msg & 0xFF);
+        byte data1 = (byte)((msg >> 8) & 0xFF);
+        byte data2 = (byte)((msg >> 16) & 0xFF);
+        byte channel = (byte)(status & 0x0F);
+        byte command = (byte)(status & 0xF0);
+
+        switch (command)
+        {
+            case 0x80: _player.RealTimeNoteOff(channel, data1); break;
+            case 0x90:
+                if (data2 == 0)
+                    _player.RealTimeNoteOff(channel, data1);
+                else
+                    _player.RealTimeNoteOn(channel, data1, data2);
+                break;
+            case 0xA0: _player.RealTimeNoteAfterTouch(channel, data1, data2); break;
+            case 0xB0: _player.RealTimeControllerChange(channel, data1, data2); break;
+            case 0xC0: _player.RealTimePatchChange(channel, data1); break;
+            case 0xD0: _player.RealTimeChannelAfterTouch(channel, data1); break;
+            case 0xE0: _player.RealTimePitchBendML(channel, data2, data1); break;
+        }
+    }
+
+    public unsafe void PlaySysex(byte[] data)
+    {
+        CheckDisposed();
+        fixed (byte* ptr = data)
+        {
+            _player.RealTimeSystemExclusive((IntPtr)ptr, (UIntPtr)data.Length);
+        }
+    }
+
+    public void Render(short[] buffer, uint frameCount)
+    {
+        CheckDisposed();
+        int samples = (int)frameCount * 2; // stereo interleaved
+        _player.Generate(buffer.AsSpan(0, samples));
+    }
+
+    public void Reset()
+    {
+        CheckDisposed();
+        _player.RealTimeResetState();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _player.Dispose();
+    }
+
+    private void CheckDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(AdlMidiEngine));
+    }
+
+    private static byte[] LoadGameBank()
+    {
+        string bankFilename = UWClass._RES == UWClass.GAME_UW2 ? "UW.OPL" : "UW.AD";
+        string bankPath = Path.Combine(UWClass.BasePath, "SOUND", bankFilename);
+        if (!File.Exists(bankPath))
+            throw new InvalidOperationException($"OPL bank file not found: {bankPath}");
+
+        GlobalTimbreLibrary oplFile;
+        using (var stream = File.OpenRead(bankPath))
+        using (var br = new BinaryReader(stream))
+        {
+            oplFile = GlobalTimbreLibrary.Serdes(
+                null,
+                new ReaderSerdes(br, br.BaseStream.Length, s => GD.Print(s)));
+        }
+
+        var wopl = new WoplFile
+        {
+            Version = 3,
+            GlobalFlags = GlobalBankFlags.DeepTremolo | GlobalBankFlags.DeepVibrato,
+            VolumeModel = VolumeModel.Auto
+        };
+        wopl.Melodic.Add(new WoplBank { Id = 0, Name = "" });
+        wopl.Percussion.Add(new WoplBank { Id = 0, Name = "" });
+
+        for (int i = 0; i < oplFile.Data.Count; i++)
+        {
+            var timbre = oplFile.Data[i];
+            var x = i < 128
+                ? wopl.Melodic[0].Instruments[i] ?? new WoplInstrument()
+                : wopl.Percussion[0].Instruments[i - 128 + 35] ?? new WoplInstrument();
+
+            x.Name = "";
+            x.NoteOffset1 = timbre.MidiPatchNumber;
+            x.NoteOffset2 = timbre.MidiBankNumber;
+            x.InstrumentMode = InstrumentMode.TwoOperator;
+            x.FbConn1C0 = timbre.FeedbackConnection;
+            x.Operator0 = timbre.Carrier;
+            x.Operator1 = timbre.Modulation;
+            x.Operator2 = Operator.Blank;
+            x.Operator3 = Operator.Blank;
+
+            if (i < 128)
+                wopl.Melodic[0].Instruments[i] = x;
+            else
+                wopl.Percussion[0].Instruments[i - 128 + 35] = x;
+        }
+
+        using var ms = new MemoryStream();
+        using var bw2 = new BinaryWriter(ms);
+        WoplFile.Serdes(wopl, new WriterSerdes(bw2, s => GD.Print(s)));
+        return ms.ToArray();
+    }
+
+    private static void SetupDllLoader()
+    {
+        lock (_dllLoaderLock)
+        {
+            if (_dllLoaderSetUp) return;
+            _dllLoaderSetUp = true;
+
+            NativeLibrary.SetDllImportResolver(
+                typeof(AdlMidi).Assembly,
+                (name, assembly, path) =>
+                {
+                    var root = AppContext.BaseDirectory;
+                    string runtime = RuntimeInformation.RuntimeIdentifier;
+
+                    string filename;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        filename = Path.GetExtension(name).Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".dll";
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        filename = Path.GetExtension(name).Equals(".dylib", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".dylib";
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        filename = Path.GetExtension(name).Equals(".so", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".so";
+                    else
+                        throw new PlatformNotSupportedException();
+
+                    var fullPath = Path.Combine(root, "runtimes", runtime, "native", filename);
+                    return File.Exists(fullPath) ? NativeLibrary.Load(fullPath) : IntPtr.Zero;
+                });
+        }
+    }
+}

--- a/src/audio/MeltySynthEngine.cs
+++ b/src/audio/MeltySynthEngine.cs
@@ -1,0 +1,120 @@
+using System;
+using System.IO;
+using Godot;
+using MeltySynth;
+using Munt.NET;
+
+namespace Underworld;
+
+/// <summary>
+/// ISynthEngine backed by MeltySynth (pure C# SoundFont synthesizer).
+/// Discovery order for soundfont:
+///   1. explicit soundfontPath parameter
+///   2. {BasePath}/SOUND/default.sf2
+///   3. res://soundfonts/default.sf2 (bundled)
+/// </summary>
+public sealed class MeltySynthEngine : ISynthEngine
+{
+    private readonly Synthesizer _synth;
+    private readonly float[] _left;
+    private readonly float[] _right;
+    private bool _disposed;
+
+    public MeltySynthEngine(string soundfontPath, int sampleRate = 44100)
+    {
+        string resolvedPath = ResolveSoundfont(soundfontPath);
+        var settings = new SynthesizerSettings(sampleRate);
+        _synth = new Synthesizer(resolvedPath, settings);
+        _left = new float[4096];
+        _right = new float[4096];
+    }
+
+    private static string ResolveSoundfont(string userPath)
+    {
+        if (!string.IsNullOrEmpty(userPath) && File.Exists(userPath))
+            return userPath;
+
+        var gameSf = Path.Combine(UWClass.BasePath, "SOUND", "default.sf2");
+        if (File.Exists(gameSf))
+            return gameSf;
+
+        var bundled = ProjectSettings.GlobalizePath("res://soundfonts/default.sf2");
+        if (File.Exists(bundled))
+            return bundled;
+
+        throw new InvalidOperationException(
+            "No soundfont found. Looked in " +
+            $"'{userPath}', '{gameSf}', '{bundled}'.");
+    }
+
+    public void PlayMsg(uint msg)
+    {
+        CheckDisposed();
+        byte status = (byte)(msg & 0xFF);
+        byte data1 = (byte)((msg >> 8) & 0xFF);
+        byte data2 = (byte)((msg >> 16) & 0xFF);
+        int channel = status & 0x0F;
+        int command = status & 0xF0;
+        _synth.ProcessMidiMessage(channel, command, data1, data2);
+    }
+
+    public void PlaySysex(byte[] data)
+    {
+        CheckDisposed();
+        // MeltySynth doesn't support arbitrary SysEx. Silently ignored.
+    }
+
+    public void Render(short[] buffer, uint frameCount)
+    {
+        CheckDisposed();
+
+        int framesRemaining = (int)frameCount;
+        int bufferOffset = 0;
+
+        while (framesRemaining > 0)
+        {
+            int chunk = Math.Min(framesRemaining, _left.Length);
+            var leftSpan = _left.AsSpan(0, chunk);
+            var rightSpan = _right.AsSpan(0, chunk);
+            _synth.Render(leftSpan, rightSpan);
+
+            for (int i = 0; i < chunk; i++)
+            {
+                buffer[bufferOffset++] = FloatToShort(_left[i]);
+                buffer[bufferOffset++] = FloatToShort(_right[i]);
+            }
+
+            framesRemaining -= chunk;
+        }
+    }
+
+    public void Reset()
+    {
+        CheckDisposed();
+        for (int ch = 0; ch < 16; ch++)
+        {
+            _synth.ProcessMidiMessage(ch, 0xB0, 123, 0); // All Notes Off
+            _synth.ProcessMidiMessage(ch, 0xB0, 120, 0); // All Sound Off
+            _synth.ProcessMidiMessage(ch, 0xB0, 121, 0); // Reset All Controllers
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+    }
+
+    private void CheckDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(MeltySynthEngine));
+    }
+
+    private static short FloatToShort(float f)
+    {
+        int s = (int)(f * 32767f);
+        if (s > 32767) s = 32767;
+        if (s < -32768) s = -32768;
+        return (short)s;
+    }
+}

--- a/src/audio/MeltySynthEngine.cs
+++ b/src/audio/MeltySynthEngine.cs
@@ -7,19 +7,35 @@ using Munt.NET;
 namespace Underworld;
 
 /// <summary>
-/// ISynthEngine backed by MeltySynth (pure C# SoundFont synthesizer).
-/// Discovery order for soundfont:
-///   1. explicit soundfontPath parameter
-///   2. {BasePath}/SOUND/default.sf2
-///   3. res://soundfonts/default.sf2 (bundled)
+/// ISynthEngine backed by MeltySynth — a pure-C# SoundFont 2 synthesizer
+/// targeting the General MIDI instrument set. This is our default engine
+/// because it has no native dependencies (works everywhere .NET runs) and
+/// SoundFonts are freely available, including tiny bundled defaults.
 /// </summary>
+/// <remarks>
+/// Not period-authentic: UW1/UW2 were composed for MT-32 (and FM fallback).
+/// SoundFont playback sounds "modern GM" rather than like the original
+/// hardware — choose <see cref="Mt32EmuEngine"/> for authenticity.
+/// Discovery order for soundfont (see <see cref="ResolveSoundfont"/>):
+///   1. explicit soundfontPath parameter (from uwsettings)
+///   2. {BasePath}/SOUND/default.sf2 (drop-in alongside game files)
+///   3. res://soundfonts/default.sf2 (bundled in the Godot project)
+/// </remarks>
 public sealed class MeltySynthEngine : ISynthEngine
 {
     private readonly Synthesizer _synth;
+    // Scratch float buffers — MeltySynth renders into separate L/R float
+    // spans; we interleave and convert to int16 in Render().
     private readonly float[] _left;
     private readonly float[] _right;
     private bool _disposed;
 
+    /// <summary>
+    /// Construct the synth. Throws <see cref="InvalidOperationException"/>
+    /// if no SoundFont can be found at any of the three discovery locations.
+    /// </summary>
+    /// <param name="soundfontPath">Explicit .sf2 path, or empty to fall through to auto-discovery.</param>
+    /// <param name="sampleRate">Output sample rate in Hz.</param>
     public MeltySynthEngine(string soundfontPath, int sampleRate = 44100)
     {
         string resolvedPath = ResolveSoundfont(soundfontPath);
@@ -29,6 +45,14 @@ public sealed class MeltySynthEngine : ISynthEngine
         _right = new float[4096];
     }
 
+    /// <summary>
+    /// Locate a SoundFont file using a 3-level discovery order:
+    ///   1. explicit user path (uwsettings.synthpath) — wins if the file exists
+    ///   2. {BasePath}/SOUND/default.sf2 — lets users drop a SoundFont next to the game
+    ///   3. res://soundfonts/default.sf2 — fallback shipped with the project
+    /// Throws if none of these exist; the message lists all three so users
+    /// know exactly where to put a SoundFont.
+    /// </summary>
     private static string ResolveSoundfont(string userPath)
     {
         if (!string.IsNullOrEmpty(userPath) && File.Exists(userPath))
@@ -47,9 +71,15 @@ public sealed class MeltySynthEngine : ISynthEngine
             $"'{userPath}', '{gameSf}', '{bundled}'.");
     }
 
+    /// <inheritdoc/>
     public void PlayMsg(uint msg)
     {
         CheckDisposed();
+        // Unpack the packed MIDI message. Layout:
+        //   byte 0 (status): top nibble = command (0x80 NoteOff ... 0xE0 PitchBend),
+        //                    bottom nibble = channel (0..15).
+        //   byte 1 (data1):  first data byte (e.g. note number, controller index).
+        //   byte 2 (data2):  second data byte (e.g. velocity, controller value).
         byte status = (byte)(msg & 0xFF);
         byte data1 = (byte)((msg >> 8) & 0xFF);
         byte data2 = (byte)((msg >> 16) & 0xFF);
@@ -58,12 +88,21 @@ public sealed class MeltySynthEngine : ISynthEngine
         _synth.ProcessMidiMessage(channel, command, data1, data2);
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Silently ignored. SoundFont synths have no meaningful interpretation
+    /// of SysEx — the SoundFont file itself defines the entire instrument
+    /// bank, and unlike an MT-32 there's no runtime patch/timbre loading
+    /// protocol to apply. Keeping this as a no-op is preferable to throwing
+    /// so that XMI streams containing GM reset / device-ID SysEx still play.
+    /// </remarks>
     public void PlaySysex(byte[] data)
     {
         CheckDisposed();
         // MeltySynth doesn't support arbitrary SysEx. Silently ignored.
     }
 
+    /// <inheritdoc/>
     public void Render(short[] buffer, uint frameCount)
     {
         CheckDisposed();
@@ -71,6 +110,9 @@ public sealed class MeltySynthEngine : ISynthEngine
         int framesRemaining = (int)frameCount;
         int bufferOffset = 0;
 
+        // Render in chunks no larger than our pre-allocated L/R scratch
+        // buffers; MeltySynth takes L/R spans and produces float samples,
+        // which we then interleave + convert to int16 for the caller.
         while (framesRemaining > 0)
         {
             int chunk = Math.Min(framesRemaining, _left.Length);
@@ -88,6 +130,16 @@ public sealed class MeltySynthEngine : ISynthEngine
         }
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Order matters. CC 120 (All Sound Off) fires first as a panic cut —
+    /// it silences every active partial immediately, including reverb /
+    /// release tails that would otherwise bleed into the new track. CC 123
+    /// (All Notes Off) then sends a normal note-off to anything that somehow
+    /// survived, and CC 121 (Reset All Controllers) returns pitch bend,
+    /// modulation, expression, etc. to their defaults so the next track
+    /// starts from a clean channel state.
+    /// </remarks>
     public void Reset()
     {
         CheckDisposed();
@@ -99,6 +151,7 @@ public sealed class MeltySynthEngine : ISynthEngine
         }
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         if (_disposed) return;
@@ -110,6 +163,14 @@ public sealed class MeltySynthEngine : ISynthEngine
         if (_disposed) throw new ObjectDisposedException(nameof(MeltySynthEngine));
     }
 
+    /// <summary>
+    /// Scale a normalised float sample (nominally in [-1, 1]) to signed 16-bit
+    /// PCM and clip to the int16 range. We multiply by 32767 (not 32768) so
+    /// that +1.0 maps exactly to <see cref="short.MaxValue"/>; the clamp to
+    /// -32768 handles the asymmetric negative range. Synths can (and do) emit
+    /// samples slightly outside [-1, 1] during transients — hard clipping is
+    /// preferable to wrap-around noise.
+    /// </summary>
     private static short FloatToShort(float f)
     {
         int s = (int)(f * 32767f);

--- a/src/audio/MeltySynthEngine.cs
+++ b/src/audio/MeltySynthEngine.cs
@@ -93,8 +93,8 @@ public sealed class MeltySynthEngine : ISynthEngine
         CheckDisposed();
         for (int ch = 0; ch < 16; ch++)
         {
+            _synth.ProcessMidiMessage(ch, 0xB0, 120, 0); // All Sound Off (hard cut — panic first)
             _synth.ProcessMidiMessage(ch, 0xB0, 123, 0); // All Notes Off
-            _synth.ProcessMidiMessage(ch, 0xB0, 120, 0); // All Sound Off
             _synth.ProcessMidiMessage(ch, 0xB0, 121, 0); // Reset All Controllers
         }
     }

--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
 using Godot;
 using Munt.NET;
 
@@ -125,6 +127,7 @@ public partial class MusicStreamPlayer : Node
             {
                 case "cm32l":
                 case "mt32":
+                    SetupMuntDllLoader();
                     return new Mt32EmuEngine(path, SampleRate);
                 case "opl":
                     return new AdlMidiEngine(SampleRate);
@@ -142,6 +145,46 @@ public partial class MusicStreamPlayer : Node
                 GD.Print($"OPL fallback also failed: {ex2.Message}. Music disabled.");
                 return null;
             }
+        }
+    }
+
+    private static bool _muntDllLoaderSetUp;
+    private static readonly object _muntDllLoaderLock = new();
+
+    /// <summary>
+    /// One-time DllImportResolver setup for libmt32emu. Munt.NET targets
+    /// netstandard2.0 so it can't register the resolver itself — we do it here.
+    /// </summary>
+    private static void SetupMuntDllLoader()
+    {
+        lock (_muntDllLoaderLock)
+        {
+            if (_muntDllLoaderSetUp) return;
+            _muntDllLoaderSetUp = true;
+
+            NativeLibrary.SetDllImportResolver(
+                typeof(Mt32EmuSynth).Assembly,
+                (name, assembly, path) =>
+                {
+                    var root = AppContext.BaseDirectory;
+                    string runtime = RuntimeInformation.RuntimeIdentifier;
+
+                    string filename;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        filename = Path.GetExtension(name).Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".dll";
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        filename = Path.GetExtension(name).Equals(".dylib", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".dylib";
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        filename = Path.GetExtension(name).Equals(".so", StringComparison.OrdinalIgnoreCase)
+                            ? name : name + ".so";
+                    else
+                        throw new PlatformNotSupportedException();
+
+                    var fullPath = Path.Combine(root, "runtimes", runtime, "native", filename);
+                    return File.Exists(fullPath) ? NativeLibrary.Load(fullPath) : IntPtr.Zero;
+                });
         }
     }
 }

--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -1,0 +1,147 @@
+using System;
+using Godot;
+using Munt.NET;
+
+namespace Underworld;
+
+/// <summary>
+/// Godot node that owns a synth engine and real-time XmiPlayer, pushes PCM to
+/// an AudioStreamGenerator from _Process. Singleton accessible via Instance.
+/// </summary>
+public partial class MusicStreamPlayer : Node
+{
+    public static MusicStreamPlayer Instance { get; private set; }
+
+    private const int SampleRate = 44100;
+    private const float BufferLengthSec = 0.1f;
+
+    private ISynthEngine _synth;
+    private XmiPlayer _xmiPlayer;
+    private AudioStreamPlayer _player;
+    private AudioStreamGeneratorPlayback _playback;
+
+    private short[] _renderBuffer;
+    private Vector2[] _frames;
+
+    public override void _Ready()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            QueueFree();
+            return;
+        }
+
+        _renderBuffer = new short[8192];
+        _frames = new Vector2[4096];
+
+        _synth = CreateSynthEngine();
+        if (_synth == null)
+        {
+            GD.Print("MusicStreamPlayer: no synth engine available, music disabled");
+            return;
+        }
+
+        _xmiPlayer = new XmiPlayer(_synth, SampleRate);
+
+        var generator = new AudioStreamGenerator
+        {
+            MixRate = SampleRate,
+            BufferLength = BufferLengthSec,
+        };
+
+        _player = new AudioStreamPlayer();
+        AddChild(_player);
+        _player.Stream = generator;
+        _player.Play();
+
+        _playback = (AudioStreamGeneratorPlayback)_player.GetStreamPlayback();
+    }
+
+    public override void _Process(double delta)
+    {
+        if (_playback == null || _xmiPlayer == null) return;
+
+        int available = _playback.GetFramesAvailable();
+        if (available <= 0) return;
+
+        int chunk = Math.Min(available, _frames.Length);
+        _xmiPlayer.Render(_renderBuffer, chunk);
+
+        for (int i = 0; i < chunk; i++)
+        {
+            float l = _renderBuffer[i * 2] / 32768f;
+            float r = _renderBuffer[i * 2 + 1] / 32768f;
+            _frames[i] = new Vector2(l, r);
+        }
+
+        if (chunk == _frames.Length)
+        {
+            _playback.PushBuffer(_frames);
+        }
+        else
+        {
+            var slice = new Vector2[chunk];
+            Array.Copy(_frames, slice, chunk);
+            _playback.PushBuffer(slice);
+        }
+    }
+
+    public void PlayXmi(string xmiPath, bool loop)
+    {
+        if (_xmiPlayer == null) return;
+        if (!System.IO.File.Exists(xmiPath))
+        {
+            GD.Print($"XMI file not found: {xmiPath}");
+            return;
+        }
+        _xmiPlayer.Load(xmiPath);
+        _xmiPlayer.Loop = loop;
+    }
+
+    public void Stop()
+    {
+        _xmiPlayer?.Stop();
+    }
+
+    public override void _ExitTree()
+    {
+        _xmiPlayer?.Dispose();
+        _synth?.Dispose();
+        if (Instance == this) Instance = null;
+    }
+
+    private static ISynthEngine CreateSynthEngine()
+    {
+        string synth = uwsettings.instance.synth?.ToLowerInvariant() ?? "soundfont";
+        string path = uwsettings.instance.synthpath ?? "";
+
+        try
+        {
+            switch (synth)
+            {
+                case "cm32l":
+                case "mt32":
+                    return new Mt32EmuEngine(path, SampleRate);
+                case "opl":
+                    return new AdlMidiEngine(SampleRate);
+                case "soundfont":
+                default:
+                    return new MeltySynthEngine(path, SampleRate);
+            }
+        }
+        catch (Exception ex)
+        {
+            GD.Print($"Primary synth '{synth}' failed: {ex.Message}. Falling back to OPL.");
+            try { return new AdlMidiEngine(SampleRate); }
+            catch (Exception ex2)
+            {
+                GD.Print($"OPL fallback also failed: {ex2.Message}. Music disabled.");
+                return null;
+            }
+        }
+    }
+}

--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -15,7 +15,9 @@ public partial class MusicStreamPlayer : Node
     public static MusicStreamPlayer Instance { get; private set; }
 
     private const int SampleRate = 44100;
-    private const float BufferLengthSec = 0.1f;
+    // Larger buffer to absorb main-thread hitches during cutscene scrolling.
+    // Godot rounds up to nearest power-of-2, so actual buffer ~371ms.
+    private const float BufferLengthSec = 0.25f;
 
     private ISynthEngine _synth;
     private XmiPlayer _xmiPlayer;
@@ -37,8 +39,9 @@ public partial class MusicStreamPlayer : Node
             return;
         }
 
-        _renderBuffer = new short[8192];
-        _frames = new Vector2[4096];
+        // Sized to cover the ~370ms buffer at 44100 Hz: 16384 frames = 32768 samples.
+        _renderBuffer = new short[32768];
+        _frames = new Vector2[16384];
 
         _synth = CreateSynthEngine();
         if (_synth == null)

--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Godot;
 using Munt.NET;
 
@@ -8,24 +9,45 @@ namespace Underworld;
 
 /// <summary>
 /// Godot node that owns a synth engine and real-time XmiPlayer, pushes PCM to
-/// an AudioStreamGenerator from _Process. Singleton accessible via Instance.
+/// an AudioStreamGenerator from a dedicated producer thread. A dedicated thread
+/// is required because _Process() runs on the main thread and stalls during
+/// cutscene scrolling / render-heavy frames, which would otherwise drain the
+/// audio ring buffer. Singleton accessible via Instance.
 /// </summary>
 public partial class MusicStreamPlayer : Node
 {
     public static MusicStreamPlayer Instance { get; private set; }
 
     private const int SampleRate = 44100;
-    // Larger buffer to absorb main-thread hitches during cutscene scrolling.
-    // Godot rounds up to nearest power-of-2, so actual buffer ~371ms.
-    private const float BufferLengthSec = 0.25f;
+    private const float BufferLengthSec = 0.1f;
 
     private ISynthEngine _synth;
     private XmiPlayer _xmiPlayer;
     private AudioStreamPlayer _player;
     private AudioStreamGeneratorPlayback _playback;
 
+    // Pre-allocated buffers for the producer thread
     private short[] _renderBuffer;
     private Vector2[] _frames;
+
+    // Threading
+    private Thread _audioThread;
+    private volatile bool _audioThreadRunning;
+    // Protects _xmiPlayer method calls between the main thread (PlayXmi/Stop)
+    // and the producer thread (Render).
+    private readonly object _playerLock = new();
+
+    /// <summary>True if an XMI track is currently loaded and playing.</summary>
+    public bool IsPlaying
+    {
+        get
+        {
+            lock (_playerLock)
+            {
+                return _xmiPlayer?.IsPlaying == true;
+            }
+        }
+    }
 
     public override void _Ready()
     {
@@ -39,9 +61,10 @@ public partial class MusicStreamPlayer : Node
             return;
         }
 
-        // Sized to cover the ~370ms buffer at 44100 Hz: 16384 frames = 32768 samples.
-        _renderBuffer = new short[32768];
-        _frames = new Vector2[16384];
+        // 4096 stereo frames ≈ 93ms at 44100 Hz — comfortably larger than one
+        // _process tick but small enough that ChangeTheme latency is low.
+        _renderBuffer = new short[8192];
+        _frames = new Vector2[4096];
 
         _synth = CreateSynthEngine();
         if (_synth == null)
@@ -64,57 +87,107 @@ public partial class MusicStreamPlayer : Node
         _player.Play();
 
         _playback = (AudioStreamGeneratorPlayback)_player.GetStreamPlayback();
+
+        _audioThreadRunning = true;
+        _audioThread = new Thread(AudioThreadLoop)
+        {
+            IsBackground = true,
+            Name = "Music Producer",
+        };
+        _audioThread.Start();
     }
 
-    public override void _Process(double delta)
+    /// <summary>
+    /// Producer-thread loop. Polls GetFramesAvailable and pushes rendered PCM
+    /// to the ring buffer. Sleeps briefly when the buffer is full.
+    /// </summary>
+    private void AudioThreadLoop()
     {
-        if (_playback == null || _xmiPlayer == null) return;
-
-        int available = _playback.GetFramesAvailable();
-        if (available <= 0) return;
-
-        int chunk = Math.Min(available, _frames.Length);
-        _xmiPlayer.Render(_renderBuffer, chunk);
-
-        for (int i = 0; i < chunk; i++)
+        while (_audioThreadRunning)
         {
-            float l = _renderBuffer[i * 2] / 32768f;
-            float r = _renderBuffer[i * 2 + 1] / 32768f;
-            _frames[i] = new Vector2(l, r);
-        }
+            try
+            {
+                int available = _playback.GetFramesAvailable();
+                if (available <= 0)
+                {
+                    Thread.Sleep(5);
+                    continue;
+                }
 
-        if (chunk == _frames.Length)
-        {
-            _playback.PushBuffer(_frames);
-        }
-        else
-        {
-            var slice = new Vector2[chunk];
-            Array.Copy(_frames, slice, chunk);
-            _playback.PushBuffer(slice);
+                int chunk = Math.Min(available, _frames.Length);
+
+                lock (_playerLock)
+                {
+                    if (_xmiPlayer == null)
+                    {
+                        Thread.Sleep(5);
+                        continue;
+                    }
+                    _xmiPlayer.Render(_renderBuffer, chunk);
+                }
+
+                // Convert stereo int16 → two float32 (-1..1) in Vector2 frames
+                for (int i = 0; i < chunk; i++)
+                {
+                    _frames[i] = new Vector2(
+                        _renderBuffer[i * 2] / 32768f,
+                        _renderBuffer[i * 2 + 1] / 32768f);
+                }
+
+                if (chunk == _frames.Length)
+                {
+                    _playback.PushBuffer(_frames);
+                }
+                else
+                {
+                    var slice = new Vector2[chunk];
+                    Array.Copy(_frames, slice, chunk);
+                    _playback.PushBuffer(slice);
+                }
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"Music audio thread error: {ex.Message}");
+                Thread.Sleep(100);
+            }
         }
     }
 
+    /// <summary>Load and begin playing an XMI file. Thread-safe.</summary>
     public void PlayXmi(string xmiPath, bool loop)
     {
-        if (_xmiPlayer == null) return;
-        if (!System.IO.File.Exists(xmiPath))
+        if (!File.Exists(xmiPath))
         {
             GD.Print($"XMI file not found: {xmiPath}");
             return;
         }
-        _xmiPlayer.Load(xmiPath);
-        _xmiPlayer.Loop = loop;
+        lock (_playerLock)
+        {
+            if (_xmiPlayer == null) return;
+            _xmiPlayer.Load(xmiPath);
+            _xmiPlayer.Loop = loop;
+        }
     }
 
+    /// <summary>Stop playback and reset synth state. Thread-safe.</summary>
     public void Stop()
     {
-        _xmiPlayer?.Stop();
+        lock (_playerLock)
+        {
+            _xmiPlayer?.Stop();
+        }
     }
 
     public override void _ExitTree()
     {
-        _xmiPlayer?.Dispose();
+        _audioThreadRunning = false;
+        _audioThread?.Join(500);
+
+        lock (_playerLock)
+        {
+            _xmiPlayer?.Dispose();
+            _xmiPlayer = null;
+        }
         _synth?.Dispose();
         if (Instance == this) Instance = null;
     }

--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -14,11 +14,22 @@ namespace Underworld;
 /// cutscene scrolling / render-heavy frames, which would otherwise drain the
 /// audio ring buffer. Singleton accessible via Instance.
 /// </summary>
+/// <remarks>
+/// Lifecycle: _Ready constructs the synth engine and starts the producer
+/// thread; _ExitTree signals shutdown and joins. PlayXmi/Stop/IsPlaying may be
+/// called from the main thread at any time and are serialised against the
+/// producer thread by <see cref="_playerLock"/>.
+/// </remarks>
 public partial class MusicStreamPlayer : Node
 {
+    /// <summary>Global singleton — the first instance added to the tree wins; later ones self-free.</summary>
     public static MusicStreamPlayer Instance { get; private set; }
 
     private const int SampleRate = 44100;
+    // 0.1s of ring buffer. Before the producer thread existed this had to be
+    // much larger (several hundred ms) to ride out main-thread stalls; now the
+    // producer thread keeps the buffer topped up independently of _Process,
+    // so a short buffer (low latency for ChangeTheme) is safe.
     private const float BufferLengthSec = 0.1f;
 
     private ISynthEngine _synth;
@@ -32,12 +43,20 @@ public partial class MusicStreamPlayer : Node
 
     // Threading
     private Thread _audioThread;
+    // volatile: read from the producer thread every loop iteration, written
+    // from the main thread in _ExitTree; no other synchronisation needed.
     private volatile bool _audioThreadRunning;
     // Protects _xmiPlayer method calls between the main thread (PlayXmi/Stop)
-    // and the producer thread (Render).
+    // and the producer thread (Render). XmiPlayer itself is not thread-safe:
+    // Load/Stop mutate the event list while Render walks it, so every touch
+    // of _xmiPlayer — on either thread — must hold this lock. The synth
+    // engine is only touched via _xmiPlayer so it inherits the same guard.
     private readonly object _playerLock = new();
 
-    /// <summary>True if an XMI track is currently loaded and playing.</summary>
+    /// <summary>
+    /// True if an XMI track is currently loaded and playing. Thread-safe —
+    /// takes <see cref="_playerLock"/> to read XmiPlayer state.
+    /// </summary>
     public bool IsPlaying
     {
         get
@@ -49,6 +68,12 @@ public partial class MusicStreamPlayer : Node
         }
     }
 
+    /// <summary>
+    /// Enforces the singleton, constructs the synth + XmiPlayer, wires up the
+    /// AudioStreamGenerator and starts the producer thread. If synth creation
+    /// fails entirely (including OPL fallback), the node remains alive but
+    /// silent — callers of PlayXmi become no-ops.
+    /// </summary>
     public override void _Ready()
     {
         if (Instance == null)
@@ -101,6 +126,15 @@ public partial class MusicStreamPlayer : Node
     /// Producer-thread loop. Polls GetFramesAvailable and pushes rendered PCM
     /// to the ring buffer. Sleeps briefly when the buffer is full.
     /// </summary>
+    /// <remarks>
+    /// We poll with <c>Thread.Sleep(5)</c> rather than a wait/signal pattern
+    /// because the API (GetFramesAvailable/PushBuffer) has no completion event
+    /// and a 5 ms sleep is cheap — at 44.1 kHz the ring buffer drains ~220
+    /// frames in that window, far below the 4096-frame chunk we render. The
+    /// try/catch guards against transient failures in the synth (e.g. a
+    /// SoundFont bug) and sleeps 100 ms on error to avoid busy-looping on a
+    /// persistent failure mode; errors surface via GD.PushError.
+    /// </remarks>
     private void AudioThreadLoop()
     {
         while (_audioThreadRunning)
@@ -153,7 +187,14 @@ public partial class MusicStreamPlayer : Node
         }
     }
 
-    /// <summary>Load and begin playing an XMI file. Thread-safe.</summary>
+    /// <summary>
+    /// Load and begin playing an XMI file. Thread-safe — may be called from
+    /// the main thread while the producer thread is rendering; the lock
+    /// serialises the Load against any in-flight Render call so event-list
+    /// mutation never races with iteration.
+    /// </summary>
+    /// <param name="xmiPath">Absolute path to an XMI file on disk.</param>
+    /// <param name="loop">If true, playback loops indefinitely.</param>
     public void PlayXmi(string xmiPath, bool loop)
     {
         if (!File.Exists(xmiPath))
@@ -169,7 +210,10 @@ public partial class MusicStreamPlayer : Node
         }
     }
 
-    /// <summary>Stop playback and reset synth state. Thread-safe.</summary>
+    /// <summary>
+    /// Stop playback and reset synth state (all-notes-off etc.). Thread-safe.
+    /// Subsequent Render calls will emit silence until the next PlayXmi.
+    /// </summary>
     public void Stop()
     {
         lock (_playerLock)
@@ -178,6 +222,11 @@ public partial class MusicStreamPlayer : Node
         }
     }
 
+    /// <summary>
+    /// Signals the producer thread to exit, joins it (bounded wait), then
+    /// disposes the XmiPlayer and synth. Join timeout is 500 ms — the loop
+    /// sleeps at most 100 ms so this is comfortable headroom.
+    /// </summary>
     public override void _ExitTree()
     {
         _audioThreadRunning = false;
@@ -192,6 +241,14 @@ public partial class MusicStreamPlayer : Node
         if (Instance == this) Instance = null;
     }
 
+    /// <summary>
+    /// Construct the synth engine selected by uwsettings.synth, with a two-
+    /// step fallback chain: primary (as configured) → OPL (AdlMidi, always
+    /// available because the game ships the OPL bank) → null (music disabled).
+    /// Any exception from the primary or OPL constructor is caught and logged
+    /// rather than propagating, so a missing ROM or SoundFont never crashes
+    /// startup.
+    /// </summary>
     private static ISynthEngine CreateSynthEngine()
     {
         string synth = uwsettings.instance.synth?.ToLowerInvariant() ?? "soundfont";
@@ -229,7 +286,13 @@ public partial class MusicStreamPlayer : Node
 
     /// <summary>
     /// One-time DllImportResolver setup for libmt32emu. Munt.NET targets
-    /// netstandard2.0 so it can't register the resolver itself — we do it here.
+    /// netstandard2.0 which does not expose <see cref="NativeLibrary"/> —
+    /// so the library can't register its own resolver and we install one
+    /// here (from a net9.0 host) on its behalf. The resolver looks in
+    /// <c>{AppContext.BaseDirectory}/runtimes/{rid}/native/</c>, which is
+    /// the standard NuGet package layout for native assets — that way the
+    /// same resolver works whether the dylib came from a NuGet restore or
+    /// was copied into the publish output by our build scripts.
     /// </summary>
     private static void SetupMuntDllLoader()
     {

--- a/src/cuts/cutsplayer.cs
+++ b/src/cuts/cutsplayer.cs
@@ -1146,7 +1146,14 @@ namespace Underworld
             uimanager.EnableDisable(cutscontrol, false);
             uimanager.EnableDisable(uimanager.instance.CutsSubtitle, false);
 
-            if (callBackMethod != null)
+            if (cancelRequested)
+            {
+                // Escape was pressed — skip the chained callback (which would play
+                // the next cutscene in the intro sequence) and return straight to
+                // the main menu.
+                uimanager.ReturnToMainMenu();
+            }
+            else if (callBackMethod != null)
             {
                 callBackMethod();
             }

--- a/src/cuts/cutsplayer.cs
+++ b/src/cuts/cutsplayer.cs
@@ -169,7 +169,7 @@ namespace Underworld
         public static void StopCutscene()
         {
             cancelRequested = true;
-            main.instance.MusicPlayer.Stop();
+            MusicStreamPlayer.Instance?.Stop();
             XMIMusic.CurrentThemeNo = 0;
         }
 

--- a/src/loaders/xmimusic.cs
+++ b/src/loaders/xmimusic.cs
@@ -18,7 +18,7 @@ namespace Underworld
 
         public static byte Armed => _RES == GAME_UW2 ? (byte)5 : (byte)10;
 
-        public static void ChangeTheme(byte themeNo, bool Loop = false)
+        public static void ChangeTheme(byte themeNo, bool Loop = true)
         {
             // Theme numbers are octal-encoded: upper 5 bits = first digit, lower 3 bits = second digit.
             // Matches original engine behaviour (see commit 9beb7e6 upstream).

--- a/src/loaders/xmimusic.cs
+++ b/src/loaders/xmimusic.cs
@@ -9,7 +9,6 @@ namespace Underworld
     public class XMIMusic : UWClass
     {
         public static byte CurrentThemeNo;
-        public static bool LoopTheme = false;
         static readonly byte[] UW2WorldThemes = [0xA, 0xC, 0xE, 0x9, 0xA, 0xF, 0xB, 0xD, 0xA, 0xC, 0xD, 0x9, 0x8, 0xB, 0xE, 0xD, 0x8, 0xF, 0xE, 0x9, 0x8, 0xF, 0xB, 0xA, 0x8, 0xC, 0x9];
         static int CurrentWorldTheme;
 
@@ -44,7 +43,6 @@ namespace Underworld
             }
 
             MusicStreamPlayer.Instance.PlayXmi(xmiPath, Loop);
-            LoopTheme = Loop;
         }
 
         public static byte PickLevelThemeMusic(int arg0 = -1)

--- a/src/loaders/xmimusic.cs
+++ b/src/loaders/xmimusic.cs
@@ -20,10 +20,14 @@ namespace Underworld
 
         public static void ChangeTheme(byte themeNo, bool Loop = false)
         {
+            // Theme numbers are octal-encoded: upper 5 bits = first digit, lower 3 bits = second digit.
+            // Matches original engine behaviour (see commit 9beb7e6 upstream).
+            var digit1 = (char)(0x30 + (themeNo >> 3));
+            var digit2 = (char)(0x30 + (themeNo & 0x7));
             CurrentThemeNo = themeNo;
             string filename = _RES == GAME_UW2
-                ? $"UWA{themeNo:D2}.XMI"
-                : $"UW{themeNo:D2}.XMI";
+                ? $"UWA{digit1}{digit2}.XMI"
+                : $"UW{digit1}{digit2}.XMI";
             ChangeTheme(filename, Loop);
         }
 

--- a/src/loaders/xmimusic.cs
+++ b/src/loaders/xmimusic.cs
@@ -1,487 +1,67 @@
 using System.IO;
-using System.Diagnostics;
-using Godot;
-using System.Runtime.InteropServices;
-using ADLMidi.NET;
-using Munt.NET;
-using SerdesNet;
-using System;
-
 
 namespace Underworld
 {
     /// <summary>
-    /// Converts the UW xmi files to WAV files. Based on example implementation from ADLMidi https://github.com/csinkers/AdlMidi.NET
+    /// Static facade over MusicStreamPlayer. Resolves theme numbers to XMI filenames
+    /// and delegates playback to the node. All synthesis is real-time — no WAV caching.
     /// </summary>
     public class XMIMusic : UWClass
-    {      
+    {
         public static byte CurrentThemeNo;
         public static bool LoopTheme = false;
-        static byte[] UW2WorldThemes = [0xA, 0xC, 0xE, 0x9, 0xA, 0xF, 0xB, 0xD, 0xA, 0xC, 0xD, 0x9, 0x8, 0xB, 0xE, 0xD, 0x8, 0xF, 0xE, 0x9, 0x8, 0xF, 0xB, 0xA, 0x8, 0xC, 0x9];
+        static readonly byte[] UW2WorldThemes = [0xA, 0xC, 0xE, 0x9, 0xA, 0xF, 0xB, 0xD, 0xA, 0xC, 0xD, 0x9, 0x8, 0xB, 0xE, 0xD, 0x8, 0xF, 0xE, 0x9, 0x8, 0xF, 0xB, 0xA, 0x8, 0xC, 0x9];
         static int CurrentWorldTheme;
-        const int SampleRate = 44100;
-        static double _time;
 
-        static string bankfile
-        {
-            get
-            {
-                if (_RES == GAME_UW2)
-                {
-                    return "UW.OPL";
-                }
-                else
-                {
-                    return "UW.AD";
-                }
-            }
-        }
-
-
-        //Playlists, returns a possibly random theme tune to play in a particular scenario.
         public const byte IntroTheme = 1;
-        public const byte MapsAndLegends = 0xD;// UW1 specific conversations and maps viewing them
+        public const byte MapsAndLegends = 15;
 
-        public static byte Armed
-        {
-            get
-            {
-                if (_RES==GAME_UW2)
-                {
-                    return 5;
-                }
-                else
-                {
-                    return 8;
-                }
-            }
-        } 
+        public static byte Armed => _RES == GAME_UW2 ? (byte)5 : (byte)10;
 
-
-        /// <summary>
-        /// Changes the music theme that is playing based on theme file number.
-        /// </summary>
-        /// <param name="themeNo"></param>
         public static void ChangeTheme(byte themeNo, bool Loop = false)
         {
-            //Calculate file number to play
-            var digit1 = (char)(0x30 + (themeNo >> 3));
-            var digit2 = (char)(0x30 + (themeNo & 0x7));
             CurrentThemeNo = themeNo;
-            switch(_RES)
-            {
-                case GAME_UW2:
-                    ChangeTheme($"UWA{digit1}{digit2}.WAV",Loop);//TODO provide a way to choose between playing UWAxx.xmi or UWRxx.xmi)
-                    break;
-                default:
-                    ChangeTheme($"UW{digit1}{digit2}.WAV",Loop);
-                    break;
-            }
+            string filename = _RES == GAME_UW2
+                ? $"UWA{themeNo:D2}.XMI"
+                : $"UW{themeNo:D2}.XMI";
+            ChangeTheme(filename, Loop);
         }
 
-        /// <summary>
-        /// Changes the theme that is playing based on the .WAV filename.
-        /// </summary>
-        /// <param name="filename"></param>
         static void ChangeTheme(string filename, bool Loop = false)
-        {   
-            if (!playerdat.MusicEnabled)
+        {
+            if (!playerdat.MusicEnabled) return;
+            if (MusicStreamPlayer.Instance == null) return;
+
+            string xmiPath = Path.Combine(BasePath, "SOUND", filename);
+            if (!File.Exists(xmiPath))
             {
+                System.Diagnostics.Debug.Print($"Theme {filename} not found at {xmiPath}");
                 return;
             }
-            filename = filename.ToUpper().Replace(".XMI",".WAV");//since I keep putting in XMI instead of WAV this will always force the WAV version to play...
-            //var Result = new AudioSample();
-            var fullPath = Path.Combine(ProjectSettings.GlobalizePath("user://"), _RES.ToString(), "SOUND", filename); 
-            if (File.Exists(fullPath))
-            {                
-                var stream = new AudioStreamWav();
-                stream.Data = File.ReadAllBytes(fullPath);//TODO: cache these themes
-                stream.Format = AudioStreamWav.FormatEnum.Format16Bits;
-                stream.Stereo = true;
-                stream.MixRate = SampleRate;
-                main.instance.MusicPlayer.Stream = stream;
-                LoopTheme = Loop;
-                main.instance.MusicPlayer.Play(); 
-            }
-            else
-            {
-                Debug.Print($"Theme {filename} not found1");
-            }
+
+            MusicStreamPlayer.Instance.PlayXmi(xmiPath, Loop);
+            LoopTheme = Loop;
         }
 
-
-        /// <summary>
-        /// For UW1 the theme one of tracks 2 to 5, for UW2 the theme is selected based on the game world the player is in.
-        /// </summary>
         public static byte PickLevelThemeMusic(int arg0 = -1)
         {
+            switch (_RES)
             {
-               switch(_RES)
-               {
                 case GAME_UW2:
-                    //playerdat.CurrentWorld;
                     if (CurrentWorldTheme != playerdat.CurrentWorld)
-                        {
-                            CurrentWorldTheme = playerdat.CurrentWorld;
-                            arg0 = 0;
-                        }
-                    else
-                        {
-                            if (arg0 == -2 )
-                            {
-                                return CurrentThemeNo;//No change in theme. Probably this is triggered by a level change to the same world.
-                            }
-                        }
-                    if (arg0 == -1)
-                        {
-                            arg0 = Rng.r.Next(3);
-                        }
-                    
-                    //Look up table.
+                    {
+                        CurrentWorldTheme = playerdat.CurrentWorld;
+                        arg0 = 0;
+                    }
+                    else if (arg0 == -2)
+                    {
+                        return CurrentThemeNo;
+                    }
+                    if (arg0 == -1) arg0 = Rng.r.Next(3);
                     return UW2WorldThemes[(playerdat.CurrentWorld * 3) + arg0];
                 default:
                     return (byte)(2 + Rng.r.Next(3));
-               } 
             }
         }
-
-
-        /// <summary>
-        /// Converts XMI files to WAV files and saves them to appdata folder. If files already exist do nothing.
-        /// </summary>
-        public static void ConvertXMIMusic()
-        {
-            if (string.Equals(uwsettings.instance.synth, "cm32l", StringComparison.OrdinalIgnoreCase))
-            {
-                var roms = FindRoms();
-                if (roms != null)
-                {
-                    ConvertXMIMusic_CM32L(roms.Value.control, roms.Value.pcm);
-                    return;
-                }
-                Debug.Print("CM-32L ROMs not found, falling back to OPL");
-            }
-            ConvertXMIMusic_OPL();
-        }
-
-        static void ConvertXMIMusic_OPL()
-        {
-            SetupDllLoader();
-            var outputfolder = Path.Combine(ProjectSettings.GlobalizePath("user://"), _RES.ToString(), "SOUND");
-            if (!Path.Exists(outputfolder))
-            {
-                System.IO.Directory.CreateDirectory(outputfolder);
-            }
-            var NewWoplPath = Path.Combine(outputfolder, bankfile.Replace(".", "_") + ".wopl");
-            GlobalTimbreLibrary oplFile = ReadOpl(Path.Combine(BasePath, "SOUND", bankfile));
-            WoplFile wopl = OplToWopl(oplFile);
-            WriteWopl(wopl, NewWoplPath);
-
-            byte[] bankData = File.ReadAllBytes(NewWoplPath);
-            var filelist = System.IO.Directory.EnumerateFiles(Path.Combine(BasePath, "SOUND"),"*.XMI");
-            foreach (var f in filelist)
-            {
-                var outputFile = f.GetFile().Replace(".XMI",".WAV");
-                if (!System.IO.File.Exists( Path.Combine(outputfolder,outputFile )))
-                {
-                    ExportXMI(xmifile: f, outfile: Path.Combine(outputfolder,outputFile ), bankData: bankData);
-                }
-            }
-        }
-
-        static void ExportXMI(string xmifile, string outfile, byte[] bankData)
-        {
-            //string path = $@"C:\Depot\bb\ualbion\Data\Exported\SONGS{songId / 100}.XLD\{songId % 100:D2}.xmi";
-            if (!File.Exists(xmifile))
-                return;
-
-            using var outputFile = new WavFile(
-                outfile,
-                SampleRate, 2, 2);
-
-            using var player = AdlMidi.Init();
-   
-            //player.SetNoteHook(NoteHook, IntPtr.Zero);
-            player.OpenBankData(bankData);
-            player.OpenFile(xmifile);
-            player.SetLoopEnabled(false);
-            short[] bufferArray = new short[4096];
-            long totalSamples = 0;
-            for (; ; )
-            {
-                _time = (double)totalSamples / (2 * SampleRate);
-                int samplesWritten = player.Play(bufferArray);
-                totalSamples += samplesWritten;
-
-                if (samplesWritten <= 0)
-                    break;
-
-                var byteSpan = MemoryMarshal.Cast<short, byte>(new ReadOnlySpan<short>(bufferArray, 0, samplesWritten));
-                outputFile.Write(byteSpan);
-            }
-        }
-
-        static WoplFile OplToWopl(GlobalTimbreLibrary oplFile)
-        {
-            var wopl = new WoplFile
-            {
-                Version = 3,
-                GlobalFlags = GlobalBankFlags.DeepTremolo | GlobalBankFlags.DeepVibrato,
-                VolumeModel = VolumeModel.Auto
-            };
-
-            wopl.Melodic.Add(new WoplBank { Id = 0, Name = "" });
-            wopl.Percussion.Add(new WoplBank { Id = 0, Name = "" });
-
-            for (int i = 0; i < oplFile.Data.Count; i++)
-            {
-                var timbre = oplFile.Data[i];
-                WoplInstrument x =
-                    i < 128
-                        ? wopl.Melodic[0].Instruments[i] ?? new WoplInstrument()
-                        : wopl.Percussion[0].Instruments[i - 128 + 35] ?? new WoplInstrument();
-
-                x.Name = "";
-                x.NoteOffset1 = timbre.MidiPatchNumber;
-                x.NoteOffset2 = timbre.MidiBankNumber;
-                x.InstrumentMode = InstrumentMode.TwoOperator;
-                x.FbConn1C0 = timbre.FeedbackConnection;
-                x.Operator0 = timbre.Carrier;
-                x.Operator1 = timbre.Modulation;
-                x.Operator2 = Operator.Blank;
-                x.Operator3 = Operator.Blank;
-
-                if (i < 128)
-                    wopl.Melodic[0].Instruments[i] = x;
-                else
-                    wopl.Percussion[0].Instruments[i - 128 + 35] = x;
-            }
-
-            return wopl;
-        }
-
-        public sealed class WavFile : IDisposable
-        {
-            readonly FileStream _stream;
-            readonly BinaryWriter _bw;
-            readonly long _riffSizeOffset;
-            readonly long _dataSizeOffset;
-            uint _dataSize;
-
-            public WavFile(string filename, uint sampleRate, ushort numChannels, ushort bytesPerSample)
-            {
-                _stream = File.Open(filename, FileMode.Create);
-                _bw = new BinaryWriter(_stream);
-                _bw.Write("RIFF"u8.ToArray()); // Container format chunk
-                _riffSizeOffset = _stream.Position;
-                _bw.Write(0); // Dummy write to start with, will be overwritten at the end.
-
-                _bw.Write("WAVEfmt "u8.ToArray()); // Subchunk1 (format metadata)
-                _bw.Write(16);
-                _bw.Write((ushort)1); // Format = Linear Quantisation
-                _bw.Write(numChannels); // NumChannels
-                _bw.Write(sampleRate); // SampleRate
-                _bw.Write(sampleRate * numChannels * bytesPerSample); // ByteRate
-                _bw.Write((ushort)(numChannels * bytesPerSample)); // BlockAlign
-                _bw.Write((ushort)(bytesPerSample * 8)); // BitsPerSample
-
-                _bw.Write("data"u8.ToArray()); // Subchunk2 (raw sample data)
-                _dataSizeOffset = _stream.Position;
-                _bw.Write(0); // Dummy write, will be overwritten at the end
-            }
-
-            public void Write(ReadOnlySpan<byte> buffer)
-            {
-                _bw.Write(buffer);
-                _dataSize += (uint)buffer.Length;
-            }
-
-            public void Dispose()
-            {
-                var totalLength = _stream.Position; // Write actual length to container format chunk
-                _stream.Position = _riffSizeOffset;
-                _bw.Write((uint)(totalLength - 8));
-
-                _stream.Position = _dataSizeOffset;
-                _bw.Write(_dataSize);
-
-                _bw.Dispose();
-                _stream.Dispose();
-            }
-        }
-        /*
-                static WoplFile ReadWopl(string filename)
-                {
-                    using var stream2 = File.OpenRead(filename);
-                    using var br = new BinaryReader(stream2);
-                    return WoplFile.Serdes(null, new GenericBinaryReader(br, br.BaseStream.Length, Encoding.ASCII.GetString, Console.WriteLine));
-                }
-        */
-
-        static void WriteWopl(WoplFile wopl, string filename)
-        {
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-            WoplFile.Serdes(wopl, new WriterSerdes(bw, Console.WriteLine));
-            byte[] bytes = ms.ToArray();
-            File.WriteAllBytes(filename, bytes);
-        }
-
-        static GlobalTimbreLibrary ReadOpl(string filename)
-        {
-            using var stream = File.OpenRead(filename);
-            using var br = new BinaryReader(stream);
-            return GlobalTimbreLibrary.Serdes(
-                null,
-                new ReaderSerdes(
-                    br,
-                    br.BaseStream.Length,
-                    Console.WriteLine));
-        }
-
-
-        static void SetupDllLoader()
-        {
-            NativeLibrary.SetDllImportResolver(
-                typeof(AdlMidi).Assembly,
-                (name, assembly, path) =>
-            {
-                var root = AppContext.BaseDirectory; //Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
-
-                string filename;
-                string runtime = RuntimeInformation.RuntimeIdentifier;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".DLL", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".dll";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".SO", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".so";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".DYLIB", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".dylib";
-                }
-                else throw new PlatformNotSupportedException();
-
-                var fullPath = Path.Combine(root, "runtimes", runtime, "native", filename);
-                return File.Exists(fullPath)
-                    ? NativeLibrary.Load(fullPath)
-                    : IntPtr.Zero;
-            });
-        }
-
-        static void SetupMt32DllLoader()
-        {
-            NativeLibrary.SetDllImportResolver(
-                typeof(Mt32EmuSynth).Assembly,
-                (name, assembly, path) =>
-            {
-                var root = AppContext.BaseDirectory;
-
-                string filename;
-                string runtime = RuntimeInformation.RuntimeIdentifier;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".DLL", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".dll";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".DYLIB", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".dylib";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    filename = string.Equals(Path.GetExtension(name), ".SO", StringComparison.OrdinalIgnoreCase)
-                        ? name
-                        : name + ".so";
-                }
-                else throw new PlatformNotSupportedException();
-
-                var fullPath = Path.Combine(root, "runtimes", runtime, "native", filename);
-                return File.Exists(fullPath)
-                    ? NativeLibrary.Load(fullPath)
-                    : IntPtr.Zero;
-            });
-        }
-
-        static (string control, string pcm)? FindRoms()
-        {
-            string[] searchPaths;
-            if (!string.IsNullOrEmpty(uwsettings.instance.rompath))
-            {
-                searchPaths = new[] { uwsettings.instance.rompath };
-            }
-            else
-            {
-                searchPaths = new[]
-                {
-                    Path.Combine(BasePath, "SOUND"),
-                    ProjectSettings.GlobalizePath("user://roms/")
-                };
-            }
-
-            // Standard and MAME-style ROM name pairs (control, pcm)
-            var namePairs = new[]
-            {
-                ("CM32L_CONTROL.ROM", "CM32L_PCM.ROM"),
-                ("cm32l_ctrl_1_02.rom", "cm32l_pcm.rom"),
-                ("cm32l_ctrl_1_00.rom", "cm32l_pcm.rom"),
-            };
-
-            foreach (var dir in searchPaths)
-            {
-                if (!System.IO.Directory.Exists(dir)) continue;
-                foreach (var (ctrlName, pcmName) in namePairs)
-                {
-                    var control = Path.Combine(dir, ctrlName);
-                    var pcm = Path.Combine(dir, pcmName);
-                    if (File.Exists(control) && File.Exists(pcm))
-                        return (control, pcm);
-                }
-            }
-
-            return null;
-        }
-
-        static void ConvertXMIMusic_CM32L(string controlRomPath, string pcmRomPath)
-        {
-            SetupMt32DllLoader();
-            var outputfolder = Path.Combine(ProjectSettings.GlobalizePath("user://"), _RES.ToString(), "SOUND");
-            if (!Path.Exists(outputfolder))
-            {
-                System.IO.Directory.CreateDirectory(outputfolder);
-            }
-
-            using var synth = new Mt32EmuSynth();
-            synth.LoadRoms(controlRomPath, pcmRomPath);
-            synth.SetSampleRate(SampleRate);
-            synth.Open();
-
-            var filelist = System.IO.Directory.EnumerateFiles(Path.Combine(BasePath, "SOUND"), "*.XMI");
-            foreach (var f in filelist)
-            {
-                var outputFile = f.GetFile().Replace(".XMI", ".WAV");
-                var outputPath = Path.Combine(outputfolder, outputFile);
-                if (!System.IO.File.Exists(outputPath))
-                {
-                    Debug.Print($"Converting {f.GetFile()} via CM-32L...");
-                    short[] pcm = XmiSequencer.RenderXmiToPcm(synth, f, SampleRate);
-                    using var wav = new WavFile(outputPath, (uint)SampleRate, 2, 2);
-                    var byteSpan = MemoryMarshal.Cast<short, byte>(new ReadOnlySpan<short>(pcm));
-                    wav.Write(byteSpan);
-                }
-            }
-        }
-
-    }//end class
-}//end namespace
+    }
+}

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -449,7 +449,7 @@ namespace Underworld
         {
             Debug.Print("Return to main menu");
             //Still some weirdness with enabling the main menu again. eg palette switch in UW1
-            if (XMIMusic.CurrentThemeNo != 1)
+            if (MusicStreamPlayer.Instance?.IsPlaying != true || XMIMusic.CurrentThemeNo != 1)
             {
                 XMIMusic.ChangeTheme(1);
             }

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -398,7 +398,7 @@ namespace Underworld
                                 case 2://turn on
                                     {
                                         playerdat.MusicEnabled = true;
-                                        if (!main.instance.MusicPlayer.Playing)
+                                        if (MusicStreamPlayer.Instance != null)
                                         {//restart music if not already playing.
                                             XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic());
                                         }
@@ -414,7 +414,7 @@ namespace Underworld
                                 case 3: //turn off
                                     {
                                         playerdat.MusicEnabled = false;
-                                        main.instance.MusicPlayer.Stop();
+                                        MusicStreamPlayer.Instance?.Stop();
                                         SetGameOptionButtons(new int[]{
                                             (int)OptionButtonIndices.MusicIsOffLabel,
                                             (int)OptionButtonIndices.TurnMusicLabel,

--- a/src/utility/config.cs
+++ b/src/utility/config.cs
@@ -64,6 +64,14 @@ public class uwsettings
                 throw new InvalidOperationException("Invalid Game Selected");
         }
 
+        // Backward compat: if legacy 'rompath' is set but new 'synthpath' isn't,
+        // promote rompath to synthpath.
+        if (string.IsNullOrEmpty(instance.synthpath) && !string.IsNullOrEmpty(instance.rompath))
+        {
+            instance.synthpath = instance.rompath;
+            Debug.Print("Warning: 'rompath' setting is deprecated, use 'synthpath' instead.");
+        }
+
     }
 
     public string pathuw1 { get; set; } = @"C:\Games\UW";
@@ -73,7 +81,10 @@ public class uwsettings
     public float FOV { get; set; } = 75;
     public bool showcolliders { get; set; }
     public int shaderbandsize { get; set; } = 8;
-    public string synth { get; set; } = "opl";
+    public string synth { get; set; } = "soundfont";
+    public string synthpath { get; set; } = "";
+    // Legacy field, still read for backward compatibility. If set and synthpath is empty,
+    // synthpath is populated from this in LoadSettings.
     public string rompath { get; set; } = "";
 
     public void Save()

--- a/uwsettings.schema.json
+++ b/uwsettings.schema.json
@@ -71,14 +71,20 @@
         },
 
         "synth": {
-            "description": "Music synthesizer to use. 'opl' for AdLib/OPL emulation, 'cm32l' for Roland CM-32L/MT-32 emulation (requires ROM files).",
+            "description": "Music synthesizer engine. 'cm32l' and 'mt32' use mt32emu (require ROM files). 'soundfont' uses a SoundFont (SF2) file. 'opl' uses AdLib/OPL FM synthesis.",
             "type": "string",
-            "enum": ["opl", "cm32l"],
-            "default": "opl"
+            "enum": ["cm32l", "mt32", "soundfont", "opl"],
+            "default": "soundfont"
+        },
+
+        "synthpath": {
+            "description": "Path to ROM directory (for cm32l/mt32) or .sf2 file (for soundfont). Empty = use defaults.",
+            "type": "string",
+            "default": ""
         },
 
         "rompath": {
-            "description": "Optional path to directory containing CM-32L ROM files (CM32L_CONTROL.ROM and CM32L_PCM.ROM). If empty, searches game SOUND folder and user://roms/.",
+            "description": "DEPRECATED: use 'synthpath'. Legacy path to ROM directory — still read if synthpath is empty.",
             "type": "string",
             "default": ""
         }


### PR DESCRIPTION
## Summary

Replaces the WAV pre-rendering pipeline with real-time MIDI synthesis. Four synth backends selectable via `synth` setting: `cm32l` / `mt32` (mt32emu, authentic), `soundfont` (MeltySynth, default — ships with a bundled GeneralUser GS), `opl` (AdlMidi, FM synthesis).

**Key benefits:**
- No startup conversion delay (was: pre-render every XMI to WAV at boot)
- Gapless track looping (was: baked-in reverb-tail silence between loops)
- Works out of the box via bundled soundfont (no ROM files required)
- Authentic CM-32L / MT-32 available via user-supplied ROMs
- One unified code path across all four synth backends

**User-visible behaviour matches the original DOS engine:** tracks loop indefinitely, theme changes are state-driven (combat, world change, cutscene command 25), never track-driven. Confirmed against disassembly of `seg016_1E73_174B` (`LoadXMIFiles`), `seg016_1E73_2B0C` (`ChangeThemeMusic`), and `seg016_1E73_2B1E` (`PickLevelThemeMusic`).

## Architecture

Start with [`docs/audio-architecture.md`](docs/audio-architecture.md) — it's a self-contained walkthrough of the data flow, components, and design rationale. Short version:

```
XMI → XmiPlayer (stateful sequencer) → ISynthEngine → AudioStreamGenerator → Godot audio
                                       [one of: Mt32EmuEngine / MeltySynthEngine / AdlMidiEngine]
```

A dedicated producer thread fills the ring buffer. The main thread calls `PlayXmi` / `Stop`; the producer thread calls `Render` on the `XmiPlayer`. A single `_playerLock` mutex makes this safe.

## Dependencies

- **[Munt.NET](https://github.com/abedegno/Munt.NET)** — new NuGet package (0.2.1), wraps mt32emu + hosts the `XmiPlayer` / `ISynthEngine` abstraction
- **[MeltySynth](https://github.com/sinshu/meltysynth)** — NuGet dependency (pure C#, SoundFont synthesis)
- **[AdlMidi.NET](https://github.com/abedegno/AdlMidi.NET)** — we use the `abedegno` fork's `master` branch, which has two improvements not yet in upstream:
  - macOS ARM64 native dylib (existing PR [csinkers/AdlMidi.NET#1](https://github.com/csinkers/AdlMidi.NET/pull/1))
  - Real-time MIDI API (`adl_rt_*` methods) unblocked — new PR [csinkers/AdlMidi.NET#2](https://github.com/csinkers/AdlMidi.NET/pull/2)

  Until both are merged upstream, the `Underworld.csproj` `ProjectReference` must point at a local clone of `abedegno/AdlMidi.NET` master. Once merged and a new NuGet release is cut, the ProjectReference can be replaced with a PackageReference to upstream.

## Suggested reading order

The 23 commits tell the story in order, but here's a guided path through the key ones:

### 1. Foundation — settings + bundled soundfont
- `e73c61a feat: add synthpath setting, default synth=soundfont, deprecate rompath`
- `a5fcd8f chore: add MeltySynth NuGet dependency`
- `19a1e6c chore: bundle GeneralUser GS v2.0.3 soundfont`

### 2. Synth backends — one `ISynthEngine` impl per backend
- `0b75115 feat: add MeltySynthEngine (SoundFont)`
- `4aaf25c feat: add AdlMidiEngine (OPL via real-time API)`
- `2986244 fix: set up DllImportResolver for libmt32emu when using cm32l/mt32 synth`

### 3. Real-time playback node
- `55f33e5 feat: add MusicStreamPlayer Godot node for real-time audio output` — initial `_Process`-based version
- `f7b9b14 feat: add MusicStreamPlayer node to Underworld scene`
- `9c2e4c5 fix: push audio from dedicated producer thread to prevent underruns` — this is the critical threading rework; supersedes the `_Process` version

### 4. XMIMusic facade shrinkage
- `8a1458c refactor: reduce XMIMusic to thin facade over MusicStreamPlayer` — 484 lines → ~50
- `87c8046 refactor: remove ConvertXMIMusic call`
- `6531504 refactor: update music control calls to use MusicStreamPlayer`

### 5. Bug fixes found during manual testing
- `ae201bf fix: theme numbers are octal-encoded, not decimal` — matches the original engine's digit-pair filename construction (`seg016_1E73_174B` lines 81789–81805)
- `09ef169 fix: loop music by default` — every UW track loops per original behaviour
- `f3fa365 fix: cutscene cancel bypasses chained callback to return straight to menu` — Escape during intro was triggering the next cutscene (CS001) instead of returning to menu
- `f90447a fix: use MusicStreamPlayer.IsPlaying in ReturnToMainMenu` — replaces fragile `CurrentThemeNo != 1` check
- `10a98ad fix: dispose AdlMidi player on constructor failure`
- `8f773e7 fix: reset MeltySynth with All Sound Off first (panic-cut)`

### 6. Cleanup
- `0d0c895 chore: remove dead LoopTheme field`
- `46dee10 chore: remove dead UI/MusicPlayer scene node and Export field`
- `426f045 docs: update README to describe real-time synthesis`
- `78f9232 docs: add detailed comments to audio engine files`
- `43a7176 docs: add audio architecture walkthrough`

## Settings

```json
{
    "synth": "soundfont",
    "synthpath": ""
}
```

| `synth` | `synthpath` | Behaviour |
|---------|-------------|-----------|
| `soundfont` (default) | optional `.sf2` path | MeltySynth; falls back to bundled `res://soundfonts/default.sf2` |
| `cm32l` | ROM directory | mt32emu with CM-32L ROMs (standard or MAME-style filenames) |
| `mt32` | ROM directory | mt32emu with MT-32 ROMs |
| `opl` | (ignored) | AdLib/OPL FM synthesis using game's `UW.OPL` / `UW.AD` bank |

Legacy `rompath` is still honoured (promoted to `synthpath` with a deprecation warning). If the primary synth fails to initialise (missing ROMs etc.) the system falls back to OPL, then silently disables music.

## Test plan

- [x] Intro cutscene music plays continuously through panorama scrolling (was pausing during scroll-heavy frames)
- [x] Music loops gaplessly at end of track
- [x] Title screen (CS011) CRNG flame effect still works
- [x] Escape from intro cutscene stops music and returns to main menu with intro theme playing
- [ ] Theme changes on world transition
- [ ] Combat music triggers / restores correctly
- [x] Rapid ChangeTheme calls don't crash (thread safety)
- [x] Clean shutdown (producer thread joins within 500ms, no hang)
- [x] Soundfont fallback works out of the box (no ROMs, no special setup)
- [x] mt32emu CM-32L works with user-supplied ROMs (MAME-style and standard filenames)
- [x] OPL works via AdlMidi real-time API
- [x] Backward-compat: legacy `rompath` setting still works with deprecation warning

## Notes

- The `AudioStreamGenerator` buffer is 0.1s. With the dedicated producer thread, underruns are architecturally prevented (no more main-thread dependence).
- The `Generate` Span-based overload in AdlMidi.NET's real-time API is what we use; this required the `#if false` guard around `adl_rt_*` methods to be removed (upstream PR [csinkers/AdlMidi.NET#2](https://github.com/csinkers/AdlMidi.NET/pull/2)).
- `XmiPlayer.Load` calls `_synth.Reset()` to silence any notes still ringing from the previous track — otherwise the final note of the title screen bled into the intro.
- `ISynthEngine.Reset()` across the three backends uses a deliberate panic-cut ordering: All Sound Off (CC 120) → All Notes Off (CC 123) → Reset All Controllers (CC 121). The MeltySynth path orders this correctly per the commit `8f773e7`.
