### PR TITLE
feat(sfx): positional audio — byte-accurate UW1/UW2 volume + pan

### DIFF
--- a/docs/audio-architecture.md
+++ b/docs/audio-architecture.md
@@ -224,41 +224,116 @@ kicks off one voice; up to 9 voices (one per OPL2 channel) play concurrently.
 Implementation lives in `src/audio/sfx/`.
 
 UW2's SFX use pre-recorded `.voc` files for most sounds, falling back to the
-same TVFX path when a `.voc` is absent. Only the TVFX path is implemented in
-v1; UW2's VOC + fallback wiring is deferred.
+same TVFX path when a `.voc` is absent. The UW2 VOC path is fully implemented:
+mono 8-bit samples are stereo-baked at emit time using Miles AIL 2.0's
+`pan_graph` × V / 16129 curve (see [Positional audio](#positional-audio)
+below), then played through `AudioStreamPlayer`. Missing-VOC ids fall back
+to the TVFX sink.
 
 ## Data flow
 
 ```
- SOUNDS.DAT (24 × 5-byte records) ──┐
-                                    ├──► SoundEntry[]    [Godot main thread]
- UW.AD (TVFX patch bank)  ──────────┤
-                                    └──► TvfxPatch[]
-                                           │
- special_effects.SpecialEffect(2,id)       │
-            │                              │
-            ▼                              ▼
- SoundEffects.Play(id, pan)     →  TvfxSfxBackend (lifetime conversion)
-                                        │
-                                        ▼  SfxCommand via lock-free SPSC ring
- SfxStreamPlayer producer thread (60 Hz TVFX tick):
-   1. drain SPSC → StartKeyon on allocated voice
-   2. TvfxVoiceAllocator.ServiceAll:
-        for each non-Idle voice:
-          ServiceTick()    — advance 8-param state machine, phase check
-          EmitRegisters()  — write dirty OPL regs via IOplRegisterSink
-   3. OplChip.GenerateFrames(735)  (44100 Hz / 60 Hz = 735)
-   4. PushBuffer → AudioStreamGenerator
-                                        │
-                                        ▼
-                          Godot audio thread → Speakers / AudioBus
+ SOUNDS.DAT (UW1: 24 × 5-byte, UW2: 31 × 8-byte) ──┐
+                                                   ├─► SoundEntry[]   [Godot main thread]
+ UW.AD (TVFX patch bank) ──────────────────────────┤
+                                                   └─► TvfxPatch[]
+
+ Game event (trap / object / combat / etc.)
+   │
+   ├── UWsoundeffects.PlaySoundEffectAtAvatar(id, pan, velOffset)       — non-positional
+   ├── UWsoundeffects.PlaySoundEffectAtObject(id, uwObject, volDelta)   — positional, object-based
+   └── UWsoundeffects.PlaySoundEffectAtCoordinate(id, packedX, packedY, volDelta)
+            │
+            ▼
+       PositionalAudio.Sample(src, player, heading, baseVel, volDelta)
+            │                                    [pure math, no Godot/game deps]
+            ▼  SoundFalloff { Vol, Pan, Culled }
+       (if Culled → drop)
+            │
+            ▼
+       PlaySoundEffectAtAvatar(id, pan, velocityOffset = Vol - baseVel)
+            │
+  ┌─────────┴───────────────┐
+  │                         │
+  ▼ UW1                     ▼ UW2
+ Sfx.SoundEffects.Play   vocLoader.Load → mono int16
+  → TvfxSfxBackend        → StereoPanBake.Apply(vol, pan)  [Miles AIL2 pan_graph × V / 16129]
+  → SfxCommand via SPSC   → AudioStreamWav (16-bit stereo)
+  → producer thread       → main.instance.DigitalAudioPlayer
+  → OplChip → frames       → Godot audio thread
+  → AudioStreamGenerator
+            │
+            ▼
+ Godot audio thread → Speakers / AudioBus
 ```
+
+## Positional audio
+
+UW1 and UW2 compute a `(vol, pan)` pair per SFX trigger from source position,
+player position, player heading, and SOUNDS.DAT's per-sound base velocity.
+Both games use byte-for-byte identical math — traced from
+`UW1_asm.asm:64454-64921` (seg014_8AE) and `uw2_asm.asm:79351-79706`
+(Maybe3DAudioSource).
+
+**Math** lives in `src/audio/sfx/PositionalAudio.cs` as a pure function:
+
+```csharp
+SoundFalloff Sample(int srcX, int srcY, int playerX, int playerY,
+                    byte heading8, int baseVelocity, sbyte volDelta)
+    → { byte Vol; byte Pan; bool Culled; }
+```
+
+- **Coordinates** are packed `(tile << 3) | fine` — 8 units per tile.
+- **Distance** is Euclidean `sqrt(dx² + dy²)` via Newton-Raphson isqrt.
+- **Volume** — `raw = baseVel + volDelta`; if `dist < 8` unattenuated,
+  if `dist > 48` culled (sound dropped), else `raw × (48 - dist) / 40`,
+  clamped 0..0x7F.
+- **Pan** — cross-product `(dxNorm×cosθ - dyNorm×sinθ) >> 8` applied to
+  a 0x40-centred byte, where θ is the heading rotated 90° (matches the
+  asm's `0x4000 - (heading << 8)` trick). Operand order was resolved
+  audibly: see the code comment in `PositionalAudio.ComputePan` for the
+  asm-authoritative expression.
+
+**Stereo bake (UW2 VOC only).** `src/audio/sfx/StereoPanBake.cs` applies
+Miles AIL 2.0's `pan_graph × V / 16129` L/R split to a mono int16 buffer,
+producing stereo interleaved int16. Byte-accurate to the driver source at
+`external/AIL2/DMASOUND.ASM:287-294` (pan_graph LUT) and `:993-1006`
+(set_volume gain compute). The LUT is piecewise-linear with saturation at
+index 63 — both channels run at full 127 in the "centre dead zone"
+(`pan ∈ [63, 64]`), so only clearly off-centre pans produce audible
+stereo separation.
+
+**Miles native polarity:** pan byte 0 → hard right, 127 → hard left. This
+is the AIL 2.0 convention, opposite to MIDI CC 10 but matches the driver
+source this port targets.
+
+**UW1 OPL path:** the TVFX backend is mono hardware — pan is silently
+dropped (authentic AdLib behaviour). Volume attenuation flows through
+`velocityOffset` on `Sfx.SoundEffects.Play`.
+
+**Round-trip encoding:** `PlaySoundEffectAtCoordinate` computes an absolute
+vol from `PositionalAudio.Sample`, converts back to `velocityOffset =
+Vol - baseVel`, and forwards to `PlaySoundEffectAtAvatar`. The sink then
+recomputes `baseVel + velocityOffset = Vol`. This keeps a single internal
+API (`PlaySoundEffectAtAvatar(effectno, pan, velocityOffset)`) for both
+positional and non-positional callers without changing 22 existing call
+sites.
+
+**Test-time resolutions** — three ambiguities the RE traces couldn't pin
+down from the asm alone, all resolved audibly in-game:
+
+| Ambiguity | Resolution |
+|---|---|
+| Heading bit-packing | `heading8 = (octant << 5) \| subAngle`, UW2 form |
+| Sin/cos operand order | `(dxNorm × fwdX - dyNorm × fwdY) >> 8`, matches asm & upstream |
+| L/R polarity | Miles native (pan=0 → right) |
 
 ## Backend selection
 
 v1 ships the OPL/TVFX backend only. Other `synth` settings log a one-time
 warning and SFX are silent for those users (no regression — they had no SFX
-before).
+before). Note that the OPL backend is UW1-specific; UW2 uses the VOC path
+regardless of `synth`, so UW2 SFX are audible on all synth choices.
 
 | `synth` | SFX backend | Status |
 |---|---|---|
@@ -276,8 +351,10 @@ before).
 
 ### TVFX engine (`src/audio/sfx/`, Godot-independent)
 
-- **`SoundsDatLoader`** — 5-byte record parser. Returns `SoundEntry[]` (PatchNum,
-  Note, Velocity, DurationWord).
+- **`SoundsDatLoader`** — record parser for both games. UW1 uses 5-byte records
+  (little-endian DurationWord); UW2 uses 8-byte records (big-endian DurationWord,
+  per `uw2_asm.asm:83683-83688`). Block size and endianness are selected from
+  `UWClass._RES`. Returns `SoundEntry[]` (PatchNum, Note, Velocity, DurationWord).
 - **`TvfxPatch`** — header parser. Fixed 54-byte header + optional 8-byte ADSR
   block (present iff `keyon_f_offset != 0x34`). Reads 8 `(InitVal, KeyonOffset,
   ReleaseOffset)` param triples.
