### PR TITLE
feat(sfx): UW1 OPL distance attenuation via Miles vel-curve scaling

### DIFF
--- a/docs/audio-architecture.md
+++ b/docs/audio-architecture.md
@@ -309,7 +309,22 @@ source this port targets.
 
 **UW1 OPL path:** the TVFX backend is mono hardware — pan is silently
 dropped (authentic AdLib behaviour). Volume attenuation flows through
-`velocityOffset` on `Sfx.SoundEffects.Play`.
+`velocityOffset` on `Sfx.SoundEffects.Play` →
+`TvfxSfxBackend.ComputeVolScale` → `SfxCommand.VolScale` →
+`TvfxVoice.EmitRegisters`, which multiplies the carrier's linear volume
+by `VolScale / 127` before inverting to OPL Total Level. Uses Miles
+AIL 2.0's 16-entry `VelGraph` LUT (`YAMAHA.INC:240`) with a 82/127
+loudness floor — full silence comes from the `dist > 48` cull in
+`PositionalAudio`, not from velocity scaling. Modulator TL stays
+patch-static (algorithm-0 FM convention, `YAMAHA.INC:1746`).
+
+**OPL3 pan bits (load-bearing):** the TVFX engine runs on top of
+libadlmidi's nuked-opl3 emulator, which always operates in OPL3 mode
+even when driving OPL2-style patches. Register `0xC0` bits 4-5 are the
+OPL3 L/R pan enables; `TvfxVoice.EmitRegisters` ORs `0x30` into every
+FBC write so voices are routed to both output channels. Real OPL2
+hardware lacks those bits and ignores them, but on an OPL3 emulator
+clearing them routes the voice to NEITHER channel → silence.
 
 **Round-trip encoding:** `PlaySoundEffectAtCoordinate` computes an absolute
 vol from `PositionalAudio.Sample`, converts back to `velocityOffset =
@@ -544,7 +559,7 @@ Under `tools/` — not shipped to end users, but useful for verification:
 
 `tests/Underworld.Sfx.Tests/` — xUnit project targeting `net10.0`. Compiles the
 pure-logic SFX source files (everything not under `godot/`) via `<Compile Include>`
-so tests run on plain .NET without a Godot runtime. 68 tests covering:
+so tests run on plain .NET without a Godot runtime. 80 tests covering:
 
 - `SoundsDatLoader` — golden UW1 fixture, field ranges, UW1 LE decode,
   UW2 BE decode regression (per `uw2_asm.asm:83683-83688`).
@@ -565,6 +580,12 @@ so tests run on plain .NET without a Godot runtime. 68 tests covering:
 - `StereoPanBake` — 8 tests: pan centre equality, hard-left/right Miles native,
   saturation edge at pan 63/64, volume attenuation scaling, interleaved output
   length, pan_graph LUT spot-checks (0, 1, 62, 63, 64, 127).
+- `TvfxVelocity` — 7 tests: `vel_graph` LUT byte-for-byte match against
+  `YAMAHA.INC:240`, `ComputeVolScale` boundaries + clamps.
+- TVFX carrier TL scaling — 4 tests: VolScale=127 backward-compat identity,
+  linear-space multiplication, modulator unaffected, 82-floor quieter-but-not-silent.
+- OPL3 pan bits — 1 test: every FBC write sets bits 4-5 so voices are
+  routed to both output channels (audible on libadlmidi's nuked-opl3).
 
 ## File index (SFX)
 
@@ -574,6 +595,7 @@ so tests run on plain .NET without a Godot runtime. 68 tests covering:
 | `src/audio/sfx/SoundsDatLoader.cs` | 5-byte (UW1 LE) / 8-byte (UW2 BE) record parser |
 | `src/audio/sfx/PositionalAudio.cs` | Pure falloff math (vol, pan, cull) |
 | `src/audio/sfx/StereoPanBake.cs` | Miles AIL2 pan_graph × V / 16129 stereo bake |
+| `src/audio/sfx/TvfxVelocity.cs` | Miles AIL2 `vel_graph` LUT + `ComputeVolScale` for UW1 OPL carrier TL scaling |
 | `src/audio/sfx/TvfxPatch.cs` | Header parser, opt-block detect |
 | `src/audio/sfx/TvfxPatchBank.cs` | UW.AD index walker + lazy patch load |
 | `src/audio/sfx/TvfxVoice.cs` | State machine, stream VM, register emitter |

--- a/src/audio/sfx/SfxCommand.cs
+++ b/src/audio/sfx/SfxCommand.cs
@@ -2,7 +2,11 @@ namespace Underworld.Sfx;
 
 /// <summary>
 /// One trigger dispatched from the game thread to the audio producer thread.
-/// Carries the patch reference (immutable, safely shared) and the per-trigger
-/// lifetime in 60 Hz service ticks (-1 = infinite).
+/// Carries the patch reference (immutable, safely shared), the per-trigger
+/// lifetime in 60 Hz service ticks (-1 = infinite), and a composite volume
+/// scale byte (0..127) computed via <see cref="TvfxVelocity.ComputeVolScale"/>.
+/// The consumer (<see cref="TvfxVoice.EmitRegisters"/>) multiplies the
+/// carrier's TVFX-computed linear volume by VolScale/127 before inverting
+/// to OPL Total Level. VolScale=127 is the identity (no extra attenuation).
 /// </summary>
-public readonly record struct SfxCommand(TvfxPatch Patch, int LifetimeTicks);
+public readonly record struct SfxCommand(TvfxPatch Patch, int LifetimeTicks, byte VolScale);

--- a/src/audio/sfx/TvfxVelocity.cs
+++ b/src/audio/sfx/TvfxVelocity.cs
@@ -1,0 +1,45 @@
+namespace Underworld.Sfx;
+
+/// <summary>
+/// Miles AIL 2.0 velocity-to-volume scaling for TVFX. Pure logic: no Godot
+/// dependencies, suitable for unit testing.
+/// </summary>
+public static class TvfxVelocity
+{
+    /// <summary>
+    /// Miles AIL 2.0 velocity-curve LUT. 16 bytes at YAMAHA.INC:240. Indexed
+    /// by <c>effectiveVelocity &gt;&gt; 3</c> (upper 4 bits of a 7-bit velocity).
+    /// Maps to a composite volume value in 82..127. The floor of 82 is
+    /// deliberate — in the original driver, even velocity 0 produces
+    /// ≈65% loudness; silence only comes from explicit voice termination
+    /// or (in our pipeline) the distance-cull in PositionalAudio.
+    /// </summary>
+    public static readonly byte[] VelGraph =
+    {
+        82, 85, 88, 91, 94, 97, 100, 103,
+        106, 109, 112, 115, 118, 121, 124, 127,
+    };
+
+    /// <summary>
+    /// Compute the composite volume-scale byte (0..127) applied to the
+    /// carrier's linear volume at TL write time. Replicates the Miles
+    /// driver's velocity path under the assumption that CC 7 = CC 11 = 127
+    /// (defaults; UW1 doesn't track them per sound). Under that assumption
+    /// the `update_voice` composite (YAMAHA.INC:1491-1502) reduces to
+    /// <c>VelGraph[effectiveVel &gt;&gt; 3]</c>.
+    ///
+    /// <para>
+    /// effectiveVel = clamp(baseVelocity + (sbyte)velocityOffset, 0, 0x7F).
+    /// The resulting byte multiplies the carrier's current "volume-in"
+    /// (0..63) in <see cref="TvfxVoice.EmitRegisters"/> before inversion to
+    /// OPL Total Level. Value 127 is the identity (no extra attenuation).
+    /// </para>
+    /// </summary>
+    public static byte ComputeVolScale(byte baseVelocity, byte velocityOffset)
+    {
+        int effective = baseVelocity + (sbyte)velocityOffset;
+        if (effective < 0) effective = 0;
+        if (effective > 0x7F) effective = 0x7F;
+        return VelGraph[effective >> 3];
+    }
+}

--- a/src/audio/sfx/TvfxVoice.cs
+++ b/src/audio/sfx/TvfxVoice.cs
@@ -358,7 +358,12 @@ public sealed class TvfxVoice
             sink.WriteReg(0x40 + car, (byte)(tl | _kslCar));
         }
         if ((_updateMask & (1 << 4)) != 0)   // feedback → FBC
-            sink.WriteReg(0xC0 + Channel, (byte)(((_acc[4] >> 12) & 0x0E) | (_fconBase & 1)));
+            // Bits 4-5 (L/R pan enable) MUST be set on OPL3-emulating backends
+            // such as libadlmidi's nuked-opl3, which always emulates OPL3 even
+            // when driving OPL2-style TVFX. On a real OPL2 these bits don't
+            // exist and are ignored. Without them every voice is routed to
+            // neither output channel — silent.
+            sink.WriteReg(0xC0 + Channel, (byte)(0x30 | ((_acc[4] >> 12) & 0x0E) | (_fconBase & 1)));
         if ((_updateMask & (1 << 7)) != 0)   // waveform → both ops
         {
             sink.WriteReg(0xE0 + mod, (byte)((_acc[7] >> 8) & 0x07));

--- a/src/audio/sfx/TvfxVoice.cs
+++ b/src/audio/sfx/TvfxVoice.cs
@@ -39,11 +39,12 @@ public sealed class TvfxVoice
     private int _phaseTicks;
     private int _lifetimeTicks;        // -1 == infinite (game's 0xFFFF sentinel)
 
-    // Composite volume scale (0..127) applied to the carrier's linear volIn
-    // before TL inversion. Miles AIL 2.0 curve; see TvfxVelocity.VelGraph
-    // and TvfxVelocity.ComputeVolScale. 127 = identity (matches pre-Task-8
-    // behaviour). Source: YAMAHA.INC:1491-1502 (composite compute) +
-    // :1748-1756 (carrier TL write with vol scaling).
+    // Composite volume scale applied to the carrier's linear volIn before
+    // TL inversion. Valid range is 0..127; the upstream pipeline (TvfxVelocity
+    // .ComputeVolScale → VelGraph) guarantees values in 82..127. 127 is the
+    // identity (byte-identical to the pre-scaling carrier TL). No clamp here
+    // — callers are responsible for the 0..127 invariant. Source: YAMAHA.INC:
+    // 1491-1502 (composite compute) + :1748-1756 (carrier TL write scaling).
     private byte _volScale = 127;
 
     public TvfxVoice(int channel) { Channel = channel; }

--- a/src/audio/sfx/TvfxVoice.cs
+++ b/src/audio/sfx/TvfxVoice.cs
@@ -39,6 +39,13 @@ public sealed class TvfxVoice
     private int _phaseTicks;
     private int _lifetimeTicks;        // -1 == infinite (game's 0xFFFF sentinel)
 
+    // Composite volume scale (0..127) applied to the carrier's linear volIn
+    // before TL inversion. Miles AIL 2.0 curve; see TvfxVelocity.VelGraph
+    // and TvfxVelocity.ComputeVolScale. 127 = identity (matches pre-Task-8
+    // behaviour). Source: YAMAHA.INC:1491-1502 (composite compute) +
+    // :1748-1756 (carrier TL write with vol scaling).
+    private byte _volScale = 127;
+
     public TvfxVoice(int channel) { Channel = channel; }
 
     public ushort Acc(int paramIndex) => _acc[paramIndex];
@@ -266,12 +273,13 @@ public sealed class TvfxVoice
     /// handover. No runtime assertion is raised; restart is safe.
     /// </para>
     /// </summary>
-    public void StartKeyon(TvfxPatch patch, int lifetimeTicks)
+    public void StartKeyon(TvfxPatch patch, int lifetimeTicks, byte volScale = 127)
     {
         Patch = patch;
         Phase = TvfxPhase.Keyon;
         _phaseTicks = 0;
         _lifetimeTicks = lifetimeTicks;
+        _volScale = volScale;
 
         for (int i = 0; i < 8; i++)
         {
@@ -337,7 +345,17 @@ public sealed class TvfxVoice
         if ((_updateMask & (1 << 1)) != 0)   // level0 → KSL/TL mod
             sink.WriteReg(0x40 + mod, (byte)(((~(_acc[1] >> 10)) & 0x3F) | _kslMod));
         if ((_updateMask & (1 << 2)) != 0)   // level1 → KSL/TL car
-            sink.WriteReg(0x40 + car, (byte)(((~(_acc[2] >> 10)) & 0x3F) | _kslCar));
+        {
+            // Miles AIL 2.0 carrier TL scaling (YAMAHA.INC:1748-1756):
+            //   volIn  = (~patch_TL) & 0x3F  — but TVFX stores volume-form
+            //                                 directly in _acc[2] >> 10.
+            //   scaled = volIn * vol / 127   — multiplication in linear space.
+            //   TL     = (~scaled) & 0x3F    — invert back to attenuation.
+            int volIn = (_acc[2] >> 10) & 0x3F;
+            int scaled = (volIn * _volScale) / 127;
+            int tl = (~scaled) & 0x3F;
+            sink.WriteReg(0x40 + car, (byte)(tl | _kslCar));
+        }
         if ((_updateMask & (1 << 4)) != 0)   // feedback → FBC
             sink.WriteReg(0xC0 + Channel, (byte)(((_acc[4] >> 12) & 0x0E) | (_fconBase & 1)));
         if ((_updateMask & (1 << 7)) != 0)   // waveform → both ops

--- a/src/audio/sfx/godot/SfxStreamPlayer.cs
+++ b/src/audio/sfx/godot/SfxStreamPlayer.cs
@@ -137,7 +137,7 @@ public partial class SfxStreamPlayer : Node
                 while (_commands.TryDequeue(out var cmd))
                 {
                     var voice = _allocator.Allocate();
-                    voice?.StartKeyon(cmd.Patch, cmd.LifetimeTicks);
+                    voice?.StartKeyon(cmd.Patch, cmd.LifetimeTicks, cmd.VolScale);
                     // null = saturated (all 9 voices busy) → drop trigger silently,
                     // matching authentic UW behaviour.
                 }

--- a/src/audio/sfx/godot/TvfxSfxBackend.cs
+++ b/src/audio/sfx/godot/TvfxSfxBackend.cs
@@ -23,12 +23,9 @@ public sealed class TvfxSfxBackend : ISfxBackend
 
     public void Play(SoundEntry entry, byte pan, byte velocityOffset)
     {
-        // TODO(Task 8): velocityOffset is accepted here but not forwarded to
-        // the voice pipeline — SfxCommand carries only (patch, lifetime).
-        // As a result UW1 positional-audio volume attenuation is currently
-        // inaudible on the OPL backend. Wiring this to per-voice velocity
-        // scaling is a follow-up. See docs/audio-architecture.md §Positional
-        // audio → UW1 OPL path. `pan` is authentic no-op (OPL is mono).
+        // pan is authentic no-op (OPL is mono). velocityOffset drives the
+        // carrier TL scaling — see TvfxVelocity.ComputeVolScale (Miles
+        // YAMAHA.INC:1491-1502 with C = E = 127 defaults).
         var patch = _bank.GetTvfx(entry.PatchNum);
         if (patch == null)
         {
@@ -65,7 +62,8 @@ public sealed class TvfxSfxBackend : ISfxBackend
         else
             lifetime = entry.DurationWord * 15 / 64;
 
-        _player.Enqueue(new SfxCommand(patch, lifetime));
+        byte volScale = TvfxVelocity.ComputeVolScale(entry.Velocity, velocityOffset);
+        _player.Enqueue(new SfxCommand(patch, lifetime, volScale));
     }
 
     public void Dispose() { /* SfxStreamPlayer is owned by the Godot scene tree */ }

--- a/tests/Underworld.Sfx.Tests/SyntheticPatch.cs
+++ b/tests/Underworld.Sfx.Tests/SyntheticPatch.cs
@@ -12,7 +12,12 @@ internal static class SyntheticPatch
     // padding that ALE.INC skips via "add ax, 2" at init. We include that
     // padding so the VM's cursor (_cursorWord[i] = offset/2 + 1) lands on the
     // first supplied stream word.
-    public static TvfxPatch Build(params ushort[] freqStreamWords)
+    public static TvfxPatch Build(params ushort[] freqStreamWords) =>
+        BuildWithLevels(0x0000, 0x0000, freqStreamWords);
+
+    // Variant: supply non-zero InitVal for level0 and level1 accumulators.
+    // This allows testing envelope behavior at specific starting volumes.
+    public static TvfxPatch BuildWithLevels(ushort level0Init, ushort level1Init, params ushort[] freqStreamWords)
     {
         // Use 0x34 as the declared freq keyon offset so HasAdsrBlock is false
         // (anything != 0x34 triggers opt-block parsing which our tiny synthetic
@@ -28,14 +33,17 @@ internal static class SyntheticPatch
         raw[3] = (byte)TvfxType.TvEffect;
         raw[4] = 60; raw[5] = 0;   // duration = 60
 
-        void WriteParam(int idx, ushort keyon, ushort release)
+        void WriteParam(int idx, ushort keyon, ushort release, ushort initVal = 0)
         {
             int o = 6 + idx * 6;
+            raw[o + 0] = (byte)(initVal & 0xFF); raw[o + 1] = (byte)(initVal >> 8);
             raw[o + 2] = (byte)(keyon & 0xFF); raw[o + 3] = (byte)(keyon >> 8);
             raw[o + 4] = (byte)(release & 0xFF); raw[o + 5] = (byte)(release >> 8);
         }
         WriteParam(0, (ushort)freqStart, (ushort)freqStart);
-        for (int i = 1; i < 8; i++) WriteParam(i, (ushort)deadStart, (ushort)deadStart);
+        WriteParam(1, (ushort)deadStart, (ushort)deadStart, level0Init);
+        WriteParam(2, (ushort)deadStart, (ushort)deadStart, level1Init);
+        for (int i = 3; i < 8; i++) WriteParam(i, (ushort)deadStart, (ushort)deadStart);
 
         for (int i = 0; i < freqStreamWords.Length; i++)
         {

--- a/tests/Underworld.Sfx.Tests/TvfxRegisterWriteTests.cs
+++ b/tests/Underworld.Sfx.Tests/TvfxRegisterWriteTests.cs
@@ -106,4 +106,126 @@ public class TvfxRegisterWriteTests
         // vectors.
         Assert.True(true);
     }
+
+    // --- Task 3 tests: VolScale applied at carrier TL write ---
+    //
+    // Source: Miles AIL 2.0 YAMAHA.INC:1748-1756 (carrier scaling path).
+    // Modulator TL stays static per YAMAHA.INC:1746 (algorithm-0 FM).
+
+    // Helper: find the LAST write to a specific OPL register address in a sink.
+    private static byte LastWrite(CapturingSink sink, int addr)
+    {
+        byte val = 0;
+        foreach (var (a, v) in sink.Writes) if (a == addr) val = v;
+        return val;
+    }
+
+    // OPL2 channel 0: modulator op=0x00 (reg 0x40), carrier op=0x03 (reg 0x43).
+    private const int Ch0CarTlReg = 0x40 + 0x03;
+    private const int Ch0ModTlReg = 0x40 + 0x00;
+
+    [Fact]
+    public void VolScale_127_is_backward_compatible_for_carrier_TL()
+    {
+        // Backward-compat invariant: VolScale=127 must produce byte-identical
+        // carrier TL to the pre-Task-8 code path (existing StartKeyon without
+        // the scaling parameter, which defaults to 127).
+        // Use level1Init=0x4000 so volIn = (~(0x4000 >> 10)) & 0x3F is non-zero.
+        var patch = SyntheticPatch.BuildWithLevels(0x0000, 0x4000, 0x0001, 0x0000);
+
+        var baselineSink = new CapturingSink();
+        var voice1 = new TvfxVoice(0);
+        voice1.StartKeyon(patch, lifetimeTicks: -1);    // default volScale = 127
+        voice1.ServiceTick();
+        voice1.EmitRegisters(baselineSink);
+        byte baselineTl = LastWrite(baselineSink, Ch0CarTlReg);
+
+        var scaledSink = new CapturingSink();
+        var voice2 = new TvfxVoice(0);
+        voice2.StartKeyon(patch, lifetimeTicks: -1, volScale: 127);
+        voice2.ServiceTick();
+        voice2.EmitRegisters(scaledSink);
+        byte scaledTl = LastWrite(scaledSink, Ch0CarTlReg);
+
+        Assert.Equal(baselineTl, scaledTl);
+    }
+
+    [Fact]
+    public void VolScale_multiplies_carrier_volIn_then_inverts()
+    {
+        // At volScale=64, carrier's linear volIn is scaled by 64/127.
+        // Miles formula: scaled = volIn * volScale / 127;  tl = (~scaled) & 0x3F.
+        // YAMAHA.INC:1748-1754.
+        var patch = SyntheticPatch.BuildWithLevels(0x0000, 0x4000, 0x0001, 0x0000);
+
+        var fullSink = new CapturingSink();
+        var voiceFull = new TvfxVoice(0);
+        voiceFull.StartKeyon(patch, lifetimeTicks: -1, volScale: 127);
+        voiceFull.ServiceTick();
+        voiceFull.EmitRegisters(fullSink);
+        byte fullTl = (byte)(LastWrite(fullSink, Ch0CarTlReg) & 0x3F);
+        int fullVolIn = (~fullTl) & 0x3F;
+
+        var halfSink = new CapturingSink();
+        var voiceHalf = new TvfxVoice(0);
+        voiceHalf.StartKeyon(patch, lifetimeTicks: -1, volScale: 64);
+        voiceHalf.ServiceTick();
+        voiceHalf.EmitRegisters(halfSink);
+        byte halfTl = (byte)(LastWrite(halfSink, Ch0CarTlReg) & 0x3F);
+        int halfVolIn = (~halfTl) & 0x3F;
+
+        // halfVolIn == fullVolIn * 64 / 127 (integer). Allow ±1 for truncation.
+        int expected = fullVolIn * 64 / 127;
+        Assert.InRange(halfVolIn, expected - 1, expected + 1);
+    }
+
+    [Fact]
+    public void VolScale_does_not_affect_modulator_TL()
+    {
+        // UW1 SFX are two-op FM (algo 0). Per YAMAHA.INC:1746, modulator TL
+        // is NEVER scaled in FM voices — it stays fully patch-static.
+        var patch = SyntheticPatch.BuildWithLevels(0x0000, 0x4000, 0x0001, 0x0000);
+
+        var fullSink = new CapturingSink();
+        var voiceFull = new TvfxVoice(0);
+        voiceFull.StartKeyon(patch, lifetimeTicks: -1, volScale: 127);
+        voiceFull.ServiceTick();
+        voiceFull.EmitRegisters(fullSink);
+        byte modFull = (byte)(LastWrite(fullSink, Ch0ModTlReg) & 0x3F);
+
+        var lowSink = new CapturingSink();
+        var voiceLow = new TvfxVoice(0);
+        voiceLow.StartKeyon(patch, lifetimeTicks: -1, volScale: 82);
+        voiceLow.ServiceTick();
+        voiceLow.EmitRegisters(lowSink);
+        byte modLow = (byte)(LastWrite(lowSink, Ch0ModTlReg) & 0x3F);
+
+        Assert.Equal(modFull, modLow);
+    }
+
+    [Fact]
+    public void VolScale_loudness_floor_at_82_is_audibly_quieter_but_not_silent()
+    {
+        // Minimum VolScale from our pipeline is 82 (vel_graph[0]). Carrier TL
+        // at that scale is more-attenuated than at 127, but not silent (0x3F).
+        // Matches Miles: zero-velocity FM output is never fully silenced.
+        var patch = SyntheticPatch.BuildWithLevels(0x0000, 0x4000, 0x0001, 0x0000);
+
+        var fullSink = new CapturingSink();
+        var voiceFull = new TvfxVoice(0);
+        voiceFull.StartKeyon(patch, lifetimeTicks: -1, volScale: 127);
+        voiceFull.ServiceTick();
+        voiceFull.EmitRegisters(fullSink);
+        byte fullTl = (byte)(LastWrite(fullSink, Ch0CarTlReg) & 0x3F);
+
+        var floorSink = new CapturingSink();
+        var voiceFloor = new TvfxVoice(0);
+        voiceFloor.StartKeyon(patch, lifetimeTicks: -1, volScale: 82);
+        voiceFloor.ServiceTick();
+        voiceFloor.EmitRegisters(floorSink);
+        byte floorTl = (byte)(LastWrite(floorSink, Ch0CarTlReg) & 0x3F);
+
+        Assert.True(floorTl > fullTl, "floor should attenuate more than full");
+        Assert.True(floorTl < 0x3F, "floor should not be fully silent");
+    }
 }

--- a/tests/Underworld.Sfx.Tests/TvfxRegisterWriteTests.cs
+++ b/tests/Underworld.Sfx.Tests/TvfxRegisterWriteTests.cs
@@ -107,6 +107,23 @@ public class TvfxRegisterWriteTests
         Assert.True(true);
     }
 
+    [Fact]
+    public void Fbc_register_sets_opl3_LR_pan_bits()
+    {
+        // Register 0xC0 bits 4-5 are the OPL3 L/R pan enables. Real OPL2
+        // doesn't have them; libadlmidi's nuked-opl3 always runs in OPL3
+        // mode, so voices with bits 4-5 clear are routed to NEITHER output
+        // channel — silent. Every FBC write must set 0x30 to keep audio
+        // alive on OPL3-emulating backends.
+        var v = PrimeVoice(0);
+        var sink = new CapturingSink();
+        v.EmitRegisters(sink);
+
+        byte fbc = 0;
+        foreach (var (a, val) in sink.Writes) if (a == 0xC0) fbc = val;
+        Assert.Equal(0x30, fbc & 0x30);
+    }
+
     // --- Task 3 tests: VolScale applied at carrier TL write ---
     //
     // Source: Miles AIL 2.0 YAMAHA.INC:1748-1756 (carrier scaling path).

--- a/tests/Underworld.Sfx.Tests/TvfxVelocityTests.cs
+++ b/tests/Underworld.Sfx.Tests/TvfxVelocityTests.cs
@@ -1,0 +1,73 @@
+using Underworld.Sfx;
+
+namespace Underworld.Sfx.Tests;
+
+public class TvfxVelocityTests
+{
+    // Reference: Miles AIL 2.0 YAMAHA.INC:240 (vel_graph) + :2376-2387 (note_on
+    // velocity capture) + :1491-1502 (update_voice composite with CC 7 / CC 11).
+    // UW1 doesn't separately track CC 7 / CC 11 per effect; we use the Miles
+    // defaults (C = E = 127), under which the composite simplifies to
+    // vol = vel_graph[effectiveVel >> 3].
+
+    [Fact]
+    public void VelGraph_matches_YAMAHA_INC_line_240()
+    {
+        // Exact 16-byte dump. Prevents future edits from drifting the curve.
+        byte[] expected = { 82, 85, 88, 91, 94, 97, 100, 103, 106, 109, 112, 115, 118, 121, 124, 127 };
+        for (int i = 0; i < 16; i++)
+            Assert.Equal(expected[i], TvfxVelocity.VelGraph[i]);
+    }
+
+    [Fact]
+    public void Max_effective_velocity_returns_127()
+    {
+        // baseVel=0x7F, no offset → effectiveVel=0x7F → V>>3=15 → vel_graph[15]=127.
+        byte vol = TvfxVelocity.ComputeVolScale(baseVelocity: 0x7F, velocityOffset: 0);
+        Assert.Equal((byte)127, vol);
+    }
+
+    [Fact]
+    public void Zero_effective_velocity_floors_at_82()
+    {
+        // baseVel=0x7F, offset=-0x7F → effectiveVel=0 → V>>3=0 → vel_graph[0]=82.
+        // Miles loudness floor — see YAMAHA.INC:240 comment in TvfxVelocity.
+        byte vol = TvfxVelocity.ComputeVolScale(
+            baseVelocity: 0x7F, velocityOffset: unchecked((byte)(-0x7F)));
+        Assert.Equal((byte)82, vol);
+    }
+
+    [Fact]
+    public void Mid_effective_velocity_picks_correct_bucket()
+    {
+        // baseVel=0x40 (64), no offset → 64>>3=8 → vel_graph[8]=106.
+        byte vol = TvfxVelocity.ComputeVolScale(baseVelocity: 0x40, velocityOffset: 0);
+        Assert.Equal((byte)106, vol);
+    }
+
+    [Fact]
+    public void Negative_effective_velocity_clamps_to_zero()
+    {
+        // baseVel=0x10, offset=-0x40 → effectiveVel=-0x30 → clamp to 0 → vel_graph[0]=82.
+        byte vol = TvfxVelocity.ComputeVolScale(
+            baseVelocity: 0x10, velocityOffset: unchecked((byte)(-0x40)));
+        Assert.Equal((byte)82, vol);
+    }
+
+    [Fact]
+    public void Over_max_effective_velocity_clamps_to_0x7F()
+    {
+        // baseVel=0x70, offset=+0x20 → effectiveVel=0x90 → clamp 0x7F → vel_graph[15]=127.
+        byte vol = TvfxVelocity.ComputeVolScale(baseVelocity: 0x70, velocityOffset: 0x20);
+        Assert.Equal((byte)127, vol);
+    }
+
+    [Fact]
+    public void Velocity_bucket_boundaries_use_right_shift_3()
+    {
+        // effectiveVel=7 → V>>3=0 → vel_graph[0]=82 (still floor).
+        // effectiveVel=8 → V>>3=1 → vel_graph[1]=85 (first step up).
+        Assert.Equal((byte)82, TvfxVelocity.ComputeVolScale(0x07, 0));
+        Assert.Equal((byte)85, TvfxVelocity.ComputeVolScale(0x08, 0));
+    }
+}


### PR DESCRIPTION
## Summary

Makes UW1 OPL sound effects audibly attenuate with distance (and finally audible at all — see the bundled fix below). Closes the last unchecked item on #28.

- **`TvfxVelocity`** (new, pure) — 16-byte `vel_graph` LUT ported verbatim from Miles AIL 2.0 `YAMAHA.INC:240`, plus `ComputeVolScale(baseVel, velocityOffset)` keyed on `effectiveVel >> 3`.
- **`SfxCommand`** gains a `VolScale` byte. `TvfxSfxBackend.Play` populates it.
- **`TvfxVoice.EmitRegisters`** multiplies the carrier's linear volume by `VolScale / 127` before inverting to OPL Total Level — matches `YAMAHA.INC:1748-1756`. Modulator TL stays patch-static (algorithm-0 FM convention, `YAMAHA.INC:1746`). `VolScale = 127` is the identity (backward-compat invariant pinned in a unit test).

### Bundled fix — OPL3 L/R pan bits

While audibly validating this PR, discovered that UW1 OPL SFX produced **zero bytes of audio** on macOS / any platform using libadlmidi's nuked-opl3 backend. Root cause: the TVFX engine's `WriteReg(0xC0, ...)` didn't set register bits 4-5 (OPL3 L/R pan enables). On real OPL2 those bits don't exist and are ignored, so the oversight survived to merge; on an OPL3 emulator, clearing them routes the voice to neither output channel. One-bit-mask change + regression test.

## Test plan

- [x] 80/80 unit tests pass (68 baseline + 7 `TvfxVelocity` + 4 carrier-scaling + 1 FBC pan-bit).
- [x] Rendered UW1 SFX via `tools/SfxWav` — 257k non-zero samples out of 272k, peak 1717 (was all zeros pre-OPL3-fix).
- [x] Audibly validated in-game on UW1 OPL: doors loud up close, quieter at mid range (vel_graph-scaled), silent past the `dist > 48` cull.

## RE source

All constants traced from Tronix286/AIL2's `YAMAHA.INC`:

- `vel_graph` 16-byte LUT: `:240`
- `note_on` velocity capture (`shr al,1` ×3 + `xlat`): `:2376-2387`
- `update_voice` composite (with `C = E = 127` UW default): `:1491-1502`
- Carrier TL scale + inversion: `:1748-1756`
- Modulator-static gate: `:1746`

## Scope / limits

- Assumes `C = E = 127` (Miles channel-volume + expression defaults). UW1 doesn't track them per sound. If a future port tracks them, the composite formula in `ComputeVolScale` generalises trivially per `YAMAHA.INC:1491-1502`.
- Carrier-only scaling — FM-correct for UW1's algorithm-0 two-op SFX patches. If a future algorithm-1 (additive) SFX appears, modulator path needs the same scaling gated on `FBC & 1`.