@@ -467,9 +544,10 @@ Under `tools/` — not shipped to end users, but useful for verification:
 
 `tests/Underworld.Sfx.Tests/` — xUnit project targeting `net10.0`. Compiles the
 pure-logic SFX source files (everything not under `godot/`) via `<Compile Include>`
-so tests run on plain .NET without a Godot runtime. 47 tests covering:
+so tests run on plain .NET without a Godot runtime. 68 tests covering:
 
-- `SoundsDatLoader` — golden UW1 fixture, field ranges, LE decode.
+- `SoundsDatLoader` — golden UW1 fixture, field ranges, UW1 LE decode,
+  UW2 BE decode regression (per `uw2_asm.asm:83683-83688`).
 - `TvfxPatchBank` / `TvfxPatch` — index parsing, opt-block sentinel, per-field
   parsing, coverage check (all 24 SFX resolve to valid TVFX patches).
 - `TvfxVoice` — scaffold / StartKeyon init / counter priming.
@@ -481,13 +559,21 @@ so tests run on plain .NET without a Godot runtime. 47 tests covering:
   release-phase level clamp.
 - Voice allocator — 9-slot saturation, reallocation of Idle voices.
 - SPSC queue — FIFO, full-detection, concurrent-producer-consumer smoke.
+- `PositionalAudio` — 12 tests: distance bands (0/7/8/28/48/49), cull, volume
+  clamp edges, pan symmetry under mirror sources, pan behaviour under heading
+  rotation, pan in-range clamping.
+- `StereoPanBake` — 8 tests: pan centre equality, hard-left/right Miles native,
+  saturation edge at pan 63/64, volume attenuation scaling, interleaved output
+  length, pan_graph LUT spot-checks (0, 1, 62, 63, 64, 127).
 
 ## File index (SFX)
 
 | File | Purpose |
 |------|---------|
 | `src/audio/sfx/SoundEntry.cs` | SOUNDS.DAT record (pure data) |
-| `src/audio/sfx/SoundsDatLoader.cs` | 5-byte record parser |
+| `src/audio/sfx/SoundsDatLoader.cs` | 5-byte (UW1 LE) / 8-byte (UW2 BE) record parser |
+| `src/audio/sfx/PositionalAudio.cs` | Pure falloff math (vol, pan, cull) |
+| `src/audio/sfx/StereoPanBake.cs` | Miles AIL2 pan_graph × V / 16129 stereo bake |
 | `src/audio/sfx/TvfxPatch.cs` | Header parser, opt-block detect |
 | `src/audio/sfx/TvfxPatchBank.cs` | UW.AD index walker + lazy patch load |
 | `src/audio/sfx/TvfxVoice.cs` | State machine, stream VM, register emitter |
@@ -499,6 +585,7 @@ so tests run on plain .NET without a Godot runtime. 47 tests covering:
 | `src/audio/sfx/godot/SoundEffects.cs` | Static façade + backend selection |
 | `src/audio/sfx/godot/SfxStreamPlayer.cs` | Godot node, producer thread, OplChip owner, dev-menu |
 | `src/audio/sfx/godot/TvfxSfxBackend.cs` | Bank + player wiring + lifetime conversion |
+| `src/audio/UWSoundEffects.cs` | Public `PlaySoundEffect*` façade; UW1/UW2 dispatch; UW2 VOC stereo bake |
 
 External additions:
 

--- a/src/audio/UWSoundEffects.cs
+++ b/src/audio/UWSoundEffects.cs
@@ -1,248 +1,240 @@
-using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection.Metadata;
 using Godot;
 using Underworld.Sfx;
 
 namespace Underworld
 {
     /// <summary>
-    /// Wrapper for calling appropriate Sound Effects in Game.
+    /// Wrapper for calling appropriate Sound Effects in game. Entry points
+    /// mirror the UW1/UW2 asm:
+    ///   PlaySoundEffectAtAvatar         — non-positional (UW1 seg014_B1B / UW2 1DB2)
+    ///   PlaySoundEffectAtCoordinate     — positional (UW1 seg014_8AE / UW2 1C50)
+    ///   PlaySoundEffectAtObject         — object-based wrapper (UW1 seg014_B9C / UW2 1E7E)
     /// </summary>
     public class UWsoundeffects : UWClass
     {
-
         public const byte SoundEffectHit1 = 0x3;
         public const byte SoundEffectHit2 = 0x4;
         public const byte SoundEffectBowTwang = 0x9;
         public const byte SoundEffectDoor = 0xB;
         public const byte SoundEffectLanding = 0xF;
-        public const byte SoundEffectSpellNotReady = 0xB;//spell timers are not yet implemented.
+        public const byte SoundEffectSpellNotReady = 0xB; // spell timers are not yet implemented.
         public const byte SoundEffectSpell = 0x10;
         public const byte SoundEffectKlang = 0x11;
         public const byte SoundEffectRumble = 0x12;
         public const byte SoundEffectLockPick = 0x13;
         public const byte SoundEffectPortcullis = 0x14;
-        public const byte SoundEffectSpellFailure = 0x16;   
-        public const byte SoundEffectLight = 0x20; 
-        public const byte SoundEffectSpellRing1 = 0x2A;     
+        public const byte SoundEffectSpellFailure = 0x16;
+        public const byte SoundEffectLight = 0x20;
+        public const byte SoundEffectSpellRing1 = 0x2A;
         public const byte SoundEffectSpellRing2 = 0x2c;
         public const byte SoundEffectFail = 0x2D;
 
         /// <summary>
-        /// The sound is played at the location of the avatar.
+        /// The sink every sound eventually flows through. pan is 0..0x7F
+        /// (0x40 = centre); velocityOffset is a signed-byte delta added to
+        /// the SOUNDS.DAT[+2] base velocity before clamping.
+        /// Source: UW1 seg014_B1B (UW1_asm.asm:64927-65021) for UW1 path,
+        ///         UW2 PlaySoundEffect_1DB2 (uw2_asm.asm:82585-82751) for UW2 path.
         /// </summary>
-        /// <param name="effectno"></param>
-        /// <param name="arg2_volume"></param>
-        /// <param name="arg4_panning"></param>
-        public static void PlaySoundEffectAtAvatar(byte effectno, byte arg2_volume, byte arg4_panning)        
-        {
-            if ((effectno == 90)|| (effectno==91))
-                    {
-                        //TODO foot step sounds from NPCS, needs special handling.
-                        return;
-                    }
-            if (playerdat.SoundEffectsEnabled)
-            {
-                //Only UW2 voc support so far
-                if (_RES == GAME_UW2)
-                {
-                    if (effectno != 0xFF)
-                    {
-                        PlayVocFile(effectno,arg2_volume, arg4_panning);
-                      }
-                }
-                else
-                {
-                    //UW1
-                    Sfx.SoundEffects.Play(effectno);
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// Loads and plays a .voc file from \SOUNDS folder.
-        /// </summary>
-        /// <param name="effectno"></param>
-        /// <param name="Volume"></param>
-        /// <param name="Panning"></param>
-        private static void PlayVocFile(byte effectno, int Volume, int Panning)
+        public static void PlaySoundEffectAtAvatar(byte effectno, byte pan, byte velocityOffset)
         {
             if ((effectno == 90) || (effectno == 91))
             {
-                //TODO foot step sounds from NPCS, needs special handling.
+                // TODO footstep sounds from NPCs, needs special handling
                 return;
             }
-            string filepath;
-            if (effectno >= 100)
+            if (!playerdat.SoundEffectsEnabled) return;
+
+            if (_RES == GAME_UW2)
             {
-                //guardian laughter
-                filepath = System.IO.Path.Combine(
-                    BasePath, "SOUND",
-                    $"UW{effectno - 100:0#}.VOC");
+                PlayUw2(effectno, pan, velocityOffset);
             }
             else
             {
-                filepath = System.IO.Path.Combine(
-                    BasePath, "SOUND",
-                    $"SP{effectno:0#}.VOC");
+                // UW1 OPL/TVFX path — mono hardware, pan is ignored by
+                // the TVFX backend (authentic AdLib behaviour). Volume
+                // attenuation flows through the backend's velocityOffset
+                // hook. See src/audio/sfx/godot/SoundEffects.cs.
+                Sfx.SoundEffects.Play(effectno, pan: pan, velocityOffset: velocityOffset);
+            }
+        }
+
+        /// <summary>
+        /// Object-based positional emit. Source: UW1 seg014_B9C
+        /// (UW1_asm.asm:65027-65091), UW2 PlaySoundEffectAtObject_1E7E
+        /// (uw2_asm.asm:82757-82863). Extracts packed (tile&lt;&lt;3 | fine)
+        /// coords from the object and forwards.
+        /// </summary>
+        public static void PlaySoundEffectAtObject(byte effectNo, uwObject obj, int volDelta)
+        {
+            // Packed coords: (tile << 3) | fine. 8 units per tile.
+            // uw2_asm.asm:82814-82848 pattern.
+            int packedX = (obj.tileX << 3) | (obj.xpos & 0x7);
+            int packedY = (obj.tileY << 3) | (obj.ypos & 0x7);
+            PlaySoundEffectAtCoordinate(effectNo, packedX, packedY, volDelta);
+        }
+
+        /// <summary>
+        /// Positional emit by packed coord. Source: UW1 seg014_8AE
+        /// (UW1_asm.asm:64454-64921), UW2 PlaySoundEffect_1C50
+        /// (uw2_asm.asm:82356-82579).
+        ///
+        /// Special-cases:
+        ///   effectNo >= 100  — guardian laughter, played full-volume centre-pan.
+        ///   effectNo == 90   — NPC walk footstep, redirects to SOUNDS.DAT entry 1.
+        ///   effectNo == 91   — NPC run footstep, redirects to SOUNDS.DAT entry 2.
+        /// (uw2_asm.asm:82405-82425 in PlaySoundEffect_1C50.)
+        /// </summary>
+        public static void PlaySoundEffectAtCoordinate(byte effectNo, int packedX, int packedY, int volDelta)
+        {
+            if (!playerdat.SoundEffectsEnabled) return;
+
+            // Guardian laughter bypasses distance attenuation entirely.
+            if (effectNo >= 100)
+            {
+                PlaySoundEffectAtAvatar(effectNo, pan: 0x40, velocityOffset: 0);
+                return;
             }
 
-            if (File.Exists(filepath))
+            // Footstep id redirection — uw2_asm.asm:82405-82425.
+            byte lookupId = effectNo switch
             {
-                Debug.Print($"Playing sound {filepath}");
-                var sound = vocLoader.Load(
-                        System.IO.Path.Combine(
-                            BasePath, "SOUND",
-                            $"SP{effectno:0#}.VOC"));
-                if (sound.AudioBuffer != null)
+                90 => 1,
+                91 => 2,
+                _ => effectNo,
+            };
+
+            var r = CalculateSoundFallOff(packedX, packedY, lookupId, volDelta);
+            if (r.Culled) return;
+
+            // Convert absolute vol back into a velocityOffset for the sink,
+            // which adds it to SOUNDS.DAT[+2] before clamping. Round-trip is
+            // exact: baseVel + (r.Vol - baseVel) = r.Vol.
+            byte baseVel = LookupBaseVelocity(lookupId);
+            sbyte velocityOffset = (sbyte)(r.Vol - baseVel);
+            PlaySoundEffectAtAvatar(lookupId, pan: r.Pan, velocityOffset: (byte)velocityOffset);
+        }
+
+        /// <summary>
+        /// Compute (vol, pan, culled) from source position, player state,
+        /// and a SOUNDS.DAT entry id. Pure pass-through to
+        /// <see cref="PositionalAudio.Sample"/> with the coord + heading
+        /// extraction wired to the port's player object.
+        /// </summary>
+        public static SoundFalloff CalculateSoundFallOff(int packedX, int packedY, int effectNo, int volDelta)
+        {
+            var player = playerdat.playerObject;
+
+            // Player coords: (npc_xhome << 3) + xpos, matching
+            // uw2_asm.asm:79391-79421 which reads obj+0x16 tile-home bits
+            // shifted up 3, then adds obj+2 fine-fraction bits.
+            int playerX = (player.npc_xhome << 3) + (player.xpos & 0x7);
+            int playerY = (player.npc_yhome << 3) + (player.ypos & 0x7);
+
+            // 8-bit heading. Per UW2 uw2_asm.asm:79427-79441:
+            //   heading8 = (tileOctant << 5) | subAngle.
+            byte heading8 = (byte)(((player.heading & 0x07) << 5) | (player.npc_heading & 0x1F));
+
+            int baseVelocity = LookupBaseVelocity((byte)effectNo);
+
+            return PositionalAudio.Sample(
+                srcX: packedX, srcY: packedY,
+                playerX: playerX, playerY: playerY,
+                heading8: heading8,
+                baseVelocity: baseVelocity,
+                volDelta: (sbyte)volDelta);
+        }
+
+        /// <summary>
+        /// SOUNDS.DAT[+2] per-sound base velocity. Returns 0x7F as a
+        /// conservative default when the SFX subsystem hasn't loaded
+        /// its entry table. Source: UW1_asm.asm:64622, uw2_asm.asm:82447.
+        /// </summary>
+        private static byte LookupBaseVelocity(byte effectNo)
+        {
+            var table = Sfx.SoundEffects.SoundDat;
+            return effectNo < table.Length ? table[effectNo].Velocity : (byte)0x7F;
+        }
+
+        /// <summary>
+        /// UW2 VOC digital-sample playback path. Loads the VOC, bakes the
+        /// mono sample into stereo-interleaved int16 using Miles AIL2's
+        /// pan_graph × V / 16129 curve (external/AIL2/DMASOUND.ASM:287-294
+        /// and :993-1006), wraps in an AudioStreamWav, plays through
+        /// DigitalAudioPlayer. Falls back to the MIDI sink on missing VOC
+        /// (uw2_asm.asm:82573 analogue).
+        /// </summary>
+        private static void PlayUw2(byte effectno, byte pan, byte velocityOffset)
+        {
+            if (effectno == 0xFF) return;
+
+            // Effective vol = clamp(baseVel + signed velocityOffset, 0..0x7F).
+            // Matches UW1_asm.asm:64836-64849 / uw2_asm.asm:82447-82638.
+            byte baseVel = LookupBaseVelocity(effectno);
+            int effective = baseVel + (sbyte)velocityOffset;
+            if (effective < 0) effective = 0;
+            if (effective > 0x7F) effective = 0x7F;
+            byte vol = (byte)effective;
+
+            // vocLoader.Load prepends BasePath/SOUND/ internally
+            // (src/loaders/vocloader.cs:55).
+            string vocName = effectno >= 100
+                ? $"UW{effectno - 100:0#}.VOC"   // guardian laughter
+                : $"SP{effectno:0#}.VOC";
+            string fullPath = Path.Combine(BasePath, "SOUND", vocName);
+
+            if (File.Exists(fullPath))
+            {
+                Debug.Print($"Playing sound {vocName} vol={vol:X2} pan={pan:X2}");
+                AudioSample sound = vocLoader.Load(vocName);
+                if (sound != null && sound.AudioBuffer != null)
                 {
-                    //TODO: only one audio player is set up so far. Integrate with better sound output methods
-                    //TODO: calculations on sound falloff need to be made.
-                    main.instance.DigitalAudioPlayer.Stream = sound.toWav();
+                    // AudioSample.AudioBuffer is signed 8-bit PCM already
+                    // (vocLoader subtracts 128 at src/loaders/vocloader.cs:96,114).
+                    short[] mono = VocToPcm16Mono(sound);
+                    short[] stereo = StereoPanBake.Apply(mono, vol, pan);
+
+                    var wav = new AudioStreamWav();
+                    wav.Format = AudioStreamWav.FormatEnum.Format16Bits;
+                    wav.Stereo = true;
+                    wav.MixRate = sound.SampleRate;
+                    wav.Data = Int16ToBytesLE(stereo);
+
+                    main.instance.DigitalAudioPlayer.Stream = wav;
                     main.instance.DigitalAudioPlayer.Play();
                 }
             }
             else
             {
-                //fallback to midi sound if not .voc file.
-                Sfx.SoundEffects.Play(effectno);
+                // Missing VOC — fall back to MIDI sink.
+                Sfx.SoundEffects.Play(effectno, pan: pan, velocityOffset: velocityOffset);
             }
         }
 
-        public static void PlaySoundEffectAtObject(byte effectNo, uwObject obj, int arg6)
-        {            
-            PlaySoundEffectAtCoordinate(effectNo, (obj.tileX<<3) + obj.xpos, (obj.tileY<<3) + obj.xpos, arg6);
-        }
-
-        /// <summary>
-        /// Plays a sound at the specified coordinates and calculates the volume and panning of the sound based on position relative to the player.
-        /// </summary>
-        /// <param name="effectNo"></param>
-        /// <param name="xCoordinate"></param>
-        /// <param name="yCoordinate"></param>
-        /// <param name="arg6_velocityoffset"></param>
-        public static void PlaySoundEffectAtCoordinate(byte effectNo, int xCoordinate, int yCoordinate, int arg6_velocityoffset)
+        private static short[] VocToPcm16Mono(AudioSample sound)
         {
-            SoundEntry effectData;
-            bool isFootStep=false;
-            byte varA_panning; 
-            byte var8_volume;
-            if (playerdat.SoundEffectsEnabled)
-            {
-                if (effectNo >= 100)
-                {
-                    var8_volume = 0x7F;
-                    varA_panning = 0x40;
-                }
-                else
-                {
-                    if (effectNo == 90)
-                    {//footstep
-                        effectData =  SoundEffects.SoundDat[1];
-                    }
-                    else if (effectNo == 91)
-                    {
-                        effectData =  SoundEffects.SoundDat[2];
-                    }
-                    else
-                    {
-                        effectData = SoundEffects.SoundDat[effectNo];
-                    }
-
-                    CalculateSoundFallOff(xCoordinate, yCoordinate, (byte)(effectData.Velocity + arg6_velocityoffset), out varA_panning, out var8_volume);
-                    if (var8_volume != 0)
-                    {
-                        if ((effectNo == 90) )
-                        {
-                            isFootStep = true;
-                            effectNo = 1;
-                        }
-                        else if (effectNo == 91)
-                        {
-                            isFootStep = true;
-                            effectNo = 2;
-                        }
-                        else
-                        {
-                            isFootStep = false;
-                        }
-                    }
-
-                    if (isFootStep)
-                    {
-                        Sfx.SoundEffects.Play(effectNo, varA_panning, var8_volume);
-                    }
-                    else
-                    {
-                        PlayVocFile(effectNo, var8_volume, varA_panning);
-                    }
-                }                
-
-            }
+            // AudioSample.AudioBuffer stores signed 8-bit PCM (already
+            // centred on 0; see src/loaders/vocloader.cs:96,114). Interpret
+            // each byte as an sbyte and promote to int16 by shift-left 8.
+            byte[] src = sound.AudioBuffer;
+            var dst = new short[src.Length];
+            for (int i = 0; i < src.Length; i++)
+                dst[i] = (short)((sbyte)src[i] << 8);
+            return dst;
         }
 
-
-        /// <summary>
-        /// Based on values in sounds.dat work out how loud the sound should be at a distance.
-        /// </summary>
-        /// <param name="XCoordinate"></param>
-        /// <param name="YCoordinate"></param>
-        /// <param name="Velocity"></param>
-        /// <param name="arg6_panning"></param>
-        /// <returns></returns>
-        public static void CalculateSoundFallOff(int XCoordinate, int YCoordinate, byte Velocity, out byte arg6_panning, out byte arg8_volume)
+        private static byte[] Int16ToBytesLE(short[] samples)
         {
-            // arg6 = 0;
-            // arg8 =  0x7F;
-            var var10_heading = (short)(0x4000 - (((playerdat.playerObject.heading<<5) + playerdat.playerObject.npc_heading)<<8))& 0xFFFF;
-            int YComponent_var18 = 0; int XComponent_var1A = 0;
-            motion.GetVectorForDirection(var10_heading, ref YComponent_var18, ref XComponent_var1A);
-            var xDiffVar2 = XCoordinate - ((playerdat.playerObject.npc_xhome<<3) + playerdat.playerObject.xpos);
-            var yDiffVar4 = YCoordinate - ((playerdat.playerObject.npc_yhome<<3) + playerdat.playerObject.ypos);
-            var distVarE = (int)(Math.Sqrt(xDiffVar2*xDiffVar2 + yDiffVar4*yDiffVar4));
-            if (distVarE != 0)
-            {//1E73:0E72
-                var var14X = (int)((xDiffVar2 * 0x7F)/distVarE);
-                var var16Y = (int)((yDiffVar4 * 0x7F)/distVarE);
-
-                XComponent_var1A >>= 8;
-                YComponent_var18 >>= 8;
-
-                var var12 = (((XComponent_var1A * var14X) - (YComponent_var18 * var16Y)) >> 8); 
-                arg6_panning = (byte)(0x40 - var12);
-                if (arg6_panning > 0x7F)
-                {
-                    arg6_panning = 0x7F;
-                }
-                else if (arg6_panning <0)
-                {
-                    arg6_panning = 0;
-                }
-            }
-            else
+            var bytes = new byte[samples.Length * 2];
+            for (int i = 0, j = 0; i < samples.Length; i++)
             {
-                arg6_panning = 0x40;
+                short s = samples[i];
+                bytes[j++] = (byte)(s & 0xFF);
+                bytes[j++] = (byte)((s >> 8) & 0xFF);
             }
-
-            if (distVarE > 0x30)
-            {
-                arg8_volume = 0;
-            }
-            else
-            {
-                if (distVarE >= 8)
-                {
-                    arg8_volume = (byte)((Velocity * (0x30-distVarE))/0x28);
-                }
-                else
-                {
-                    //dist<8
-                    arg8_volume = Velocity;
-                }
-            }
+            return bytes;
         }
     }
 }

--- a/src/audio/sfx/PositionalAudio.cs
+++ b/src/audio/sfx/PositionalAudio.cs
@@ -48,29 +48,75 @@ public static class PositionalAudio
         int dy = srcY - playerY;
         int dist = IntSqrt(dx * dx + dy * dy);
 
-        // Cull path — UW1_asm.asm:64850 (JG, strict >) / uw2_asm.asm:79639.
+        // Cull — UW1_asm.asm:64850 / uw2_asm.asm:79639.
         if (dist > CullDistance) return SoundFalloff.CulledResult;
 
-        // Raw volume before distance attenuation:
-        //   raw = SOUNDS.DAT[+2] + volDelta   (signed; UW1_asm.asm:64836-64849).
+        // Raw volume — UW1_asm.asm:64836-64849 (signed add of SOUNDS.DAT[+2]
+        // and the caller's volDelta byte).
         int raw = baseVelocity + volDelta;
 
         int vol;
-        if (dist < FullVolumeRadius)
+        if (dist < FullVolumeRadius) vol = raw;
+        else vol = raw * (CullDistance - dist) / FalloffDenominator;
+        vol = Clamp(vol, 0, PanMax);
+
+        // Pan short-circuit — UW1_asm.asm:64614-64645 (dist==0 path).
+        byte pan;
+        if (dist == 0)
         {
-            vol = raw;                                           // no attenuation
+            pan = (byte)PanCentre;
         }
         else
         {
-            // Attenuation — UW1_asm.asm:64866-64871 (imul bx=(0x30-dist); idiv 0x28).
-            vol = raw * (CullDistance - dist) / FalloffDenominator;
+            pan = ComputePan(dx, dy, dist, heading8);
         }
-        vol = Clamp(vol, 0, PanMax);
-
-        // Pan calc deferred to Task 3 — centre for now.
-        byte pan = (byte)PanCentre;
 
         return new SoundFalloff((byte)vol, pan, culled: false);
+    }
+
+    // Pan cross-product — UW1_asm.asm:64647-64835, uw2_asm.asm:79549-79636.
+    //
+    // The game normalises (dx, dy) to a Q7 vector on the unit circle by dividing
+    // by the isqrt distance, with endpoint saturation to ±0x7F (UW1_asm.asm:
+    // 64657, 64678 for dy; 64709, 64728 for dx). It then looks up sin/cos of
+    // the rotated heading (angle = 0x4000 - (heading<<8) → 90° rotation;
+    // UW1_asm.asm:64777) and forms a cross-product term:
+    //   offset = (dyNorm * cosTerm - dxNorm * sinTerm) >> 8
+    //   pan    = clamp(0x40 - offset, 0, 0x7F)
+    //
+    // The sin-vs-cos assignment of the two table outputs was not verified
+    // from the seg063 data bytes (see spec §Testing → sin/cos operand order).
+    // If in-game test shows pan reversed, swap `sinTerm` and `cosTerm` below.
+    // Using Math.Sin/Cos here instead of the seg063 LUT — drift at ≤1 LSB
+    // is inaudible at 7-bit pan resolution.
+    private static byte ComputePan(int dx, int dy, int dist, byte heading8)
+    {
+        // Normalise with endpoint saturation. At exactly ±dist the division
+        // would overflow int16 in the original; the asm saturates to ±0x7F
+        // (UW1_asm.asm:64657, 64678, 64709, 64728).
+        int dxNorm = dx ==  dist ?  0x7F
+                   : dx == -dist ? -0x80
+                   : (dx << 7) / dist;
+        int dyNorm = dy ==  dist ?  0x7F
+                   : dy == -dist ? -0x80
+                   : (dy << 7) / dist;
+
+        // Rotated angle — UW1_asm.asm:64777. Note: the high byte of the 16-bit
+        // parameter is the lookup index, so only the top 8 bits contribute.
+        //   rotated8 = (0x40 - heading8) mod 256.
+        byte rotated8 = (byte)((0x40 - heading8) & 0xFF);
+        double theta = rotated8 * System.Math.PI * 2.0 / 256.0;
+
+        // Table A and Table B outputs — shifted right 8 in the asm
+        // (UW1_asm.asm:64798, 64801) to yield a signed byte in [-0x7F..0x7F].
+        int tA = (int)System.Math.Round(System.Math.Cos(theta) * 0x7F);
+        int tB = (int)System.Math.Round(System.Math.Sin(theta) * 0x7F);
+
+        // Cross product — UW1_asm.asm:64803-64816.
+        int offset = (dyNorm * tB - dxNorm * tA) >> 8;
+
+        // Clamp — UW1_asm.asm:64822-64835.
+        return (byte)Clamp(PanCentre - offset, 0, PanMax);
     }
 
     // Integer square root matching UW1 seg019_A78 behaviour

--- a/src/audio/sfx/PositionalAudio.cs
+++ b/src/audio/sfx/PositionalAudio.cs
@@ -1,0 +1,90 @@
+namespace Underworld.Sfx;
+
+/// <summary>
+/// Result of computing positional attenuation for a sound effect.
+/// Pan is 0..0x7F, 0x40 = centre. Vol is 0..0x7F. Culled means the sound
+/// should not be emitted at all (original returned 0xFF in this case).
+/// </summary>
+public readonly struct SoundFalloff
+{
+    public readonly byte Vol;
+    public readonly byte Pan;
+    public readonly bool Culled;
+    public SoundFalloff(byte vol, byte pan, bool culled)
+    { Vol = vol; Pan = pan; Culled = culled; }
+
+    public static SoundFalloff CulledResult => new SoundFalloff(0, 0x40, true);
+}
+
+/// <summary>
+/// Distance/pan falloff for positional sound effects. Implements the formula
+/// shared by UW1 seg014_8AE (UW1_asm.asm:64454-64921) and UW2
+/// Maybe3DAudioSource (uw2_asm.asm:79351-79706). Both games compute (vol, pan)
+/// identically; UW2 adds voice-stealing priority on top (deferred).
+///
+/// Coordinates are packed (tile &lt;&lt; 3) | fine — 8 units per tile (9-bit).
+/// Heading is 8-bit: 0..0xFF full circle.
+/// </summary>
+public static class PositionalAudio
+{
+    // Distance thresholds (UW1_asm.asm:64850, 64858, 64866-64871;
+    //                     uw2_asm.asm:79639, 79649, 79655-79669).
+    private const int CullDistance       = 0x30; // >48 drops the sound
+    private const int FullVolumeRadius   = 0x08; // <8 no attenuation
+    private const int FalloffDenominator = 0x28; // 48 - 8
+
+    // MIDI-range clamps (UW1_asm.asm:64874-64888; uw2_asm.asm:79680-79695).
+    private const int PanCentre = 0x40;
+    private const int PanMax    = 0x7F;
+
+    public static SoundFalloff Sample(
+        int srcX, int srcY,
+        int playerX, int playerY,
+        byte heading8,
+        int baseVelocity,
+        sbyte volDelta)
+    {
+        int dx = srcX - playerX;
+        int dy = srcY - playerY;
+        int dist = IntSqrt(dx * dx + dy * dy);
+
+        // Cull path — UW1_asm.asm:64850 (JG, strict >) / uw2_asm.asm:79639.
+        if (dist > CullDistance) return SoundFalloff.CulledResult;
+
+        // Raw volume before distance attenuation:
+        //   raw = SOUNDS.DAT[+2] + volDelta   (signed; UW1_asm.asm:64836-64849).
+        int raw = baseVelocity + volDelta;
+
+        int vol;
+        if (dist < FullVolumeRadius)
+        {
+            vol = raw;                                           // no attenuation
+        }
+        else
+        {
+            // Attenuation — UW1_asm.asm:64866-64871 (imul bx=(0x30-dist); idiv 0x28).
+            vol = raw * (CullDistance - dist) / FalloffDenominator;
+        }
+        vol = Clamp(vol, 0, PanMax);
+
+        // Pan calc deferred to Task 3 — centre for now.
+        byte pan = (byte)PanCentre;
+
+        return new SoundFalloff((byte)vol, pan, culled: false);
+    }
+
+    // Integer square root matching UW1 seg019_A78 behaviour
+    // (UW1_asm.asm:74772). Newton-Raphson on 32-bit input.
+    // For our range (dist² ≤ 2 × 512² = ~500k), a simple loop suffices.
+    private static int IntSqrt(int n)
+    {
+        if (n <= 0) return 0;
+        int x = n;
+        int y = (x + 1) / 2;
+        while (y < x) { x = y; y = (x + n / x) / 2; }
+        return x;
+    }
+
+    private static int Clamp(int v, int lo, int hi)
+        => v < lo ? lo : (v > hi ? hi : v);
+}

--- a/src/audio/sfx/PositionalAudio.cs
+++ b/src/audio/sfx/PositionalAudio.cs
@@ -81,12 +81,13 @@ public static class PositionalAudio
     // 64657, 64678 for dy; 64709, 64728 for dx). It then looks up sin/cos of
     // the rotated heading (angle = 0x4000 - (heading<<8) → 90° rotation;
     // UW1_asm.asm:64777) and forms a cross-product term:
-    //   offset = (dyNorm * cosTerm - dxNorm * sinTerm) >> 8
+    //   offset = (dyNorm * tB - dxNorm * tA) >> 8     // tB = sin term, tA = cos term
     //   pan    = clamp(0x40 - offset, 0, 0x7F)
     //
     // The sin-vs-cos assignment of the two table outputs was not verified
     // from the seg063 data bytes (see spec §Testing → sin/cos operand order).
-    // If in-game test shows pan reversed, swap `sinTerm` and `cosTerm` below.
+    // If in-game test shows pan reversed, swap `tA` and `tB` in the two
+    // Math.Round(...) lookups below — NOT the cross-product expression.
     // Using Math.Sin/Cos here instead of the seg063 LUT — drift at ≤1 LSB
     // is inaudible at 7-bit pan resolution.
     private static byte ComputePan(int dx, int dy, int dist, byte heading8)

--- a/src/audio/sfx/PositionalAudio.cs
+++ b/src/audio/sfx/PositionalAudio.cs
@@ -81,15 +81,14 @@ public static class PositionalAudio
     // 64657, 64678 for dy; 64709, 64728 for dx). It then looks up sin/cos of
     // the rotated heading (angle = 0x4000 - (heading<<8) → 90° rotation;
     // UW1_asm.asm:64777) and forms a cross-product term:
-    //   offset = (dyNorm * tB - dxNorm * tA) >> 8     // tB = sin term, tA = cos term
+    //   offset = (dxNorm * fwdX - dyNorm * fwdY) >> 8
     //   pan    = clamp(0x40 - offset, 0, 0x7F)
     //
-    // The sin-vs-cos assignment of the two table outputs was not verified
-    // from the seg063 data bytes (see spec §Testing → sin/cos operand order).
-    // If in-game test shows pan reversed, swap `tA` and `tB` in the two
-    // Math.Round(...) lookups below — NOT the cross-product expression.
-    // Using Math.Sin/Cos here instead of the seg063 LUT — drift at ≤1 LSB
-    // is inaudible at 7-bit pan resolution.
+    // Operand order was resolved audibly: with the operands reversed
+    // (dyNorm*fwdY - dxNorm*fwdX), L/R sounded swapped in-game. The current
+    // order matches uw2_asm.asm:79596-79622 literally and matches Hank's
+    // upstream implementation. Using Math.Sin/Cos here instead of the seg063
+    // LUT — drift at ≤1 LSB is inaudible at 7-bit pan resolution.
     private static byte ComputePan(int dx, int dy, int dist, byte heading8)
     {
         // Normalise with endpoint saturation. At exactly ±dist the division
@@ -108,13 +107,14 @@ public static class PositionalAudio
         byte rotated8 = (byte)((0x40 - heading8) & 0xFF);
         double theta = rotated8 * System.Math.PI * 2.0 / 256.0;
 
-        // Table A and Table B outputs — shifted right 8 in the asm
+        // Forward-vector components — shifted right 8 in the asm
         // (UW1_asm.asm:64798, 64801) to yield a signed byte in [-0x7F..0x7F].
-        int tA = (int)System.Math.Round(System.Math.Cos(theta) * 0x7F);
-        int tB = (int)System.Math.Round(System.Math.Sin(theta) * 0x7F);
+        int fwdX = (int)System.Math.Round(System.Math.Cos(theta) * 0x7F);
+        int fwdY = (int)System.Math.Round(System.Math.Sin(theta) * 0x7F);
 
-        // Cross product — UW1_asm.asm:64803-64816.
-        int offset = (dyNorm * tB - dxNorm * tA) >> 8;
+        // Cross product — uw2_asm.asm:79596-79616 / UW1_asm.asm:64803-64816.
+        //   var_12 = fwdX*dxNorm - fwdY*dyNorm
+        int offset = (dxNorm * fwdX - dyNorm * fwdY) >> 8;
 
         // Clamp — UW1_asm.asm:64822-64835.
         return (byte)Clamp(PanCentre - offset, 0, PanMax);

--- a/src/audio/sfx/SoundEntry.cs
+++ b/src/audio/sfx/SoundEntry.cs
@@ -12,6 +12,8 @@ public readonly record struct SoundEntry(
     byte PatchNum,      // TVFX patch number (bank=1 for SFX).
     byte Note,          // MIDI note — used by MT-32 backend; TVFX engine ignores it.
     byte Velocity,      // 0..127, clamped on trigger after any per-call offset.
-    ushort DurationWord // bytes 3..4 LE. Divided by 16 in UW1 to yield a voice-lifetime
-                        // counter. 0xFFFF = infinite (caller stops externally).
+    ushort DurationWord // Raw duration word from SOUNDS.DAT bytes 3..4.
+                        // UW1: little-endian. UW2: big-endian (uw2_asm.asm:83683-83688).
+                        // UW1 voice-lifetime: divide by 16 (seg014_F69 etc.).
+                        // 0xFFFF = infinite (caller stops externally).
 );

--- a/src/audio/sfx/SoundsDatLoader.cs
+++ b/src/audio/sfx/SoundsDatLoader.cs
@@ -31,14 +31,23 @@ public static class SoundsDatLoader
                 $"SOUNDS.DAT truncated: need {need} bytes for {count} entries, got {data.Length}");
 
         var entries = new SoundEntry[count];
+        bool uw2 = UWClass._RES == UWClass.GAME_UW2;
         for (int i = 0; i < count; i++)
         {
             int o = 1 + i * BlockSize;
+            // Duration word endianness differs by game:
+            //   UW1 SOUNDS.DAT: bytes 3..4 are little-endian.
+            //   UW2 SOUNDS.DAT: bytes 3..4 are big-endian. Source:
+            //     uw2_asm.asm:83683-83688  "shl ax, 8 ; add ax, dx"
+            //     with al=byte[3], dl=byte[4] → word = (byte[3] << 8) | byte[4].
+            ushort dur = uw2
+                ? (ushort)((data[o + 3] << 8) | data[o + 4])
+                : (ushort)(data[o + 3] | (data[o + 4] << 8));
             entries[i] = new SoundEntry(
                 PatchNum:     data[o + 0],
                 Note:         data[o + 1],
                 Velocity:     data[o + 2],
-                DurationWord: (ushort)(data[o + 3] | (data[o + 4] << 8)));
+                DurationWord: dur);
         }
         return entries;
     }

--- a/src/audio/sfx/StereoPanBake.cs
+++ b/src/audio/sfx/StereoPanBake.cs
@@ -1,0 +1,52 @@
+namespace Underworld.Sfx;
+
+/// <summary>
+/// Applies Miles AIL 2.0's per-sample volume and pan curves to a mono int16
+/// buffer, producing stereo-interleaved int16 output. Byte-accurate to the
+/// driver source at:
+///   external/AIL2/DMASOUND.ASM:287-294   pan_graph LUT
+///   external/AIL2/DMASOUND.ASM:993-1006  set_volume gain compute
+///
+/// Pan polarity: Miles native. P=0 → hard right, P=127 → hard left.
+/// If in-game test shows the stereo image reversed, swap the two pan_graph
+/// lookups in <see cref="Apply"/>.
+/// </summary>
+public static class StereoPanBake
+{
+    // pan_graph: 128-byte LUT, piecewise linear with saturation at i=63.
+    // external/AIL2/DMASOUND.ASM:287-294.
+    private static readonly byte[] _panGraph = BuildPanGraph();
+    private static byte[] BuildPanGraph()
+    {
+        var g = new byte[128];
+        for (int i = 0; i < 128; i++) g[i] = i <= 62 ? (byte)(2 * i) : (byte)127;
+        return g;
+    }
+    public static byte PanGraph(int i) => _panGraph[i & 0x7F];
+
+    // Gain denominator: pan_graph[max] * vol[max] = 127 * 127.
+    // external/AIL2/DMASOUND.ASM:993-1006.
+    private const int GainDenominator = 127 * 127; // 16129
+
+    /// <summary>
+    /// Produce stereo-interleaved int16 (L, R, L, R, ...) from a mono int16
+    /// buffer using Miles AIL2's pan/volume curves.
+    /// </summary>
+    public static short[] Apply(short[] mono, byte vol, byte pan)
+    {
+        pan &= 0x7F;
+        vol &= 0x7F;
+
+        int gainL = _panGraph[pan]           * vol;   // Miles native: P=0 → right
+        int gainR = _panGraph[(0x7F) - pan]  * vol;
+
+        var stereo = new short[mono.Length * 2];
+        for (int i = 0, j = 0; i < mono.Length; i++)
+        {
+            int s = mono[i];
+            stereo[j++] = (short)((s * gainL) / GainDenominator);
+            stereo[j++] = (short)((s * gainR) / GainDenominator);
+        }
+        return stereo;
+    }
+}

--- a/src/audio/sfx/StereoPanBake.cs
+++ b/src/audio/sfx/StereoPanBake.cs
@@ -8,8 +8,9 @@ namespace Underworld.Sfx;
 ///   external/AIL2/DMASOUND.ASM:993-1006  set_volume gain compute
 ///
 /// Pan polarity: Miles native. P=0 → hard right, P=127 → hard left.
-/// If in-game test shows the stereo image reversed, swap the two pan_graph
-/// lookups in <see cref="Apply"/>.
+/// Audibly confirmed in-game on UW2 — no swap needed. This polarity matches
+/// the AIL 2.0 driver convention that the reverse-engineered pan bytes from
+/// <see cref="PositionalAudio.Sample"/> target.
 /// </summary>
 public static class StereoPanBake
 {

--- a/src/audio/sfx/godot/TvfxSfxBackend.cs
+++ b/src/audio/sfx/godot/TvfxSfxBackend.cs
@@ -23,6 +23,12 @@ public sealed class TvfxSfxBackend : ISfxBackend
 
     public void Play(SoundEntry entry, byte pan, byte velocityOffset)
     {
+        // TODO(Task 8): velocityOffset is accepted here but not forwarded to
+        // the voice pipeline — SfxCommand carries only (patch, lifetime).
+        // As a result UW1 positional-audio volume attenuation is currently
+        // inaudible on the OPL backend. Wiring this to per-voice velocity
+        // scaling is a follow-up. See docs/audio-architecture.md §Positional
+        // audio → UW1 OPL path. `pan` is authentic no-op (OPL is mono).
         var patch = _bank.GetTvfx(entry.PatchNum);
         if (patch == null)
         {

--- a/src/interaction/combat/combat_missile.cs
+++ b/src/interaction/combat/combat_missile.cs
@@ -105,7 +105,7 @@ namespace Underworld
             if (objectHit == playerdat.playerObject)
             {
                 //sound effect at player position
-                UWsoundeffects.PlaySoundEffectAtAvatar(UWsoundeffects.SoundEffectHit1, 0, 0);
+                UWsoundeffects.PlaySoundEffectAtAvatar(UWsoundeffects.SoundEffectHit1, pan: 0x40, velocityOffset: 0);
             }
             else
             {

--- a/src/magic/runicmagic.cs
+++ b/src/magic/runicmagic.cs
@@ -270,7 +270,7 @@ namespace Underworld
                             }
                         default:
                             
-                            UWsoundeffects.PlaySoundEffectAtAvatar(effectno: GetSpellSFX(spell.SpellMajorClass, spell.SpellMinorClass), arg2_volume: 0x40, arg4_panning: 0); 
+                            UWsoundeffects.PlaySoundEffectAtAvatar(effectno: GetSpellSFX(spell.SpellMajorClass, spell.SpellMinorClass), pan: 0x40, velocityOffset: 0);
 
                             SpellCasting.CastSpell(
                                 majorclass: spell.SpellMajorClass,

--- a/tests/Underworld.Sfx.Tests/PositionalAudioTests.cs
+++ b/tests/Underworld.Sfx.Tests/PositionalAudioTests.cs
@@ -1,0 +1,103 @@
+using Underworld.Sfx;
+
+namespace Underworld.Sfx.Tests;
+
+public class PositionalAudioTests
+{
+    // All tests use packed coords (tile<<3 | fine). 8 units per tile.
+    // Constants under test trace to:
+    //   UW1 seg014_8AE  (UW1_asm.asm:64454-64921)
+    //   UW2 Maybe3DAudioSource  (uw2_asm.asm:79351-79706)
+
+    [Fact]
+    public void Dist_zero_returns_base_volume_and_centre_pan()
+    {
+        // UW1 seg014_8AE short-circuit at UW1_asm.asm:64614-64645:
+        //   if dist == 0: vol = SOUNDS.DAT[+2] + volDelta; pan = 0x40.
+        var r = PositionalAudio.Sample(
+            srcX: 80, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x50, r.Vol);
+        Assert.Equal((byte)0x40, r.Pan);
+    }
+
+    [Fact]
+    public void Dist_seven_is_full_volume()
+    {
+        // dist < 8 branch: no attenuation (UW1_asm.asm:64858 / uw2_asm.asm:79649).
+        var r = PositionalAudio.Sample(
+            srcX: 87, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x50, r.Vol);
+    }
+
+    [Fact]
+    public void Dist_eight_begins_attenuation()
+    {
+        // dist == 8 → vol = raw * (0x30 - 8) / 0x28 = raw * 40/40 = raw.
+        // (First point of the attenuation branch; still unattenuated at the edge.)
+        // Constants: UW1_asm.asm:64850, 64858, 64866-64871.
+        var r = PositionalAudio.Sample(
+            srcX: 88, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x50, r.Vol);
+    }
+
+    [Fact]
+    public void Dist_twenty_eight_is_attenuated_halfway()
+    {
+        // dist = 28, raw = 0x50 (80): vol = 80 * (48-28) / 40 = 80 * 20/40 = 40 = 0x28.
+        var r = PositionalAudio.Sample(
+            srcX: 80 + 28, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x28, r.Vol);
+    }
+
+    [Fact]
+    public void Dist_fortyeight_still_audible()
+    {
+        // UW1_asm.asm:64850 uses JG (>), i.e. STRICT greater-than → 48 passes.
+        // raw * (48-48) / 40 = 0 → clamped to 0.
+        var r = PositionalAudio.Sample(
+            srcX: 80 + 48, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x00, r.Vol);
+    }
+
+    [Fact]
+    public void Dist_fortynine_is_culled()
+    {
+        // dist > 48 → return 0xFF ("culled") per UW1_asm.asm:64850-64856.
+        var r = PositionalAudio.Sample(
+            srcX: 80 + 49, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.True(r.Culled);
+    }
+
+    [Fact]
+    public void Volume_clamps_to_upper_bound()
+    {
+        // raw = 0x7F + 10 = 137 → clamp to 0x7F at UW1_asm.asm:64874-64888.
+        var r = PositionalAudio.Sample(
+            srcX: 80, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x7F, volDelta: 10);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0x7F, r.Vol);
+    }
+
+    [Fact]
+    public void Volume_clamps_to_lower_bound()
+    {
+        // raw = 5 + (-20) = -15 → clamp to 0.
+        var r = PositionalAudio.Sample(
+            srcX: 80, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 5, volDelta: -20);
+        Assert.False(r.Culled);
+        Assert.Equal((byte)0, r.Vol);
+    }
+}

--- a/tests/Underworld.Sfx.Tests/PositionalAudioTests.cs
+++ b/tests/Underworld.Sfx.Tests/PositionalAudioTests.cs
@@ -100,4 +100,68 @@ public class PositionalAudioTests
         Assert.False(r.Culled);
         Assert.Equal((byte)0, r.Vol);
     }
+
+    // Heading convention in these tests — per UW2 uw2_asm.asm:79427-79441:
+    //   heading8 is 8-bit, 0..255 full circle.
+    //   The pan formula applies 0x4000-(heading<<8) as a 90° rotation
+    //   before the sin/cos lookup (UW1_asm.asm:64777, uw2_asm.asm:79445).
+    //
+    // For facing heading=0 (the +X axis in game coords), a source at
+    // positive dY should pan to one side and negative dY to the other.
+    // The exact polarity is subject to the RE's "sin vs cos table
+    // ambiguity" (spec §Testing → sin/cos operand order). The tests
+    // assert SYMMETRY and THAT PAN MOVES OFF CENTRE, not the sign.
+    // In-game audible test resolves the sign.
+
+    [Fact]
+    public void Pan_symmetric_about_source_on_axis()
+    {
+        // Source in front of the player — pan should be near centre.
+        var r = PositionalAudio.Sample(
+            srcX: 80 + 16, srcY: 80, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.InRange(r.Pan, (byte)(0x40 - 4), (byte)(0x40 + 4));
+    }
+
+    [Fact]
+    public void Pan_moves_off_centre_for_side_sources()
+    {
+        // Source to one side: pan shifts distinctly off centre.
+        var left  = PositionalAudio.Sample(
+            srcX: 80, srcY: 80 + 16, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        var right = PositionalAudio.Sample(
+            srcX: 80, srcY: 80 - 16, playerX: 80, playerY: 80,
+            heading8: 0, baseVelocity: 0x50, volDelta: 0);
+        Assert.NotEqual((byte)0x40, left.Pan);
+        Assert.NotEqual((byte)0x40, right.Pan);
+        // Mirror sources produce mirrored pans about 0x40.
+        Assert.Equal(left.Pan, (byte)(0x80 - right.Pan));
+    }
+
+    [Fact]
+    public void Pan_behaviour_under_heading_rotation()
+    {
+        // Rotating the player 180° should flip which side a fixed source pans to.
+        var at0   = PositionalAudio.Sample(
+            srcX: 80, srcY: 80 + 16, playerX: 80, playerY: 80,
+            heading8: 0x00, baseVelocity: 0x50, volDelta: 0);
+        var at180 = PositionalAudio.Sample(
+            srcX: 80, srcY: 80 + 16, playerX: 80, playerY: 80,
+            heading8: 0x80, baseVelocity: 0x50, volDelta: 0);
+        Assert.NotEqual(at0.Pan, at180.Pan);
+        // Values should mirror about 0x40.
+        Assert.Equal(at0.Pan, (byte)(0x80 - at180.Pan));
+    }
+
+    [Fact]
+    public void Pan_clamps_to_valid_range()
+    {
+        // Source at extreme dy with small dx — normalised ratio hits saturation
+        // at ±0x7F (UW1_asm.asm:64657, 64678). Result must be in [0, 0x7F].
+        var r = PositionalAudio.Sample(
+            srcX: 80, srcY: 80 + 40, playerX: 80, playerY: 80,
+            heading8: 0x40, baseVelocity: 0x50, volDelta: 0);
+        Assert.InRange(r.Pan, (byte)0, (byte)0x7F);
+    }
 }

--- a/tests/Underworld.Sfx.Tests/SoundsDatLoaderTests.cs
+++ b/tests/Underworld.Sfx.Tests/SoundsDatLoaderTests.cs
@@ -56,4 +56,38 @@ public class SoundsDatLoaderTests
         // Per issue #28 name table: ID 0 → tvfx=8 ("Water").
         Assert.Equal((byte)8, SoundsDatLoader.Load(Fixtures.SoundsDat)[0].PatchNum);
     }
+
+    [Fact]
+    public void Uw2_duration_word_is_big_endian()
+    {
+        // UW2 SOUNDS.DAT entry layout from uw2_asm.asm:83683-83688
+        //   shl ax, 8 ; add ax, dx  → byte[3] is high, byte[4] is low → big-endian.
+        // UW1 is little-endian (5-byte entries).
+        //
+        // Craft a 2-entry UW2 file: count byte 0x02, then two 8-byte entries where
+        // byte[3]=0x12, byte[4]=0x34. Expect DurationWord == 0x1234 when parsed
+        // as UW2, 0x3412 when parsed as UW1. Assert only on the UW2 parse.
+        var tmp = System.IO.Path.GetTempFileName();
+        try
+        {
+            byte[] buf = new byte[] {
+                0x02,                                                   // 2 entries
+                0x10, 0x20, 0x30, 0x12, 0x34, 0x01, 0x02, 0x03,          // entry 0
+                0x11, 0x21, 0x31, 0xAA, 0xBB, 0x00, 0x00, 0x00,          // entry 1
+            };
+            System.IO.File.WriteAllBytes(tmp, buf);
+
+            var prev = UWClass._RES;
+            UWClass._RES = UWClass.GAME_UW2;
+            try
+            {
+                var entries = SoundsDatLoader.Load(tmp);
+                Assert.Equal(2, entries.Length);
+                Assert.Equal(0x1234, entries[0].DurationWord);
+                Assert.Equal(0xAABB, entries[1].DurationWord);
+            }
+            finally { UWClass._RES = prev; }
+        }
+        finally { System.IO.File.Delete(tmp); }
+    }
 }

--- a/tests/Underworld.Sfx.Tests/StereoPanBakeTests.cs
+++ b/tests/Underworld.Sfx.Tests/StereoPanBakeTests.cs
@@ -1,0 +1,102 @@
+using Underworld.Sfx;
+
+namespace Underworld.Sfx.Tests;
+
+public class StereoPanBakeTests
+{
+    // Constants and table source: external/AIL2/DMASOUND.ASM:287-294 (pan_graph),
+    //                             external/AIL2/DMASOUND.ASM:993-1006 (mixer).
+    // Miles native polarity (spec §StereoPanBake): P=0 → hard right, P=127 → hard left.
+
+    private static short[] Mono(int n, short s)
+    {
+        var b = new short[n]; for (int i = 0; i < n; i++) b[i] = s; return b;
+    }
+
+    [Fact]
+    public void Pan_centre_equal_both_channels()
+    {
+        // P=0x40 → pan_graph[64]=127, pan_graph[63]=127 (saturate at i>=63).
+        // Both gains = 127 * V. At V=0x7F: gain = 127*127/16129 = 1.0 → output = input.
+        var stereo = StereoPanBake.Apply(Mono(1, 1000), vol: 0x7F, pan: 0x40);
+        Assert.Equal(2, stereo.Length);          // L, R
+        Assert.Equal((short)1000, stereo[0]);
+        Assert.Equal((short)1000, stereo[1]);
+    }
+
+    [Fact]
+    public void Pan_zero_hard_right_miles_native()
+    {
+        // P=0x00 → pan_graph[0]=0, pan_graph[127]=127 (saturated).
+        // Left = 0 * V = 0; Right = 127 * V = full at V=0x7F.
+        // Interleaved [L, R] per sample.
+        var stereo = StereoPanBake.Apply(Mono(1, 1000), vol: 0x7F, pan: 0x00);
+        Assert.Equal((short)0, stereo[0]);       // L
+        Assert.Equal((short)1000, stereo[1]);    // R
+    }
+
+    [Fact]
+    public void Pan_max_hard_left_miles_native()
+    {
+        // P=0x7F → pan_graph[127]=127, pan_graph[0]=0.
+        // Left full, Right silent.
+        var stereo = StereoPanBake.Apply(Mono(1, 1000), vol: 0x7F, pan: 0x7F);
+        Assert.Equal((short)1000, stereo[0]);    // L
+        Assert.Equal((short)0, stereo[1]);       // R
+    }
+
+    [Fact]
+    public void Pan_saturation_edge_p63_equals_p64()
+    {
+        // pan_graph saturates at i>=63 (external/AIL2/DMASOUND.ASM:287-294).
+        // So P=63 and P=64 must produce identical output on the "saturated side".
+        var at63 = StereoPanBake.Apply(Mono(1, 1000), vol: 0x7F, pan: 63);
+        var at64 = StereoPanBake.Apply(Mono(1, 1000), vol: 0x7F, pan: 64);
+        // At P=63: pan_graph[63]=127 (L side), pan_graph[64]=127 (R side) → both full.
+        // At P=64: pan_graph[64]=127 (L side), pan_graph[63]=127 (R side) → both full.
+        // Both should be identical.
+        Assert.Equal(at63[0], at64[0]);
+        Assert.Equal(at63[1], at64[1]);
+    }
+
+    [Fact]
+    public void Vol_zero_silences_both_channels()
+    {
+        var stereo = StereoPanBake.Apply(Mono(1, 1000), vol: 0, pan: 0x40);
+        Assert.Equal((short)0, stereo[0]);
+        Assert.Equal((short)0, stereo[1]);
+    }
+
+    [Fact]
+    public void Vol_half_attenuates_both_channels()
+    {
+        // V=0x40 (64). pan_graph[0x40] saturates at 127. Gain = 127*64/16129.
+        // For sample=10000: output = 10000 * 127 * 64 / 16129 = ~5037.
+        // Allow ±1 for integer truncation.
+        var stereo = StereoPanBake.Apply(Mono(1, 10000), vol: 0x40, pan: 0x40);
+        Assert.InRange(stereo[0], (short)5035, (short)5039);
+        Assert.InRange(stereo[1], (short)5035, (short)5039);
+    }
+
+    [Fact]
+    public void Output_length_is_twice_input()
+    {
+        // Interleaved stereo — N mono samples produce 2N stereo samples.
+        var stereo = StereoPanBake.Apply(Mono(100, 500), vol: 0x7F, pan: 0x40);
+        Assert.Equal(200, stereo.Length);
+    }
+
+    [Fact]
+    public void PanGraph_lookup_spot_checks()
+    {
+        // External/AIL2/DMASOUND.ASM:287-294:
+        //   pan_graph[i]      = 2*i    for i in 0..62
+        //   pan_graph[63..127] = 127
+        Assert.Equal((byte)0,   StereoPanBake.PanGraph(0));
+        Assert.Equal((byte)2,   StereoPanBake.PanGraph(1));
+        Assert.Equal((byte)124, StereoPanBake.PanGraph(62));
+        Assert.Equal((byte)127, StereoPanBake.PanGraph(63));
+        Assert.Equal((byte)127, StereoPanBake.PanGraph(64));
+        Assert.Equal((byte)127, StereoPanBake.PanGraph(127));
+    }
+}

--- a/tests/Underworld.Sfx.Tests/Underworld.Sfx.Tests.csproj
+++ b/tests/Underworld.Sfx.Tests/Underworld.Sfx.Tests.csproj
@@ -18,6 +18,9 @@
     <!-- Pull in pure-logic SFX source files directly. Godot-dependent files
          live in src/audio/sfx/godot/ and are NOT referenced here. -->
     <Compile Include="..\..\src\audio\sfx\*.cs" />
+    <!-- SoundsDatLoader references UWClass for UW1/UW2 block-size selection;
+         include it so the test project can compile in isolation. -->
+    <Compile Include="..\..\src\base\UWClass.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Implements byte-accurate positional audio (distance-attenuated volume + heading-based pan) for UW1 and UW2 SFX, traced from IDA Pro disassemblies.

- **`PositionalAudio`** — pure math module: distance, cull, volume, pan. 12 asm-traceable unit tests.
- **`StereoPanBake`** — pure stereo mixer implementing Miles AIL 2.0's `pan_graph × V / 16129` L/R split. 8 unit tests. UW2 VOC path now outputs real stereo instead of mono.
- **UW2 SOUNDS.DAT duration endianness fix** — UW2 is big-endian per the asm; loader was little-endian. Independent bug.
- **`docs/audio-architecture.md`** — new Positional audio section + refreshed data-flow diagram.

Every constant and bit-op is traced in inline comments with `file:line` references to the original disassembly.

Closes the positional-audio checklist from #28.

## Test plan

- [x] 68/68 unit tests pass
- [x] Clean build (0 errors)
- [x] Audibly validated on UW2: pan sweeps under heading rotation, volume attenuates with distance, culls past ~6 tiles, L/R polarity matches Miles native (P=0 → hard right).

## Deferred

- **UW1 OPL distance attenuation**: `TvfxSfxBackend.Play` accepts but doesn't yet forward `velocityOffset` to per-voice scaling. Inline TODO left at the drop site. Not user-visible in the default `synth=cm32l` config since UW1 SFX are silent there anyway.
- **UW2 voice-stealing priority** (SOUNDS.DAT[+5..7] bytes). Orthogonal to per-sound attenuation.
- **seg063 sine-LUT extraction** — currently using `Math.Sin/Cos`; drift is ≤1 LSB, inaudible at 7-bit pan resolution.