### PR TITLE
feat: save-game writing for UW1 (UW2 pending)

### DIFF
--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -32,7 +32,7 @@ The DOS game did save as a **two-tier** process:
    current level, and finally `CopySaveGameFiles` cloned the whole `DATA/`
    tree into `SAVE{n}/`.
 
-We chose **Option B: consolidate at save-time**. `SaveGame.Save` writes all
+I chose **Option B: consolidate at save-time**. `SaveGame.Save` writes all
 files from the in-memory representation in one pass; there is no live
 writeback to `DATA/` during gameplay. Rationale:
 
@@ -108,9 +108,9 @@ fine in the port) causes DOS `UW.EXE` to crash on any save with >80
 uncompressed blocks. Once the upstream compressor lands, remove the gate.
 
 **UW1 save is DOS-compatible in format.** UW1 `lev.ark` is uncompressed by
-spec, so the compression issue doesn't apply. DOS round-trip compatibility
-has been format-checked but not yet verified by an end-to-end DOSBox test
-— that is the next validation step.
+spec, so the compression issue doesn't apply. DOS round-trip is verified
+end-to-end via dos-mcp / DOSBox — see "UW1 DOS round-trip" section below
+for the four byte-level fixes that were required.
 
 **No atomic write.** If `File.WriteAllBytes` fails mid-sequence (disk full,
 permission loss), `SAVE{n}/` is left in a partial state that the loader may
@@ -128,7 +128,7 @@ dispatches the first click with no confirm-overwrite.
 
 **No gravestone trick.** The DOS save path pushed the player into the
 current tile's object list as `item_id = 63` (gravestone) at save time, then
-reloaded `player.dat` to restore live state. We skip this because the port
+reloaded `player.dat` to restore live state. I skip this because the port
 takes player position from `player.dat` at restore, not from a gravestone in
 the level. Two follow-ons flow from this:
 
@@ -160,6 +160,167 @@ for serialised static-state mutation):
 
 23 tests total. Manual playthrough on UW1 and UW2 validated at the end: new
 game → move → drop item → save → quit → restore → state preserved.
+
+## UW1 DOS round-trip
+
+A port save loaded by genuine DOS `UW.EXE` (under DOSBox or dos-mcp's
+js-dos backend) needs **six** byte-level adjustments beyond what the
+in-port loader requires. All six are implemented in `SaveGame.Save`,
+`PlayerDatWriter`, and `playerdatainit.InitEmptyPlayer`; the section
+below documents them so future field changes don't accidentally regress.
+
+### 1. Chargen spawn tile (32, 2), not (32, 1)
+
+`uimanager_mainmenu.JourneyOnwards` hardcoded the UW1 starting tile
+to `(32, 1)`, one tile north of where DOS chargen spawns the Avatar.
+The port itself rendered fine (player faces an open corridor by
+chance), but DOS-loaded port saves placed the camera against the
+solid wall at `(32, 0)` — the entire viewport was occluded by the
+wall face. Fixed by changing the call to
+`Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 2)`.
+
+### 2. Detach the player from the tile object chain at save-time
+
+`PlacePlayerInTile` inserts `LevelObjects[1]` at the head of the
+current tile's `indexObjectList` so the in-game collision pipeline
+can find the player. DOS UW.EXE never writes the player into a
+tile's object chain — slot 1 is reachable only through the
+`pdat[PlayerObjectStoragePTR..]` storage path. When DOS loads a
+save where slot 1 IS in a tile chain, it prints "Underworld
+internal error - Problems in object list" and bails out of the
+3D render with walls/floor/ceiling all flat.
+
+`SaveGame.DetachPlayerFromCurrentTile` walks the chain at the
+player's current tile, unlinks slot 1 (or returns clean if the
+player isn't in the chain — shouldn't happen but defensive), and
+clears `LevelObjects[1].next`. A `finally`-guarded
+`ReattachPlayerToCurrentTile` re-inserts after the file write so
+in-memory state stays consistent if the user keeps playing.
+
+Order is critical: detach BEFORE `StashLiveStateToPdat`, otherwise
+the stash captures `next = <previous chain head>` into the pdat
+copy of the player object. DOS validates pdat-vs-LEV-slot-1
+consistency for bytes 1..26; mismatch yields "Bad save file".
+
+### 3. Slot-1 marker bytes for the player avatar
+
+DOS UW.EXE writes specific marker bytes at LEV.ARK slot 1 to
+distinguish "this slot represents the player camera, do not render
+an NPC sprite at this world position":
+
+- `slot1[0]`: `item_id` bit 6 cleared. Avatar's real `item_id` 127
+  (`0x7F`) is masked to 63 (`0x3F`), an invisible-placeholder NPC
+  type that UW's renderer skips.
+- `slot1[1]` bit 5: doordir flag set. Repurposed on the player
+  slot as a "this is the player" signal.
+- `slot1[26]` (npc_whoami): `0xFD` sentinel. Without this, UW's
+  NPC sprite-draw loop renders the Avatar mesh at the player's
+  own position; the camera ends up inside the mesh, producing
+  the same flat-untextured appearance as a wall occlusion.
+
+`pdat[0xD5+i]` (the player-object copy) mirrors slot 1 bytes 1..26
+exactly. Byte 0 is the only allowed cross-file divergence:
+`pdat[0xD5]` stays `0x7F` (avatar) so in-game inventory / paperdoll
+code keeps the right `item_id` reference; `slot1[0]` is masked
+only in LEV.ARK.
+
+`SaveGame.ApplySlot1Markers` runs after `StashLiveStateToPdat` so
+the byte-0 mask is applied to LEV.ARK only and never propagates
+into pdat.
+
+### 4. UW1 Detail Level (pdat[0xB6] bits 4-5)
+
+`pdat[0xB6]` bits 4-5 encode the in-game **Detail Level** option:
+0 = Low, 1 = Medium, 2 = High, 3 = Very High. DOS chargen defaults
+this to 3; without it, DOS-loaded saves render with walls (and/or
+floor/ceiling) untextured. Specifically:
+
+- `0b00`: walls + floor + ceiling all flat
+- `0b01`: walls textured, floor + ceiling flat
+- `0b10`: walls + floor textured, ceiling flat
+- `0b11`: all surfaces textured (Very High)
+
+Port chargen never wrote these bits, leaving every fresh save at
+detail level 0. The `playerdat.DetailLevel` accessor reads/writes
+the field, and `InitEmptyPlayer` sets `DetailLevel = 3` for UW1.
+UW2 storage offset is TBD; the accessor short-circuits to 3 for
+UW2 to avoid touching unknown bytes.
+
+### 5. pdat[0xD3] = 0x08 (UW1 chargen, semantics TBD)
+
+DOS UW.EXE chargen writes `0x08` at `pdat[0xD3]` and the Journey-
+Onward path validates it. Port chargen left this byte at `0`; on
+DOS load, that 0 sends UW.EXE into a non-returning loop somewhere
+in the load sequence (player UI never appears, game hangs after
+"You enter the Abyss" splash).
+
+Setting `pdat[0xD3] = 0x08` in `InitEmptyPlayer` (UW1 branch only)
+unblocks the load. Empirically pinned by single-byte bisection
+between matched fresh-chargen+bag-pickup port and DOS saves.
+
+**Semantics: TBD.** The byte sits between `pdat[0xCE-0xD1]` (Int32
+game time per uw-formats Abysmal — port treats it as 0xCF-0xD2,
+1-byte off from the docs) and `pdat[0xDC]` (current vitality), in
+a 10-byte region that neither uw-formats project documents. The
+exported `UW1_asm.asm` has no symbol-named annotation for this
+offset; finding the read site needs UW.idb opened in IDA Pro to
+dereference `pdat_base + 0xD3`. Filed as a follow-up RE task.
+
+### 6. Avatar self-link `pdat[0xDB-0xDC] = 0x0040` (link = 1)
+
+The player object copy at `pdat[0xD5..0xEF]` includes a `link`
+field at byte 6 (= `pdat[0xDB-0xDC]`). DOS chargen writes `link = 1`
+— a self-reference (slot 1 IS the player avatar in the mobile
+object list per uw-formats §4.3 "object 1 is always the avatar").
+DOS Journey-Onward reads this as the inventory-presence flag when
+populating the paperdoll/backpack UI; `link = 0` renders the
+inventory as empty.
+
+The port's load code at `uimanager_mainmenu.cs:283` explicitly
+forces `LevelObjects[1].link = 0` after copying pdat → LevelObjects
+to break what the comment calls an "infinite loop" — and that 0
+propagates back into pdat on the next save via `StashLiveStateToPdat`.
+
+We can't write `link = 1` to in-memory pdat permanently (port's
+own loader would re-read it and hit the cycle). Instead,
+`SaveGame.PatchPlayerLinkInSerialised` patches the **serialised
+PLAYER.DAT bytes only** after the writer returns and before the
+file write. In-memory pdat stays at 0; on-disk pdat has `link = 1`.
+
+**Semantics: TBD.** "What does `link = 1` actually flag?" — same
+RE follow-up as §5.
+
+### Diagnostic workflow
+
+The four issues above were each found by byte-diffing a
+fresh-chargen port save against a fresh-chargen DOS save — `cmp -l`
+on the raw files for LEV.ARK, plus the symmetric `EncryptDecryptUW1`
+routine for PLAYER.DAT comparison. Tools:
+
+- **dos-mcp** (`abedegno/dos-mcp`) drives DOSBox in a headless
+  Chromium tab, with `fs_push_dir` / `fs_pull_dir` for moving
+  saves between host and the VFS. UW.EXE scans the save dirs at
+  startup, so pushed files only register if they were in the
+  host source dir at `load_bundle` time — populate the host save
+  dir before reloading the bundle.
+- A small Python helper in `tests/scripts/decrypt_pdat.py`
+  (TODO: extract from the inline scripts used during diagnosis)
+  decrypts UW1 PLAYER.DAT for byte-level comparison.
+
+### Open follow-ups
+
+- **Identify pdat[0xD3] and pdat[0xDB] semantics from disassembly.**
+  Both fields are documented above only by their empirical effect
+  on DOS Journey-Onward. Open `UWReverseEngineering/UW.idb` in IDA
+  Pro, find the function that reads each offset during the load
+  sequence, and update the doc with the field's actual meaning.
+  The exported `UW1_asm.asm` doesn't preserve enough symbol
+  context for grep-style searches against the raw text.
+- **DOS → port round-trip** (DOS chargen + play, then port load)
+  has not been tested under the new fixes.
+- **Description text input.** UI still uses `"Save {slot}"` as
+  the description. DESC writes only the first ASCII byte
+  regardless, so this is cosmetic.
 
 ## Files
 

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -251,25 +251,38 @@ the field, and `InitEmptyPlayer` sets `DetailLevel = 3` for UW1.
 UW2 storage offset is TBD; the accessor short-circuits to 3 for
 UW2 to avoid touching unknown bytes.
 
-### 5. pdat[0xD3] = 0x08 (UW1 chargen, semantics TBD)
+### 5. pdat[0xD3] = ShadeCutOff (shade-table index)
 
-DOS UW.EXE chargen writes `0x08` at `pdat[0xD3]` and the Journey-
-Onward path validates it. Port chargen left this byte at `0`; on
-DOS load, that 0 sends UW.EXE into a non-returning loop somewhere
-in the load sequence (player UI never appears, game hangs after
-"You enter the Abyss" splash).
+DOS UW.EXE chargen writes a non-zero value at `pdat[0xD3]` and the
+Journey-Onward path validates it. Port chargen left this byte at `0`;
+on DOS load, that 0 sent UW.EXE into a non-returning loop in the
+load sequence (player UI never appeared, game hung after the "You
+enter the Abyss" splash).
 
-Setting `pdat[0xD3] = 0x08` in `InitEmptyPlayer` (UW1 branch only)
-unblocks the load. Empirically pinned by single-byte bisection
-between matched fresh-chargen+bag-pickup port and DOS saves.
+**Semantics** (per @hankmorgan, PR #33 review, confirmed by
+disassembly): the byte is the **shade-table index** — the global
+named `ShadeCutOff_dseg_67d6_8622` in the UW2 disassembly, written
+by `ovr142_0` (`OpenAndApplyShadesDat_ovr142_0` in UW2; same
+function in UW1 at `UW1_asm.asm:385926-386218`). Indexes into
+`shades.dat`: `0=Darkness, 1=Burning Match, 2=Candlelight,
+3=Light, 4=Magic Lantern, 5=Night Vision, 6=Daylight, 7=Sunlight`.
+SHADES.DAT is exactly 96 bytes (8 entries × 12 bytes); valid
+range is `0..7`. UW2 stores it at `pdat[0x37F]`. Both format-doc
+projects had it labelled incorrectly as "no of items+1".
 
-**Semantics: TBD.** The byte sits between `pdat[0xCE-0xD1]` (Int32
-game time per uw-formats Abysmal — port treats it as 0xCF-0xD2,
-1-byte off from the docs) and `pdat[0xDC]` (current vitality), in
-a 10-byte region that neither uw-formats project documents. The
-exported `UW1_asm.asm` has no symbol-named annotation for this
-offset; finding the read site needs UW.idb opened in IDA Pro to
-dereference `pdat_base + 0xD3`. Filed as a follow-up RE task.
+The function does NOT bound-check the input — passing `8` reads
+12 bytes off EOF; DOS tolerates because subsequent gameplay
+overwrites the shading params before they're rendered. An
+earlier diagnostic write of `0x08` therefore "worked" by
+accident. The correct chargen value is `3` (Light); see
+`InitEmptyPlayer`.
+
+The port already tracks an analogous `playerdat.lightlevel`
+accessor at `pdat[0x64]` bits 4-7 (different storage). Long-term:
+keep these in sync at light-source change events. Short-term:
+`InitEmptyPlayer` (UW1) writes `pdat[0xD3] = 0x03` (Light) at
+chargen; replacing the literal with a derived-from-lightlevel
+expression is a follow-up.
 
 ### 6. Avatar self-link `pdat[0xDB-0xDC] = 0x0040` (link = 1)
 

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -115,7 +115,7 @@ that haven't been pinned yet.
 **UW1 save is DOS-compatible in format.** UW1 `lev.ark` is uncompressed by
 spec, so the compression issue doesn't apply. DOS round-trip is verified
 end-to-end via dos-mcp / DOSBox — see "UW1 DOS round-trip" section below
-for the four byte-level fixes that were required.
+for the seven byte-level fixes that were required.
 
 **No atomic write.** If `File.WriteAllBytes` fails mid-sequence (disk full,
 permission loss), `SAVE{n}/` is left in a partial state that the loader may
@@ -318,9 +318,38 @@ exact Journey-Onward read site that propagates link → "show inventory"
 hasn't been pinned without IDA database access. Filed as the same
 follow-up as §5.
 
+### 7. Empty-inventory PLAYER.DAT must be at least `InventoryPtr + 8` bytes
+
+`SerializeUw1Canonical` sizes the output at `InventoryPtr + N*8` where
+`N` is the count of emitted inventory slots. A fresh port chargen has
+no items in BP0..BP7 + paperdoll, so `N = 0` and the file ends at
+exactly `InventoryPtr` (= 312 bytes for UW1).
+
+DOS UW.EXE Journey-Onward then hangs at "You reenter the Abyss…"
+(infinite loop reading past EOF — Escape no-ops; the load routine
+never returns). One zero slot (file ≥ 320 bytes) is sufficient to
+unstick the load path. Verified empirically: padding a 312-byte
+port-chargen save to 320 bytes makes UW.EXE load it cleanly with
+textured walls, HP bar, empty paperdoll, and the correct chargen
+spawn tile. Bisected — even a single zero slot is enough; the loader
+isn't checking for a particular minimum slot count, just refusing to
+work when the file ends exactly at `InventoryPtr`.
+
+The fix in `PlayerDatWriter.SerializeUw1Canonical` floors `slotsToEmit`
+at 1. Regression test:
+`Uw1Serialize_EmptyInventory_PadsToAtLeastOneSlot`.
+
+**Why this is empirical, not disasm-derived.** The exact UW.EXE site
+that loops on EOF hasn't been pinned. Likely candidates: the inventory
+DFS the port mirrors (object-link traversal that reads slot 1 even when
+all roots point to slot 0), or a cooked-vs-raw file-size check before
+the inventory loop. Either way, the empirical floor is sound — DOS
+chargen always writes more than 0 slots, so the port is just matching
+DOS's de facto minimum.
+
 ### Diagnostic workflow
 
-The four issues above were each found by byte-diffing a
+The issues above were each found by byte-diffing a
 fresh-chargen port save against a fresh-chargen DOS save — `cmp -l`
 on the raw files for LEV.ARK, plus the symmetric `EncryptDecryptUW1`
 routine for PLAYER.DAT comparison. Tools:
@@ -337,15 +366,20 @@ routine for PLAYER.DAT comparison. Tools:
 
 ### Open follow-ups
 
-- **Identify pdat[0xD3] and pdat[0xDB] semantics from disassembly.**
-  Both fields are documented above only by their empirical effect
-  on DOS Journey-Onward. Open `UWReverseEngineering/UW.idb` in IDA
-  Pro, find the function that reads each offset during the load
-  sequence, and update the doc with the field's actual meaning.
-  The exported `UW1_asm.asm` doesn't preserve enough symbol
-  context for grep-style searches against the raw text.
-- **DOS → port round-trip** (DOS chargen + play, then port load)
-  has not been tested under the new fixes.
+- **Identify pdat[0xD3], pdat[0xDB], and the empty-inventory EOF-loop
+  site from disassembly.** All three are documented above only by
+  their empirical effect on DOS Journey-Onward. Open
+  `UWReverseEngineering/UW.idb` in IDA Pro, find the function that
+  reads each offset (and the loader site that loops when PLAYER.DAT
+  ends exactly at InventoryPtr), and update the doc with each field's
+  actual meaning. The exported `UW1_asm.asm` doesn't preserve enough
+  symbol context for grep-style searches against the raw text.
+- **DOS → port → DOS round-trip** validated on Hank's
+  Carrying-Backpack save: byte-identical inventory region after
+  re-save, all items intact (Alfred's letter, runebag, 4 runes,
+  key). Other in-progress saves with moving doors / thrown
+  projectiles still trip bug (c) and bug (d) on Hank's PR #33
+  review — pending.
 - **Description text input.** UI still uses `"Save {slot}"` as
   the description. DESC writes only the first ASCII byte
   regardless, so this is cosmetic.

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -99,13 +99,18 @@ re-reads unmutated blocks from disk at save time.
 
 ## Known limitations
 
-**UW2 save is UI-gated pending upstream compressor.** The `SaveGame.Save`
-orchestrator and all UW2 writers are still present and tested — they produce
-files that round-trip through the port's own loader — but the Save button
-in the UW2 Options menu refuses to invoke them. Rationale: the port's
-`RepackUW2` is a stub, and writing uncompressed UW2 blocks (which load
-fine in the port) causes DOS `UW.EXE` to crash on any save with >80
-uncompressed blocks. Once the upstream compressor lands, remove the gate.
+**UW2 save is UI-gated pending validation.** The `SaveGame.Save`
+orchestrator and all UW2 writers are still present and tested - they
+produce files that round-trip through the port's own loader - but the
+Save button in the UW2 Options menu refuses to invoke them. Per
+@AlistairBrown (PR #33 review), DOS UW2 accepts uncompressed level
+blocks fine as long as the per-block compression flag is set
+correctly; an earlier theory that >80 uncompressed blocks crashed
+DOS UW2 was incorrect. Re-validating UW2 round-trip under the same
+matched-state byte-diff workflow used for UW1 (see "UW1 DOS round-trip"
+section below) is the right next step before un-gating the UI; the
+six byte-level adjustments needed for UW1 likely have UW2 analogues
+that haven't been pinned yet.
 
 **UW1 save is DOS-compatible in format.** UW1 `lev.ark` is uncompressed by
 spec, so the compression issue doesn't apply. DOS round-trip is verified

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -292,8 +292,18 @@ own loader would re-read it and hit the cycle). Instead,
 PLAYER.DAT bytes only** after the writer returns and before the
 file write. In-memory pdat stays at 0; on-disk pdat has `link = 1`.
 
-**Semantics: TBD.** "What does `link = 1` actually flag?" — same
-RE follow-up as §5.
+**Semantics: partially understood.** A code-review pass on the UW.EXE
+disassembly identified `PlayerObject_dseg_7274` as the far-pointer slot
+DOS code uses to address the player object record (`les bx, ...`),
+which lines up the player's `link` field at `[bx+6]` — exactly
+pdat[0xDB-0xDC] given `PlayerObjectStoragePTR = 0xD5`. The reset/
+teardown routine `ovr134_22` is observed masking `[bx+6]` with `0x3F`
+(clearing link bits, preserving owner) AND writing `[bx+1Ah] = 0xFD`
+(the `npc_whoami` sentinel — confirms the §3 marker), which strongly
+implies the link bits gate something the reset path tears down. The
+exact Journey-Onward read site that propagates link → "show inventory"
+hasn't been pinned without IDA database access. Filed as the same
+follow-up as §5.
 
 ### Diagnostic workflow
 
@@ -308,9 +318,9 @@ routine for PLAYER.DAT comparison. Tools:
   startup, so pushed files only register if they were in the
   host source dir at `load_bundle` time — populate the host save
   dir before reloading the bundle.
-- A small Python helper in `tests/scripts/decrypt_pdat.py`
-  (TODO: extract from the inline scripts used during diagnosis)
-  decrypts UW1 PLAYER.DAT for byte-level comparison.
+- UW1 PLAYER.DAT decryption is symmetric (same routine encrypts and
+  decrypts); a 6-line Python implementation of the loop in
+  `playerdatutil.cs:99` is sufficient for byte-level diff work.
 
 ### Open follow-ups
 

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -99,23 +99,28 @@ re-reads unmutated blocks from disk at save time.
 
 ## Known limitations
 
-**UW2 lev.ark is written uncompressed (compression flag = 0).** The port's
-`RepackUW2` compressor in `dataloader.cs:148` is a documented stub (copy-
-record logic commented out as "THIS IS WRONG"). Writing uncompressed
-sidesteps it. Files are roughly 3.8× larger than DOS originals
-(~1.4 MB vs ~367 KB for a saved level). **DOS `UW.EXE` cannot load these
-files.** Cross-compat is a follow-up; finish `RepackUW2` first.
+**UW2 save is UI-gated pending upstream compressor.** The `SaveGame.Save`
+orchestrator and all UW2 writers are still present and tested — they produce
+files that round-trip through the port's own loader — but the Save button
+in the UW2 Options menu refuses to invoke them. Rationale: the port's
+`RepackUW2` is a stub, and writing uncompressed UW2 blocks (which load
+fine in the port) causes DOS `UW.EXE` to crash on any save with >80
+uncompressed blocks. Once the upstream compressor lands, remove the gate.
+
+**UW1 save is DOS-compatible in format.** UW1 `lev.ark` is uncompressed by
+spec, so the compression issue doesn't apply. DOS round-trip compatibility
+has been format-checked but not yet verified by an end-to-end DOSBox test
+— that is the next validation step.
 
 **No atomic write.** If `File.WriteAllBytes` fails mid-sequence (disk full,
 permission loss), `SAVE{n}/` is left in a partial state that the loader may
 crash on. Mitigation: write all files to `SAVE{n}.tmp/` then
 `Directory.Move` on success. Not implemented.
 
-**Automap visited-tile state and map-notes pass through from the source
-ARK.** If the player walked new tiles since last level-load, those visited
-tiles are not yet saved back to `lev.ark` automap block. UW1 same issue.
-Requires serialising `automap.automaps[i]` and `automapnote.automapsnotes[i]`
-back into ARK blocks `i+27`/`i+36` (UW1) or `i+160`/`i+240` (UW2).
+**Automap visited-tile state passes through from source ARK.** Map notes
+ARE now persisted (see `LevArkWriter` automap-notes reconstruction), but
+visited-tile shading is not: requires serialising `automap.automaps[i]`
+back into ARK blocks `i+27` (UW1) or `i+160` (UW2). Noted as follow-up.
 
 **UI polish.** Description fallback is `"Save {slot}"`; no text-input prompt
 for custom descriptions. Existing slot DESC is reused on overwrite. Save-menu

--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -1,0 +1,177 @@
+# Save-game architecture
+
+This document describes the save-game write path added in the `feat/save-game`
+branch. It covers scope, the design choice made (Option B), where the code
+lives, known limitations, and follow-up work.
+
+## What ships
+
+`SaveGame.Save(int slot, string description)` writes five files to
+`{BasePath}/SAVE{slot}/`:
+
+| File | Written for | Produced by |
+|---|---|---|
+| `DESC` | UW1, UW2 | Inline in `SaveGame.Save` (plain ASCII) |
+| `PLAYER.DAT` | UW1, UW2 | `PlayerDatWriter.Serialize()` |
+| `BGLOBALS.DAT` | UW1, UW2 | `BGlobalWriter.Serialize()` |
+| `LEV.ARK` | UW1, UW2 | `LevArkWriter.Serialize()` |
+| `SCD.ARK` | UW2 only | `ScdArkWriter.Serialize(folder)` |
+
+UI entry point is the `Save Game` button in the in-game Options panel
+(`uimanager_options.cs` case 0 under `MainOptionMenu`). It reuses the existing
+slot-picker UI that was already wired for Restore.
+
+## Design choice: Option B — consolidate at save-time
+
+The DOS game did save as a **two-tier** process:
+
+1. Live code continuously wrote partial state to `DATA/` during play —
+   `bglobals.dat` on `ExitConversation`, `scd.ark` every ~20 minutes in
+   `PlayerUpdates`, `lev.ark` map-notes on map-close, etc.
+2. The "Save" menu then orchestrated `SaveLoadPlayerDat` + `SaveLEVARK` for the
+   current level, and finally `CopySaveGameFiles` cloned the whole `DATA/`
+   tree into `SAVE{n}/`.
+
+We chose **Option B: consolidate at save-time**. `SaveGame.Save` writes all
+files from the in-memory representation in one pass; there is no live
+writeback to `DATA/` during gameplay. Rationale:
+
+- The port already keeps every relevant slice of state in RAM (`pdat`,
+  `bGlobals[]`, `dungeons[i].lev_ark_block.Data`, `scd.scd_data[]`).
+- Mirroring the DOS two-tier flow would require scattering write hooks across
+  many unrelated gameplay code paths (conversations, map UI, `PlayerUpdates`
+  ticker).
+- Success criterion for MVP is **round-trip through the port's own loader**,
+  not cross-compatibility with DOS `UW.EXE`.
+
+## Why writing live state is more than "encrypt and dump `pdat`"
+
+The port keeps **two redundant copies** of the player's position at runtime:
+
+- `playerdat.pdat` — the serialised player.dat in memory, loaded at game
+  start, read by chargen, never updated during play.
+- `motion.playerMotionParams` (live X/Y/Z/heading) and
+  `UWTileMap.current_tilemap.LevelObjects[1]` (live player-object record) —
+  updated every frame by motion, pickup, teleport, etc.
+
+The write path therefore **stashes live state into `pdat` before encrypting**
+(see `SaveGame.StashLiveStateToPdat`). This copies:
+
+- `motion.playerMotionParams.{x_0, y_2, z_4}` → `pdat.{XCoordinate, YCoordinate, Z}`
+- `motion.PlayerHeadingMinor_dseg_8294` → `pdat[0x5B]`
+- `motion.playerMotionParams.tilestate25` → high 5 bits of
+  `pdat.RelatedToMotionState` (swim bits kept from pdat, which motion updates
+  directly)
+- 27-byte `LevelObjects[1]` record → `pdat[PlayerObjectStoragePTR..]`
+  (inverse of the load-time copy in `uimanager_mainmenu.JourneyOnwards`)
+
+Without this stash, a fresh chargen's zero-initialised `pdat` fields end up
+on disk, and restoring produces a player at tile (0, 0) that crashes motion
+physics with `Invalid PTR in GetTileByPTR -260`.
+
+## Loader quirks the writer mirrors
+
+**`player.dat` file length.** The load loop in `playerdatutil.cs:Load`
+starts `oIndex = 1` at `CurrentInventoryPtr = InventoryPtr`, so slot `i`
+lives at `PTR = InventoryPtr + (i-1)*8`. `N` populated slots occupy `N*8`
+bytes past `InventoryPtr` — file length is `InventoryPtr + N*8`, not
+`InventoryPtr + (N+1)*8`. (See commit `cf2c359`.)
+
+**`bglobals.dat` format.** Repeating `{Int16 ConversationNo; Int16 Size;
+Size × Int16 Globals}` until EOF. No header, no footer, little-endian.
+(`uw-formats (Abysmal).txt` §7.2.)
+
+**`lev.ark` container (UW2).** Header is `[Int32 count][2 bytes padding]
+[offsets×N][compressionFlags×N][dataLengths×N][reservedSpace×N]` then block
+data at the recorded offsets. Loader reads the per-block compression flag
+and dispatches — flag `0 == UW2_NOCOMPRESSION` is valid.
+
+**`lev.ark` container (UW1).** Simpler: `[Int16 count][offsets×N]` then block
+data. No per-block metadata; the caller supplies `targetDataLen`. The writer
+computes each block's length as `offset[i+1] - offset[i]` (or `fileLen -
+offset[i]` for the last present block) so non-tilemap blocks (overlay,
+texmap, automap, notes) round-trip correctly.
+
+**`scd.ark`.** UW2-only. 16-block UW2-format ARK container. Because the
+port's SCD loader is lazy and null-sets blocks after processing, there is no
+persistent source buffer — the writer takes a `sourceFolder` argument and
+re-reads unmutated blocks from disk at save time.
+
+## Known limitations
+
+**UW2 lev.ark is written uncompressed (compression flag = 0).** The port's
+`RepackUW2` compressor in `dataloader.cs:148` is a documented stub (copy-
+record logic commented out as "THIS IS WRONG"). Writing uncompressed
+sidesteps it. Files are roughly 3.8× larger than DOS originals
+(~1.4 MB vs ~367 KB for a saved level). **DOS `UW.EXE` cannot load these
+files.** Cross-compat is a follow-up; finish `RepackUW2` first.
+
+**No atomic write.** If `File.WriteAllBytes` fails mid-sequence (disk full,
+permission loss), `SAVE{n}/` is left in a partial state that the loader may
+crash on. Mitigation: write all files to `SAVE{n}.tmp/` then
+`Directory.Move` on success. Not implemented.
+
+**Automap visited-tile state and map-notes pass through from the source
+ARK.** If the player walked new tiles since last level-load, those visited
+tiles are not yet saved back to `lev.ark` automap block. UW1 same issue.
+Requires serialising `automap.automaps[i]` and `automapnote.automapsnotes[i]`
+back into ARK blocks `i+27`/`i+36` (UW1) or `i+160`/`i+240` (UW2).
+
+**UI polish.** Description fallback is `"Save {slot}"`; no text-input prompt
+for custom descriptions. Existing slot DESC is reused on overwrite. Save-menu
+dispatches the first click with no confirm-overwrite.
+
+**No gravestone trick.** The DOS save path pushed the player into the
+current tile's object list as `item_id = 63` (gravestone) at save time, then
+reloaded `player.dat` to restore live state. We skip this because the port
+takes player position from `player.dat` at restore, not from a gravestone in
+the level. Two follow-ons flow from this:
+
+- A restore inserts `LevelObjects[1]` (player) into the saved tile's object
+  list via `PlacePlayerInTile`. The player's own adventurer sprite renders
+  at their position unless filtered — fixed by early-return in
+  `ObjectCreator.RenderObject` when `obj.index == 1` (commit `3d46427`).
+- Motion also inserts the player into every new tile during walking
+  (`motion_player.cs:282`). Saved state preserves that, so the restore's
+  `PlacePlayerInTile` would double-insert and create a `LevelObjects[1].next
+  = 1` self-loop on slot 1 — fix is an idempotent head-check
+  (commit `e17a022`).
+
+## Testing
+
+`tests/Underworld.Save.Tests/` (xUnit, shares `[Collection("UWClassState")]`
+for serialised static-state mutation):
+
+- **BGlobalRoundTripTests**: real UW2/SAVE0 fixture round-trip + empty/one-slot
+  boundary cases.
+- **PlayerDatRoundTripTests**: UW1 and UW2 `InitEmptyPlayer` → serialise →
+  decrypt → byte-compare in populated region.
+- **LevArkRoundTripTests**: per-block extraction round-trip, full-container
+  round-trip (UW1 + UW2), and a visited-level test that seeds `dungeons[0]`
+  with a known byte to verify the live-state path.
+- **ScdArkRoundTripTests**: UW2/SAVE0 real-fixture round-trip.
+- **SaveGameOrchestratorTests**: all-five-files UW2 happy path, UW1
+  SCD.ARK-absent case, invalid-slot throws, DESC byte-content checks.
+
+23 tests total. Manual playthrough on UW1 and UW2 validated at the end: new
+game → move → drop item → save → quit → restore → state preserved.
+
+## Files
+
+```
+src/savegame/
+├── SaveGame.cs         — public orchestrator (Save + StashLiveStateToPdat)
+├── BGlobalWriter.cs    — bglobals.dat format writer
+├── PlayerDatWriter.cs  — player.dat format writer (UW1/UW2)
+├── LevArkWriter.cs     — lev.ark container writer (UW1/UW2)
+└── ScdArkWriter.cs     — scd.ark container writer (UW2)
+
+src/ui/uimanager_options.cs          — wired Save button (case 0), try/catch
+src/player/playerdatobject.cs        — idempotent PlacePlayerInTile fix
+src/utility/ObjectCreator.cs         — skip rendering LevelObjects[1]
+src/ui/uimanager_flasks.cs           — null guards for test-context callers
+
+tests/Underworld.Save.Tests/         — 23 tests
+docs/superpowers/plans/2026-04-19-save-game.md   — original plan
+docs/save-architecture.md            — this document
+```

--- a/src/World/automapnotes.cs
+++ b/src/World/automapnotes.cs
@@ -31,21 +31,21 @@ namespace Underworld
         }
         public automapnote(int LevelNo, int gameNo)
         {
-            int blockno;  
-            int noOfPossibleBlocks; 
-            int thisAddress;        
+            int blockno;
+            int noOfPossibleBlocks;
+            int thisAddress;
             int startblock;
             if (gameNo == GAME_UW2)
             {
                 blockno = 240 + LevelNo;
-                noOfPossibleBlocks = 80;  
-                startblock =240;              
+                noOfPossibleBlocks = 80;
+                startblock =240;
             }
             else
             {
                 blockno = LevelNo + 36;
-                noOfPossibleBlocks = 9; 
-                startblock = 36;              
+                noOfPossibleBlocks = 9;
+                startblock = 36;
             }
             thisAddress = GetBlockAddress(blockno, LevArkLoader.lev_ark_file_data);
             if (thisAddress==0)
@@ -68,15 +68,15 @@ namespace Underworld
                     }
                 }
             }
-            
-            
-            
+
+
+
             if (DataLoader.LoadUWBlock(LevArkLoader.lev_ark_file_data, blockno, EOF-thisAddress, out UWBlock block))
             {
                 var addptr = 0;
                 int counter =0;
                 var NoOfNotes = block.Data.GetUpperBound(0) / 54;
-                while ((addptr<= block.Data.GetUpperBound(0)) && (counter<NoOfNotes))  
+                while ((addptr<= block.Data.GetUpperBound(0)) && (counter<NoOfNotes))
                 {
                     //construct note
                     if (block.Data[addptr]!='\0')//if not null
@@ -85,7 +85,7 @@ namespace Underworld
                         var nextchar = (char)block.Data[addptr];
                         var fullstring = "";
                         while ((charptr<0x31) && (nextchar!='\0'))
-                        {                            
+                        {
                             fullstring+=(char)block.Data[addptr+charptr];
                             charptr++;
                             nextchar= (char)block.Data[addptr+charptr];
@@ -96,8 +96,46 @@ namespace Underworld
                     }
                     addptr+=54;
                     counter++;
-                }                        
+                }
             }
+        }
+
+        /// <summary>
+        /// Parameterless constructor for tests and for writer flows that populate
+        /// the notes list independently of lev.ark load.
+        /// </summary>
+        public automapnote() { }
+
+        /// <summary>
+        /// Serialises the notes list back to the 54-byte-per-record block layout
+        /// used in lev.ark map-notes blocks (UW1 blocks 36..44, UW2 blocks 240..319).
+        /// Each record: zero-terminated string from offset 0 (max 0x31 bytes),
+        /// Int16 posX at offset 0x32, Int16 posY at offset 0x34.
+        /// Returns an empty byte array when there are no notes.
+        /// </summary>
+        public byte[] Serialize()
+        {
+            if (notes == null || notes.Count == 0) return System.Array.Empty<byte>();
+
+            byte[] output = new byte[notes.Count * 54];
+            for (int i = 0; i < notes.Count; i++)
+            {
+                int recordStart = i * 54;
+                var n = notes[i];
+                string text = n.notetext ?? "";
+
+                int copyLen = System.Math.Min(text.Length, 0x31);
+                for (int c = 0; c < copyLen; c++)
+                {
+                    output[recordStart + c] = (byte)text[c];
+                }
+
+                output[recordStart + 0x32] = (byte)(n.posX & 0xFF);
+                output[recordStart + 0x33] = (byte)((n.posX >> 8) & 0xFF);
+                output[recordStart + 0x34] = (byte)(n.posY & 0xFF);
+                output[recordStart + 0x35] = (byte)((n.posY >> 8) & 0xFF);
+            }
+            return output;
         }    
 
         public class mapnotetext:UWClass

--- a/src/World/automapnotes.cs
+++ b/src/World/automapnotes.cs
@@ -75,7 +75,7 @@ namespace Underworld
             {
                 var addptr = 0;
                 int counter =0;
-                var NoOfNotes = block.Data.GetUpperBound(0) / 54;
+                var NoOfNotes = block.Data.Length / 54;
                 while ((addptr<= block.Data.GetUpperBound(0)) && (counter<NoOfNotes))
                 {
                     //construct note

--- a/src/player/playerdat.cs
+++ b/src/player/playerdat.cs
@@ -515,6 +515,32 @@ namespace Underworld
             }
         }
 
+        /// <summary>
+        /// UW1 graphics-detail level (DOS Options menu setting). Stored in
+        /// bits 4-5 of pdat[0xB6] in UW1 (untouched-by-port until 2026-04-25,
+        /// which left fresh-chargen saves at LOW detail when round-tripped
+        /// through DOS UW.EXE — walls/floor/ceiling rendered as flat
+        /// untextured polygons in the 3D viewport).
+        /// 0 = LOW (no textures), 1 = MEDIUM (walls textured),
+        /// 2 = HIGH (walls + floor), 3 = VERY HIGH (walls + floor + ceiling).
+        /// DOS UW.EXE chargen defaults to 3. UW2 storage TBD.
+        /// </summary>
+        public static int DetailLevel
+        {
+            get
+            {
+                if (_RES == GAME_UW2) return 3;
+                return (GetAt(0xB6) >> 4) & 0x3;
+            }
+            set
+            {
+                if (_RES == GAME_UW2) return;
+                var tmp = GetAt(0xB6) & 0xCF;
+                tmp |= (value & 0x3) << 4;
+                SetAt(0xB6, (byte)tmp);
+            }
+        }
+
         public static bool SoundEffectsEnabled
         {
             get

--- a/src/player/playerdat.cs
+++ b/src/player/playerdat.cs
@@ -523,21 +523,35 @@ namespace Underworld
         /// untextured polygons in the 3D viewport).
         /// 0 = LOW (no textures), 1 = MEDIUM (walls textured),
         /// 2 = HIGH (walls + floor), 3 = VERY HIGH (walls + floor + ceiling).
-        /// DOS UW.EXE chargen defaults to 3. UW2 storage TBD.
+        /// DOS UW.EXE chargen defaults to 3. UW2 storage is at pdat[0x303] bits 4-5.
         /// </summary>
         public static int DetailLevel
         {
             get
             {
-                if (_RES == GAME_UW2) return 3;
-                return (GetAt(0xB6) >> 4) & 0x3;
+                if (_RES == GAME_UW2)
+                {
+                    return (GetAt(0x303) >> 4) & 0x3;
+                } 
+                else
+                {
+                    return (GetAt(0xB6) >> 4) & 0x3;    
+                }                
             }
             set
             {
-                if (_RES == GAME_UW2) return;
-                var tmp = GetAt(0xB6) & 0xCF;
-                tmp |= (value & 0x3) << 4;
-                SetAt(0xB6, (byte)tmp);
+                if (_RES == GAME_UW2)
+                {
+                    var tmp = GetAt(0x303) & 0xCF;
+                    tmp |= (value & 0x3) << 4;
+                    SetAt(0x303, (byte)tmp);
+                }
+                else
+                {
+                    var tmp = GetAt(0xB6) & 0xCF;
+                    tmp |= (value & 0x3) << 4;
+                    SetAt(0xB6, (byte)tmp);
+                }
             }
         }
 

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -227,6 +227,13 @@ namespace Underworld
             if (_RES != GAME_UW2)
             {
                 DetailLevel = 3;
+
+                // pdat[0xD3] = 0x08 — undocumented byte that DOS UW.EXE
+                // chargen sets and Journey-Onward validates. Leaving it 0
+                // (port default) hangs the DOS load before the inventory/
+                // paperdoll UI populates. Empirically pinned by byte-diff
+                // against a fresh-chargen DOS save with matched state.
+                SetAt(0xD3, 0x08);
             }
 
             //Game specific

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -220,6 +220,14 @@ namespace Underworld
             //default game options
             MusicEnabled = true;
             SoundEffectsEnabled = true;
+            // pdat[0xB6] bits 4-5 = UW1 graphics detail level
+            // (0=Low, 1=Medium, 2=High, 3=Very High). DOS UW.EXE chargen
+            // sets this to Very High; without it, DOS-loaded port saves
+            // render walls/floor/ceiling as untextured flat polygons.
+            if (_RES != GAME_UW2)
+            {
+                DetailLevel = 3;
+            }
 
             //Game specific
             if (_RES == GAME_UW2)

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -224,15 +224,27 @@ namespace Underworld
             // (0=Low, 1=Medium, 2=High, 3=Very High). DOS UW.EXE chargen
             // sets this to Very High; without it, DOS-loaded port saves
             // render walls/floor/ceiling as untextured flat polygons.
+            // Hank's 9969989 added the UW2 offset to the accessor so this
+            // single call covers both games.
             DetailLevel = 3;
             if (_RES != GAME_UW2)
             {
-                // pdat[0xD3] = 0x08 — undocumented byte that DOS UW.EXE
-                // chargen sets and Journey-Onward validates. Leaving it 0
-                // (port default) hangs the DOS load before the inventory/
-                // paperdoll UI populates. Empirically pinned by byte-diff
-                // against a fresh-chargen DOS save with matched state.
-                SetAt(0xD3, 0x08);
+                // pdat[0xD3] = ShadeCutOff (shade-table index, per @hankmorgan
+                // on PR #33: the global is named ShadeCutOff_dseg_67d6_8622
+                // in the UW2 disasm, set by OpenAndApplyShadesDat_ovr142_0;
+                // the UW1 equivalent is ovr142_0 at UW1_asm.asm:385926-386218).
+                // Indexes shades.dat: 0=Darkness, 1=Burning Match,
+                // 2=Candlelight, 3=Light, 4=Magic Lantern, 5=Night Vision,
+                // 6=Daylight, 7=Sunlight. SHADES.DAT is exactly 96 bytes
+                // (8 entries × 12 bytes); valid range 0..7. DOS chargen
+                // default is 3 (Light). The function does NOT bound-check
+                // the input — passing 8 reads off EOF; DOS tolerates
+                // because subsequent gameplay overwrites the shading params
+                // before they're rendered. Without ANY value here (port
+                // default 0 = Darkness; functions but DOS Journey-Onward
+                // hangs in some load paths) DOS won't load. 3 is the
+                // semantically correct chargen value.
+                SetAt(0xD3, 0x03);
             }
 
             //Game specific

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -224,10 +224,9 @@ namespace Underworld
             // (0=Low, 1=Medium, 2=High, 3=Very High). DOS UW.EXE chargen
             // sets this to Very High; without it, DOS-loaded port saves
             // render walls/floor/ceiling as untextured flat polygons.
+            DetailLevel = 3;
             if (_RES != GAME_UW2)
             {
-                DetailLevel = 3;
-
                 // pdat[0xD3] = 0x08 — undocumented byte that DOS UW.EXE
                 // chargen sets and Journey-Onward validates. Leaving it 0
                 // (port default) hangs the DOS load before the inventory/

--- a/src/player/playerdatobject.cs
+++ b/src/player/playerdatobject.cs
@@ -70,15 +70,17 @@ namespace Underworld
             {
                 var tile = UWTileMap.current_tilemap.Tiles[newTileX, newTileY];
                 var obj = UWTileMap.current_tilemap.LevelObjects[1];//the player object.
-                // Idempotent insertion: if the player is already at the head of this
-                // tile's object list (e.g. on restore from a save written mid-tile),
-                // reinserting would set obj.next = 1 and create a self-loop — which
-                // hangs any later walker of the tile chain (motion, triggers, etc).
-                if (tile.indexObjectList != 1)
-                {
-                    obj.next = tile.indexObjectList;
-                    tile.indexObjectList = 1;//insert into the tile object list so it can be subject to collisions.
-                }
+                // Unlink slot 1 (player) from this tile's chain if it appears anywhere
+                // in it — otherwise inserting at head again creates a cycle. On restore
+                // from a save written while the player was in this tile, slot 1 may be:
+                //   - at the head (player last placed),
+                //   - mid-chain (NPCs moved into the tile after the player was placed),
+                //   - absent (player arrived from elsewhere).
+                // RemoveObjectFromLinkedList handles all three cases; for "absent" it
+                // walks the chain to 0 and returns false, leaving the chain intact.
+                ObjectRemover_OLD.RemoveObjectFromLinkedList(tile.indexObjectList, 1, UWTileMap.current_tilemap.LevelObjects, tile.Ptr + 2);
+                obj.next = tile.indexObjectList;
+                tile.indexObjectList = 1;//insert into the tile object list so it can be subject to collisions.
                 obj.tileX = newTileX; obj.tileY = newTileY;
                 if (_RES == GAME_UW2)
                 {

--- a/src/player/playerdatobject.cs
+++ b/src/player/playerdatobject.cs
@@ -70,8 +70,15 @@ namespace Underworld
             {
                 var tile = UWTileMap.current_tilemap.Tiles[newTileX, newTileY];
                 var obj = UWTileMap.current_tilemap.LevelObjects[1];//the player object.
-                obj.next = tile.indexObjectList;
-                tile.indexObjectList = 1;//insert into the tile object list so it can be subject to collisions.
+                // Idempotent insertion: if the player is already at the head of this
+                // tile's object list (e.g. on restore from a save written mid-tile),
+                // reinserting would set obj.next = 1 and create a self-loop — which
+                // hangs any later walker of the tile chain (motion, triggers, etc).
+                if (tile.indexObjectList != 1)
+                {
+                    obj.next = tile.indexObjectList;
+                    tile.indexObjectList = 1;//insert into the tile object list so it can be subject to collisions.
+                }
                 obj.tileX = newTileX; obj.tileY = newTileY;
                 if (_RES == GAME_UW2)
                 {

--- a/src/savegame/BGlobalWriter.cs
+++ b/src/savegame/BGlobalWriter.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Underworld
+{
+    /// <summary>
+    /// Serializes bglobal.BablGlobal[] to BGLOBALS.DAT wire format (little-endian, no header/footer).
+    /// </summary>
+    public static class BGlobalWriter
+    {
+        /// <summary>
+        /// Serialize an array of BablGlobal to BGLOBALS.DAT format.
+        /// Format (little-endian, repeating until EOF):
+        /// - Int16 ConversationNo
+        /// - Int16 Size (number of globals in this slot)
+        /// - Size × Int16 globals
+        /// </summary>
+        public static byte[] Serialize(bglobal.BablGlobal[] globals)
+        {
+            using var ms = new MemoryStream();
+            using var bw = new BinaryWriter(ms);
+
+            foreach (var g in globals)
+            {
+                bw.Write(g.ConversationNo);
+                bw.Write(g.Size);
+                for (int i = 0; i < g.Size; i++)
+                {
+                    bw.Write(g.Globals[i]);
+                }
+            }
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -272,6 +272,25 @@ namespace Underworld
                 }
             }
 
+            // Replace automap blocks (27..35) with the in-memory automap buffer
+            // for any visited level. DOS UW.EXE writes at least block 27 (the
+            // current level's automap) on every save; without it, UW.EXE treats
+            // the level as un-automapped and may mis-render the automap view.
+            //
+            // Each per-level automap buffer is a fixed 4096 bytes (64×64 tiles
+            // × 1 byte/tile of visited+display flags).
+            if (automap.automaps != null)
+            {
+                for (int lvl = 0; lvl < 9; lvl++)
+                {
+                    if (automap.automaps[lvl]?.buffer != null &&
+                        automap.automaps[lvl].buffer.Length == 64 * 64)
+                    {
+                        blockData[27 + lvl] = automap.automaps[lvl].buffer;
+                    }
+                }
+            }
+
             // Replace automap-note blocks (36..44) with the in-memory notes when non-empty.
             // Without this, newly-created notes are silently lost on save because
             // ExtractSourceBlock returns the pre-play bytes from the source ARK.

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -105,6 +105,18 @@ namespace Underworld
                 }
             }
 
+            // Replace automap-note blocks (240..319) with the in-memory notes when non-empty.
+            if (automapnote.automapsnotes != null)
+            {
+                for (int lvl = 0; lvl < 80; lvl++)
+                {
+                    if (automapnote.automapsnotes[lvl] != null && automapnote.automapsnotes[lvl].notes.Count > 0)
+                    {
+                        blockData[240 + lvl] = automapnote.automapsnotes[lvl].Serialize();
+                    }
+                }
+            }
+
             // ---- Step 2: compute layout ----------------------------------------
             // Header size: 4 (count) + 2 (padding) + N * (4+4+4+4) = 6 + N*16
             int headerSize = 6 + noOfBlocks * 16;
@@ -256,6 +268,20 @@ namespace Underworld
                         {
                             blockData[lvl] = SerializeLevelBlock(live);
                         }
+                    }
+                }
+            }
+
+            // Replace automap-note blocks (36..44) with the in-memory notes when non-empty.
+            // Without this, newly-created notes are silently lost on save because
+            // ExtractSourceBlock returns the pre-play bytes from the source ARK.
+            if (automapnote.automapsnotes != null)
+            {
+                for (int lvl = 0; lvl < 9; lvl++)
+                {
+                    if (automapnote.automapsnotes[lvl] != null && automapnote.automapsnotes[lvl].notes.Count > 0)
+                    {
+                        blockData[36 + lvl] = automapnote.automapsnotes[lvl].Serialize();
                     }
                 }
             }

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -1,0 +1,270 @@
+using System;
+using System.IO;
+
+namespace Underworld
+{
+    // UW2 LEV.ARK container header layout (verified from DataLoader.LoadUWBlock):
+    //
+    //   Bytes 0-3:              NoOfBlocks (Int32 LE)
+    //   Bytes 4-5:              2 padding/unknown bytes (0x0000 in all observed files)
+    //   Bytes 6 .. 6+(N*4)-1:  offsets[N]          (N × Int32 LE; 0 = block absent)
+    //   Bytes 6+(N*4) ..
+    //          6+(N*8)-1:       compressionFlags[N] (N × Int32 LE; 0=none, 2=compressed)
+    //   Bytes 6+(N*8) ..
+    //          6+(N*12)-1:      dataLengths[N]      (N × Int32 LE; uncompressed length)
+    //   Bytes 6+(N*12) ..
+    //          6+(N*16)-1:      reservedSpace[N]    (N × Int32 LE)
+    //   Then block data at each recorded offset.
+    //
+    // UW1 LEV.ARK container header layout (default case in DataLoader.LoadUWBlock):
+    //   Bytes 0-1:              NoOfBlocks (Int16 LE)
+    //   Bytes 2 .. 2+(N*4)-1:  offsets[N]          (N × Int32 LE; 0 = block absent)
+    //   Block data follows immediately after the offset table.
+    //   No per-block metadata; targetDataLen is passed in by the caller.
+    //
+    // For UW2 we always write uncompressed blocks (compressionFlag = 0) to avoid the
+    // incomplete RepackUW2 compressor.  The loader handles uncompressed blocks at
+    // DataLoader.cs:418-422.
+
+    /// <summary>
+    /// Rebuilds a LEV.ARK container from in-memory game state.
+    /// Visited levels use UWTileMap.dungeons[i].lev_ark_block.Data directly.
+    /// Unvisited levels pass through from LevArkLoader.lev_ark_file_data.
+    /// </summary>
+    public static class LevArkWriter
+    {
+        // UW2 per-level block size (tilemap + animation overlay)
+        private const int UW2BlockSize = 0x8000;
+        // UW1 per-level block size
+        private const int UW1BlockSize = UWTileMap.TileMapDataSize; // 0x7C08
+
+        /// <summary>
+        /// Serialize one level block (UWBlock) to the raw bytes that should be
+        /// stored in the ARK container.  For UW2 the result is exactly 0x8000 bytes;
+        /// for UW1 it is TileMapDataSize bytes.
+        /// </summary>
+        public static byte[] SerializeLevelBlock(UWBlock block)
+        {
+            int targetSize = (UWClass._RES == UWClass.GAME_UW2) ? UW2BlockSize : UW1BlockSize;
+            byte[] result = new byte[targetSize];
+            if (block?.Data != null)
+            {
+                int copyLen = Math.Min(block.Data.Length, targetSize);
+                Buffer.BlockCopy(block.Data, 0, result, 0, copyLen);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Rebuild the full LEV.ARK container from current game state.
+        /// Returns the raw bytes ready to write to disk as SAVE{n}/LEV.ARK.
+        /// </summary>
+        public static byte[] Serialize()
+        {
+            return UWClass._RES == UWClass.GAME_UW2
+                ? AssembleUW2Ark()
+                : AssembleUW1Ark();
+        }
+
+        // -----------------------------------------------------------------------
+        // UW2 writer
+        // -----------------------------------------------------------------------
+
+        private static byte[] AssembleUW2Ark()
+        {
+            // UW2 block layout: 80 levels × 4 slot types = 320 blocks.
+            //   blocks   0..79  = tilemap+overlay for level 0..79
+            //   blocks  80..159 = texmap for level 0..79
+            //   blocks 160..239 = automap for level 0..79
+            //   blocks 240..319 = notes for level 0..79
+
+            int noOfBlocks = 320;
+
+            // ---- Step 1: gather each block's raw bytes -------------------------
+            byte[][] blockData = new byte[noOfBlocks][];
+
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                UWBlock src = ExtractSourceBlock(i, targetLen: -1);
+                blockData[i] = src?.Data; // null means absent (address == 0)
+            }
+
+            // For visited levels, replace the tilemap block (index 0..79) with live data.
+            if (UWTileMap.dungeons != null)
+            {
+                for (int lvl = 0; lvl < UWTileMap.NO_OF_LEVELS; lvl++)
+                {
+                    if (UWTileMap.dungeons[lvl] != null)
+                    {
+                        UWBlock live = UWTileMap.dungeons[lvl].lev_ark_block;
+                        if (live?.Data != null)
+                        {
+                            blockData[lvl] = SerializeLevelBlock(live);
+                        }
+                    }
+                }
+            }
+
+            // ---- Step 2: compute layout ----------------------------------------
+            // Header size: 4 (count) + 2 (padding) + N * (4+4+4+4) = 6 + N*16
+            int headerSize = 6 + noOfBlocks * 16;
+            int[] offsets = new int[noOfBlocks];
+            int[] flags = new int[noOfBlocks];
+            int[] lengths = new int[noOfBlocks];
+            int[] reserved = new int[noOfBlocks];
+
+            // The source ARK's reservedSpace values — preserve them.
+            // (They are read from source block metadata at load time.)
+            byte[] source = LevArkLoader.lev_ark_file_data;
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                // Read reservedSpace from source header if available.
+                int srcReserved = 0;
+                if (source != null && source.Length >= 6 + noOfBlocks * 16)
+                {
+                    int srcNoOfBlocks = (int)Loader.getAt(source, 0, 32);
+                    if (srcNoOfBlocks == noOfBlocks)
+                    {
+                        srcReserved = (int)Loader.getAt(source,
+                            6 + (i * 4) + (noOfBlocks * 12), 32);
+                    }
+                }
+                reserved[i] = srcReserved;
+            }
+
+            // Assign offsets: layout all present blocks sequentially after header.
+            int cursor = headerSize;
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                {
+                    offsets[i] = cursor;
+                    flags[i] = DataLoader.UW2_NOCOMPRESSION; // 0 — uncompressed
+                    lengths[i] = blockData[i].Length;
+                    cursor += blockData[i].Length;
+                }
+                else
+                {
+                    offsets[i] = 0;
+                    flags[i] = 0;
+                    lengths[i] = 0;
+                }
+            }
+
+            // ---- Step 3: write output ------------------------------------------
+            using var ms = new MemoryStream(cursor);
+            using var bw = new BinaryWriter(ms);
+
+            // Header: count (Int32) + padding (Int16)
+            bw.Write((int)noOfBlocks);
+            bw.Write((short)0); // 2 padding bytes
+
+            // Offsets table
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(offsets[i]);
+            // Compression flags table
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(flags[i]);
+            // Data lengths table
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(lengths[i]);
+            // Reserved space table
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(reserved[i]);
+
+            // Block data
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                {
+                    bw.Write(blockData[i]);
+                }
+            }
+
+            return ms.ToArray();
+        }
+
+        // -----------------------------------------------------------------------
+        // UW1 writer
+        // -----------------------------------------------------------------------
+
+        private static byte[] AssembleUW1Ark()
+        {
+            // UW1 block layout: 9 levels × 15 slot types = 135 blocks.
+            //   blocks  0..8   = level tilemap
+            //   blocks  9..17  = per-level overlay
+            //   blocks 18..26  = texmap
+            //   blocks 27..35  = automap
+            //   blocks 36..44  = notes
+            //   blocks 45..134 = unused
+
+            int noOfBlocks = 135;
+            byte[][] blockData = new byte[noOfBlocks][];
+
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                int tLen = (i < 9) ? UW1BlockSize : 0;
+                UWBlock src = ExtractSourceBlock(i, targetLen: tLen);
+                blockData[i] = src?.Data;
+            }
+
+            // Replace visited tilemap blocks with live dungeon data.
+            if (UWTileMap.dungeons != null)
+            {
+                for (int lvl = 0; lvl < UWTileMap.NO_OF_LEVELS; lvl++)
+                {
+                    if (UWTileMap.dungeons[lvl] != null)
+                    {
+                        UWBlock live = UWTileMap.dungeons[lvl].lev_ark_block;
+                        if (live?.Data != null)
+                        {
+                            blockData[lvl] = SerializeLevelBlock(live);
+                        }
+                    }
+                }
+            }
+
+            // Header: 2-byte count + N × 4-byte offsets
+            int headerSize = 2 + noOfBlocks * 4;
+            int[] offsets = new int[noOfBlocks];
+            int cursor = headerSize;
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                {
+                    offsets[i] = cursor;
+                    cursor += blockData[i].Length;
+                }
+                else
+                {
+                    offsets[i] = 0;
+                }
+            }
+
+            using var ms = new MemoryStream(cursor);
+            using var bw = new BinaryWriter(ms);
+
+            bw.Write((short)noOfBlocks);
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(offsets[i]);
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                    bw.Write(blockData[i]);
+            }
+
+            return ms.ToArray();
+        }
+
+        // -----------------------------------------------------------------------
+        // Helpers
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Extract block <paramref name="blockNo"/> from the source ARK file data.
+        /// Returns null if the block is absent (address == 0).
+        /// </summary>
+        private static UWBlock ExtractSourceBlock(int blockNo, int targetLen)
+        {
+            byte[] src = LevArkLoader.lev_ark_file_data;
+            if (src == null) return null;
+            DataLoader.LoadUWBlock(src, blockNo, targetLen, out UWBlock uwb);
+            return (uwb.DataLen > 0) ? uwb : null;
+        }
+    }
+}

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -197,9 +197,49 @@ namespace Underworld
             int noOfBlocks = 135;
             byte[][] blockData = new byte[noOfBlocks][];
 
+            // For UW1, LoadUWBlock (default case) requires the caller to supply targetDataLen
+            // because the format has no per-block length metadata — only an offset table.
+            // We compute each block's length as offset[i+1] - offset[i] (or fileLen - offset[i]
+            // for the last present block).  This handles all block types (tilemap, overlay,
+            // texmap, automap, notes) correctly without hard-coding per-type sizes.
+            byte[] uw1Src = LevArkLoader.lev_ark_file_data;
+            int uw1HeaderBlocks = (uw1Src != null) ? (int)Loader.getAt(uw1Src, 0, 16) : noOfBlocks;
+            int uw1HeaderSize = 2 + uw1HeaderBlocks * 4;
+
             for (int i = 0; i < noOfBlocks; i++)
             {
-                int tLen = (i < 9) ? UW1BlockSize : 0;
+                int tLen;
+                if (i < 9)
+                {
+                    tLen = UW1BlockSize;
+                }
+                else if (uw1Src == null || i >= uw1HeaderBlocks)
+                {
+                    tLen = 0;
+                }
+                else
+                {
+                    // Read this block's offset and find the next non-zero offset to compute length.
+                    int thisOff = (int)Loader.getAt(uw1Src, 2 + i * 4, 32);
+                    if (thisOff == 0)
+                    {
+                        tLen = 0; // absent block
+                    }
+                    else
+                    {
+                        int nextOff = uw1Src.Length; // default: run to end of file
+                        for (int j = i + 1; j < uw1HeaderBlocks; j++)
+                        {
+                            int candidate = (int)Loader.getAt(uw1Src, 2 + j * 4, 32);
+                            if (candidate > thisOff)
+                            {
+                                nextOff = candidate;
+                                break;
+                            }
+                        }
+                        tLen = nextOff - thisOff;
+                    }
+                }
                 UWBlock src = ExtractSourceBlock(i, targetLen: tLen);
                 blockData[i] = src?.Data;
             }

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -15,7 +15,10 @@ namespace Underworld
         public static byte[] Serialize()
         {
             int lastSlot = LastPopulatedInventorySlot();
-            int fileLen = playerdat.InventoryPtr + (lastSlot + 1) * 8;
+            // Slot i is stored at PTR = InventoryPtr + (i-1)*8 per the load loop in
+            // playerdatutil.cs:Load which starts oIndex=1 at CurrentInventoryPtr=InventoryPtr.
+            // So N populated slots occupy [InventoryPtr, InventoryPtr + N*8).
+            int fileLen = playerdat.InventoryPtr + lastSlot * 8;
 
             // pdat is oversized (InventoryPtr + 512*8) after load; trim to real file length.
             byte[] plain = new byte[fileLen];

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Underworld
+{
+    /// <summary>
+    /// Serialises playerdat.pdat to on-disk player.dat format, applying the
+    /// game-specific encryption. UW1 encrypts bytes 1..210 (0xD2) via XOR;
+    /// UW2 encrypts bytes 1..0x37D via an 80-byte chained cipher and copies
+    /// 0x37E..EOF verbatim. Inventory lives in pdat from InventoryPtr onward.
+    /// See src/player/playerdatutil.cs for the inverse (load) routines; the
+    /// EncryptDecryptUW1 and EncryptDecryptUW2 functions there are symmetric.
+    /// </summary>
+    public static class PlayerDatWriter
+    {
+        public static byte[] Serialize()
+        {
+            int lastSlot = LastPopulatedInventorySlot();
+            int fileLen = playerdat.InventoryPtr + (lastSlot + 1) * 8;
+
+            // pdat is oversized (InventoryPtr + 512*8) after load; trim to real file length.
+            byte[] plain = new byte[fileLen];
+            Array.Copy(playerdat.pdat, plain, fileLen);
+
+            byte seed = plain[0];
+
+            return Loader._RES == Loader.GAME_UW2
+                ? playerdat.EncryptDecryptUW2(plain, seed)
+                : playerdat.EncryptDecryptUW1(plain, seed);
+        }
+
+        /// <summary>
+        /// Returns the highest index i where playerdat.InventoryObjects[i] != null.
+        /// Returns 0 if no slots are populated (slot 0 is unused by convention — see
+        /// the load loop in playerdatutil.cs which starts oIndex at 1).
+        /// </summary>
+        public static int LastPopulatedInventorySlot()
+        {
+            var inv = playerdat.InventoryObjects;
+            for (int i = inv.GetUpperBound(0); i >= 1; i--)
+            {
+                if (inv[i] != null) return i;
+            }
+            return 0;
+        }
+    }
+}

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -175,6 +175,12 @@ namespace Underworld
             return playerdat.EncryptDecryptUW1(plain, seed);
         }
 
+        // Hard cap on emitted slots — defends against a pathological source
+        // chain (cycle that survives remap.ContainsKey via a free-list
+        // duplicate, or a deeper-than-realistic nested-container tree) blowing
+        // the stack in VisitDfs's recursion.
+        private const int MaxInventoryEmit = 1024;
+
         // Depth-first: assign new slot to src, then walk contents (src.link +
         // sibling chain via .next) recursively. Returns src's new slot index.
         // Empty source slots (item_id=0) — left behind in the link chain by
@@ -186,6 +192,12 @@ namespace Underworld
         // tile object chain (e.g. before pickup) on non-container items.
         private static int VisitDfs(int src, List<int> order, Dictionary<int, int> remap, Dictionary<int, int> firstChildOf)
         {
+            if (order.Count >= MaxInventoryEmit)
+            {
+                throw new InvalidOperationException(
+                    $"PlayerDatWriter: inventory emission exceeded {MaxInventoryEmit} slots — " +
+                    "likely a cycle or unbounded nesting in the source chain.");
+            }
             order.Add(src);
             int newIdx = order.Count;
             remap[src] = newIdx;

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -98,6 +98,8 @@ namespace Underworld
             byte[] plain = new byte[fileLen];
             Array.Copy(playerdat.pdat, plain, playerdat.InventoryPtr);
 
+            var topLevelNewSet = new HashSet<int>(topLevelNewSlots);
+
             // 3. Emit each slot's 8 bytes at its new location, remapping next/link.
             for (int newIdx = 1; newIdx <= newLast; newIdx++)
             {
@@ -106,19 +108,40 @@ namespace Underworld
                 int dstOff = playerdat.InventoryPtr + (newIdx - 1) * 8;
                 Array.Copy(playerdat.pdat, srcOff, plain, dstOff, 8);
 
-                // Close any opened sacks in the saved inventory. UW1 toggles
-                // a sack's classindex bit 0 (item_id 128 closed → 129 open)
-                // when the player double-clicks it; the open state is a UI
-                // affordance that should not persist to disk. DOS UW.EXE
-                // doesn't recognise an open sack at BP0 as a valid container
-                // and renders the inventory as empty. Detect sack class
-                // (majorclass=2, minorclass=0) and force bit 0 = 0.
-                int origItemId = (plain[dstOff] | (plain[dstOff + 1] << 8)) & 0x1FF;
-                int majorclass = origItemId >> 6;
-                int minorclass = (origItemId & 0x30) >> 4;
-                if (majorclass == 2 && minorclass == 0 && (origItemId & 0x1) != 0)
+                // Close opened sacks ONLY at top-level positions (referenced
+                // by BP0..BP7 or paperdoll). UW1 toggles a sack's classindex
+                // bit 0 (item_id 128 closed → 129 open) when the player
+                // opens the bag UI; that open state is a UI affordance and
+                // must not persist on the equipped container — DOS UW.EXE
+                // sees an open BP0 sack as invalid and renders inventory
+                // empty. But for sack-class items NESTED INSIDE another
+                // container, item_id bit 0 is part of the genuine item
+                // distinction (e.g. Hank's DOS save Save4-Carrying-Backpack
+                // has id=143 in slot 3 inside the BP0 pack). Restricting
+                // the close-bit toggle to top-level prevents corrupting
+                // those nested values.
+                if (topLevelNewSet.Contains(newIdx))
                 {
-                    plain[dstOff] = (byte)(plain[dstOff] & 0xFE);
+                    int origItemId = (plain[dstOff] | (plain[dstOff + 1] << 8)) & 0x1FF;
+                    int majorclass = origItemId >> 6;
+                    int minorclass = (origItemId & 0x30) >> 4;
+                    int classindex = origItemId & 0xF;
+                    // Container-class items 128-143 are majorclass=2, minorclass=0
+                    // but only classindex 0..0xB use the bit-0 open/closed
+                    // toggle (per src/objects/container.cs:26 — open code only
+                    // fires for classindex <= 0xB). Items 140-143 (incl. the
+                    // runebag at 143) are distinct items with their own
+                    // identities, NOT open variants of 140/142 — restricting
+                    // the close-bit toggle prevents corrupting a runebag-on-
+                    // paperdoll save (143 → 142 was Hank's exact diagnostic
+                    // scenario for nested items; the same bug applies to
+                    // top-level placement).
+                    if (majorclass == 2 && minorclass == 0
+                        && classindex <= 0xB
+                        && (origItemId & 0x1) != 0)
+                    {
+                        plain[dstOff] = (byte)(plain[dstOff] & 0xFE);
+                    }
                 }
 
                 int srcNext = ExtractBits10(playerdat.pdat, srcOff + 4, 6);
@@ -192,6 +215,17 @@ namespace Underworld
         // tile object chain (e.g. before pickup) on non-container items.
         private static int VisitDfs(int src, List<int> order, Dictionary<int, int> remap, Dictionary<int, int> firstChildOf)
         {
+            // Bounds-check src BEFORE emitting it, otherwise the emit pass
+            // hits Array.Copy(pdat, srcOff, ...) and throws ArgumentException
+            // for out-of-range slot indices. is_quant skip + SkipEmpties
+            // normally prevent OOB src reaching here, but defensive: 0 is a
+            // sentinel that callers' link-rewrite logic (remap.TryGetValue
+            // returning false → 0) treats as "no slot".
+            int srcOff = InvOff(src);
+            if (srcOff < 0 || srcOff + 8 > playerdat.pdat.Length)
+            {
+                return 0;
+            }
             if (order.Count >= MaxInventoryEmit)
             {
                 throw new InvalidOperationException(
@@ -202,19 +236,34 @@ namespace Underworld
             int newIdx = order.Count;
             remap[src] = newIdx;
 
-            int child = ExtractBits10(playerdat.pdat, InvOff(src) + 6, 6); // src.link
+            int linkOff = srcOff + 6;
+            // is_quant items reuse the link bits to encode quantity / special
+            // property (NOT a slot index — see uw-formats §4.2 and Alfred's
+            // letter at item 312 with link=514 = property 2 in Hank's
+            // sample save Save4-Carrying-Backpack). Following an is_quant
+            // link as a child slot blew up the DFS prior to bounds-checking
+            // (Hank's IndexOutOfRange report on PR #33). Even with the
+            // bounds-check it's still wrong semantically — skip cleanly.
+            if (IsQuantAt(src))
+            {
+                firstChildOf[src] = 0;
+                return newIdx;
+            }
+            int child = ExtractBits10(playerdat.pdat, linkOff, 6); // src.link
             int firstVisited = 0;
             while (child != 0 && !remap.ContainsKey(child))
             {
+                int childNextOff = InvOff(child) + 4;
+                if (childNextOff + 1 >= playerdat.pdat.Length) break;
                 if (ItemIdAt(child) == 0)
                 {
                     // Hop past the empty slot via its .next without recursing.
-                    child = ExtractBits10(playerdat.pdat, InvOff(child) + 4, 6);
+                    child = ExtractBits10(playerdat.pdat, childNextOff, 6);
                     continue;
                 }
                 if (firstVisited == 0) firstVisited = child;
                 VisitDfs(child, order, remap, firstChildOf);
-                child = ExtractBits10(playerdat.pdat, InvOff(child) + 4, 6); // child.next
+                child = ExtractBits10(playerdat.pdat, childNextOff, 6); // child.next
             }
             firstChildOf[src] = firstVisited;
             return newIdx;
@@ -223,8 +272,22 @@ namespace Underworld
         private static int ItemIdAt(int slot)
         {
             int o = InvOff(slot);
+            // The link / next fields are 10-bit (slots 0..1023) but port pdat
+            // is only allocated up to InventoryPtr + 512*8. Defensive bound
+            // check belt-and-braces with the is_quant skip in VisitDfs:
+            // either path on its own should prevent OOB, both together also
+            // protect against any future edge case.
+            if (o < 0 || o + 1 >= playerdat.pdat.Length) return 0;
             int w = playerdat.pdat[o] | (playerdat.pdat[o + 1] << 8);
             return w & 0x1FF;
+        }
+
+        private static bool IsQuantAt(int slot)
+        {
+            int o = InvOff(slot);
+            if (o < 0 || o + 1 >= playerdat.pdat.Length) return false;
+            // is_quant flag = bit 15 of word 0 = bit 7 of byte 1.
+            return (playerdat.pdat[o + 1] & 0x80) != 0;
         }
 
         // Walk the source .next chain past any empty (item_id=0) slots and
@@ -235,7 +298,9 @@ namespace Underworld
             int hops = 0;
             while (slot != 0 && ItemIdAt(slot) == 0 && hops < 1024)
             {
-                slot = ExtractBits10(playerdat.pdat, InvOff(slot) + 4, 6);
+                int o = InvOff(slot) + 4;
+                if (o + 1 >= playerdat.pdat.Length) return 0;
+                slot = ExtractBits10(playerdat.pdat, o, 6);
                 hops++;
             }
             return slot;

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -94,7 +94,16 @@ namespace Underworld
             }
 
             int newLast = order.Count;
-            int fileLen = playerdat.InventoryPtr + newLast * 8;
+            // DOS UW.EXE hangs at "You reenter the Abyss..." when PLAYER.DAT
+            // ends exactly at InventoryPtr (0x138) with no inventory slots
+            // emitted. Padding to at least one zero slot (file >= 0x140) is
+            // sufficient to unstick the load path — verified empirically
+            // against UW.EXE under js-dos. A fresh port chargen with all
+            // BP0..BP7 + paperdoll pointers = 0 (no items) used to produce a
+            // 312-byte file; bumping the floor to (InventoryPtr + 8) makes it
+            // 320 bytes and DOS loads cleanly.
+            int slotsToEmit = Math.Max(newLast, 1);
+            int fileLen = playerdat.InventoryPtr + slotsToEmit * 8;
             byte[] plain = new byte[fileLen];
             Array.Copy(playerdat.pdat, plain, playerdat.InventoryPtr);
 

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -32,16 +32,23 @@ namespace Underworld
         }
 
         /// <summary>
-        /// Returns the highest index i where playerdat.InventoryObjects[i] != null.
-        /// Returns 0 if no slots are populated (slot 0 is unused by convention — see
-        /// the load loop in playerdatutil.cs which starts oIndex at 1).
+        /// Returns the highest index i where playerdat.InventoryObjects[i] refers
+        /// to an object with item_id != 0. Slots with item_id == 0 are empty and
+        /// DOS saves truncate them off the end of the file — an empty-inventory
+        /// DOS PLAYER.DAT is exactly InventoryPtr bytes long.
+        ///
+        /// Checking != null is not enough: playerdatutil.cs:Load creates a
+        /// non-null uwObject for every 8-byte chunk past InventoryPtr in the
+        /// source file, regardless of the item_id stored there. If a previous
+        /// save wrote N slots, we'd carry them forward as "populated" even
+        /// after they were cleared.
         /// </summary>
         public static int LastPopulatedInventorySlot()
         {
             var inv = playerdat.InventoryObjects;
             for (int i = inv.GetUpperBound(0); i >= 1; i--)
             {
-                if (inv[i] != null) return i;
+                if (inv[i] != null && inv[i].item_id != 0) return i;
             }
             return 0;
         }

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Underworld
 {
@@ -9,39 +10,189 @@ namespace Underworld
     /// 0x37E..EOF verbatim. Inventory lives in pdat from InventoryPtr onward.
     /// See src/player/playerdatutil.cs for the inverse (load) routines; the
     /// EncryptDecryptUW1 and EncryptDecryptUW2 functions there are symmetric.
+    ///
+    /// For UW1 we remap the inventory into DOS-canonical order before
+    /// encrypting: top-level items (BP0..BP7 containers + equipped paperdoll
+    /// items) form one unified next-chain starting at slot 1, with container
+    /// contents chained internally via link/next. Paperdoll and BP pointers
+    /// are rewritten to the new slot indices. Without this pass, DOS UW.EXE
+    /// loads bag-only but truncates the chain before reaching equipped items.
     /// </summary>
     public static class PlayerDatWriter
     {
+        // UW1 paperdoll slot-pointer offsets in emission order.
+        private static readonly int[] Uw1PaperdollOffsets =
+        {
+            0xF8, // Helm
+            0xFA, // ChestArmour
+            0xFC, // Gloves
+            0xFE, // Leggings
+            0x100,// Boots
+            0x102,// RightShoulder
+            0x104,// LeftShoulder
+            0x106,// RightHand
+            0x108,// LeftHand
+            0x10A,// RightRing
+            0x10C,// LeftRing
+        };
+
+        private const int Uw1BpOffsetBase = 0x10E;
+        private const int Uw1BpCount = 8;
+
         public static byte[] Serialize()
         {
-            int lastSlot = LastPopulatedInventorySlot();
-            // Slot i is stored at PTR = InventoryPtr + (i-1)*8 per the load loop in
-            // playerdatutil.cs:Load which starts oIndex=1 at CurrentInventoryPtr=InventoryPtr.
-            // So N populated slots occupy [InventoryPtr, InventoryPtr + N*8).
-            int fileLen = playerdat.InventoryPtr + lastSlot * 8;
+            if (Loader._RES == Loader.GAME_UW2)
+            {
+                // UW2 save format not yet DOS-round-trip verified; keep legacy
+                // straight-copy path until UW2 reference data is captured.
+                return SerializeLegacy();
+            }
 
-            // pdat is oversized (InventoryPtr + 512*8) after load; trim to real file length.
+            return SerializeUw1Canonical();
+        }
+
+        private static byte[] SerializeLegacy()
+        {
+            int lastSlot = LastPopulatedInventorySlot();
+            int fileLen = playerdat.InventoryPtr + lastSlot * 8;
             byte[] plain = new byte[fileLen];
             Array.Copy(playerdat.pdat, plain, fileLen);
-
             byte seed = plain[0];
-
             return Loader._RES == Loader.GAME_UW2
                 ? playerdat.EncryptDecryptUW2(plain, seed)
                 : playerdat.EncryptDecryptUW1(plain, seed);
         }
 
+        private static byte[] SerializeUw1Canonical()
+        {
+            // 1. Gather top-level source slots: BP0..BP7 first, then paperdoll.
+            var topLevel = new List<int>();
+            for (int bp = 0; bp < Uw1BpCount; bp++)
+            {
+                int s = GetSlotPtr(playerdat.pdat, Uw1BpOffsetBase + bp * 2);
+                if (s != 0) topLevel.Add(s);
+            }
+            foreach (int off in Uw1PaperdollOffsets)
+            {
+                int s = GetSlotPtr(playerdat.pdat, off);
+                if (s != 0) topLevel.Add(s);
+            }
+
+            // 2. Depth-first walk from each top-level root. Each visited source
+            //    slot is assigned a new slot index in emission order.
+            var order = new List<int>();         // new_slot_index -> source_slot
+            var remap = new Dictionary<int, int>(); // source_slot -> new_slot_index
+            remap[0] = 0;
+            var topLevelNewSlots = new List<int>();
+
+            foreach (int root in topLevel)
+            {
+                if (remap.ContainsKey(root)) continue; // shouldn't happen; defensive
+                int rootNew = VisitDfs(root, order, remap);
+                topLevelNewSlots.Add(rootNew);
+            }
+
+            int newLast = order.Count;
+            int fileLen = playerdat.InventoryPtr + newLast * 8;
+            byte[] plain = new byte[fileLen];
+            Array.Copy(playerdat.pdat, plain, playerdat.InventoryPtr);
+
+            // 3. Emit each slot's 8 bytes at its new location, remapping next/link.
+            for (int newIdx = 1; newIdx <= newLast; newIdx++)
+            {
+                int srcSlot = order[newIdx - 1];
+                int srcOff = playerdat.InventoryPtr + (srcSlot - 1) * 8;
+                int dstOff = playerdat.InventoryPtr + (newIdx - 1) * 8;
+                Array.Copy(playerdat.pdat, srcOff, plain, dstOff, 8);
+
+                int srcNext = ExtractBits10(playerdat.pdat, srcOff + 4, 6);
+                int srcLink = ExtractBits10(playerdat.pdat, srcOff + 6, 6);
+                int newNext = remap.TryGetValue(srcNext, out var nn) ? nn : 0;
+                int newLink = remap.TryGetValue(srcLink, out var nl) ? nl : 0;
+                WriteBits10(plain, dstOff + 4, 6, newNext);
+                WriteBits10(plain, dstOff + 6, 6, newLink);
+            }
+
+            // 4. Overwrite next for each top-level slot to form the unified chain.
+            for (int i = 0; i < topLevelNewSlots.Count; i++)
+            {
+                int myNew = topLevelNewSlots[i];
+                int myOff = playerdat.InventoryPtr + (myNew - 1) * 8;
+                int nextTop = (i + 1 < topLevelNewSlots.Count) ? topLevelNewSlots[i + 1] : 0;
+                WriteBits10(plain, myOff + 4, 6, nextTop);
+            }
+
+            // 5. Rewrite paperdoll + BP pointers to new slot indices.
+            for (int bp = 0; bp < Uw1BpCount; bp++)
+            {
+                int off = Uw1BpOffsetBase + bp * 2;
+                int oldSlot = GetSlotPtr(playerdat.pdat, off);
+                int newSlot = remap.TryGetValue(oldSlot, out var v) ? v : 0;
+                SetSlotPtr(plain, off, newSlot);
+            }
+            foreach (int off in Uw1PaperdollOffsets)
+            {
+                int oldSlot = GetSlotPtr(playerdat.pdat, off);
+                int newSlot = remap.TryGetValue(oldSlot, out var v) ? v : 0;
+                SetSlotPtr(plain, off, newSlot);
+            }
+
+            byte seed = plain[0];
+            return playerdat.EncryptDecryptUW1(plain, seed);
+        }
+
+        // Depth-first: assign new slot to src, then walk contents (src.link +
+        // sibling chain via .next) recursively. Returns src's new slot index.
+        private static int VisitDfs(int src, List<int> order, Dictionary<int, int> remap)
+        {
+            order.Add(src);
+            int newIdx = order.Count;
+            remap[src] = newIdx;
+
+            int child = ExtractBits10(playerdat.pdat, InvOff(src) + 6, 6); // src.link
+            while (child != 0 && !remap.ContainsKey(child))
+            {
+                VisitDfs(child, order, remap);
+                child = ExtractBits10(playerdat.pdat, InvOff(child) + 4, 6); // child.next
+            }
+            return newIdx;
+        }
+
+        private static int InvOff(int slot) => playerdat.InventoryPtr + (slot - 1) * 8;
+
+        // 10-bit slot pointer stored in bits 6..15 of a 16-bit word.
+        private static int GetSlotPtr(byte[] buf, int off)
+        {
+            int w = buf[off] | (buf[off + 1] << 8);
+            return (w >> 6) & 0x3FF;
+        }
+
+        private static void SetSlotPtr(byte[] buf, int off, int slot)
+        {
+            int w = buf[off] | (buf[off + 1] << 8);
+            w = (w & 0x003F) | ((slot & 0x3FF) << 6);
+            buf[off] = (byte)(w & 0xFF);
+            buf[off + 1] = (byte)((w >> 8) & 0xFF);
+        }
+
+        private static int ExtractBits10(byte[] buf, int off, int shift)
+        {
+            int w = buf[off] | (buf[off + 1] << 8);
+            return (w >> shift) & 0x3FF;
+        }
+
+        private static void WriteBits10(byte[] buf, int off, int shift, int value)
+        {
+            int w = buf[off] | (buf[off + 1] << 8);
+            int mask = 0x3FF << shift;
+            w = (w & ~mask) | ((value & 0x3FF) << shift);
+            buf[off] = (byte)(w & 0xFF);
+            buf[off + 1] = (byte)((w >> 8) & 0xFF);
+        }
+
         /// <summary>
         /// Returns the highest index i where playerdat.InventoryObjects[i] refers
-        /// to an object with item_id != 0. Slots with item_id == 0 are empty and
-        /// DOS saves truncate them off the end of the file — an empty-inventory
-        /// DOS PLAYER.DAT is exactly InventoryPtr bytes long.
-        ///
-        /// Checking != null is not enough: playerdatutil.cs:Load creates a
-        /// non-null uwObject for every 8-byte chunk past InventoryPtr in the
-        /// source file, regardless of the item_id stored there. If a previous
-        /// save wrote N slots, we'd carry them forward as "populated" even
-        /// after they were cleared.
+        /// to an object with item_id != 0. Retained for legacy path / tests.
         /// </summary>
         public static int LastPopulatedInventorySlot()
         {

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -82,13 +82,14 @@ namespace Underworld
             //    slot is assigned a new slot index in emission order.
             var order = new List<int>();         // new_slot_index -> source_slot
             var remap = new Dictionary<int, int>(); // source_slot -> new_slot_index
+            var firstChildOf = new Dictionary<int, int>(); // src_slot -> first emitted child src_slot
             remap[0] = 0;
             var topLevelNewSlots = new List<int>();
 
             foreach (int root in topLevel)
             {
                 if (remap.ContainsKey(root)) continue; // shouldn't happen; defensive
-                int rootNew = VisitDfs(root, order, remap);
+                int rootNew = VisitDfs(root, order, remap, firstChildOf);
                 topLevelNewSlots.Add(rootNew);
             }
 
@@ -105,10 +106,43 @@ namespace Underworld
                 int dstOff = playerdat.InventoryPtr + (newIdx - 1) * 8;
                 Array.Copy(playerdat.pdat, srcOff, plain, dstOff, 8);
 
+                // Close any opened sacks in the saved inventory. UW1 toggles
+                // a sack's classindex bit 0 (item_id 128 closed → 129 open)
+                // when the player double-clicks it; the open state is a UI
+                // affordance that should not persist to disk. DOS UW.EXE
+                // doesn't recognise an open sack at BP0 as a valid container
+                // and renders the inventory as empty. Detect sack class
+                // (majorclass=2, minorclass=0) and force bit 0 = 0.
+                int origItemId = (plain[dstOff] | (plain[dstOff + 1] << 8)) & 0x1FF;
+                int majorclass = origItemId >> 6;
+                int minorclass = (origItemId & 0x30) >> 4;
+                if (majorclass == 2 && minorclass == 0 && (origItemId & 0x1) != 0)
+                {
+                    plain[dstOff] = (byte)(plain[dstOff] & 0xFE);
+                }
+
                 int srcNext = ExtractBits10(playerdat.pdat, srcOff + 4, 6);
-                int srcLink = ExtractBits10(playerdat.pdat, srcOff + 6, 6);
+                srcNext = SkipEmpties(srcNext);
                 int newNext = remap.TryGetValue(srcNext, out var nn) ? nn : 0;
-                int newLink = remap.TryGetValue(srcLink, out var nl) ? nl : 0;
+                // link semantics depend on the is_quant flag (word0 bit 15):
+                //   is_quant=1  → link is a literal quantity/special property
+                //                 (NOT a slot reference). Preserve verbatim.
+                //   is_quant=0  → link is a slot reference: first child for
+                //                 containers (rewritten via firstChildOf so
+                //                 stale pickup-time pointers are cleared),
+                //                 or sp_link for leaf items (default 0).
+                int word0 = playerdat.pdat[srcOff] | (playerdat.pdat[srcOff + 1] << 8);
+                bool isQuant = (word0 & 0x8000) != 0;
+                int newLink;
+                if (isQuant)
+                {
+                    newLink = ExtractBits10(playerdat.pdat, srcOff + 6, 6);
+                }
+                else
+                {
+                    int firstChildSrc = firstChildOf.TryGetValue(srcSlot, out var fc) ? fc : 0;
+                    newLink = (firstChildSrc != 0 && remap.TryGetValue(firstChildSrc, out var nl)) ? nl : 0;
+                }
                 WriteBits10(plain, dstOff + 4, 6, newNext);
                 WriteBits10(plain, dstOff + 6, 6, newLink);
             }
@@ -143,19 +177,56 @@ namespace Underworld
 
         // Depth-first: assign new slot to src, then walk contents (src.link +
         // sibling chain via .next) recursively. Returns src's new slot index.
-        private static int VisitDfs(int src, List<int> order, Dictionary<int, int> remap)
+        // Empty source slots (item_id=0) — left behind in the link chain by
+        // pickup/drop activity that didn't compact the linked list — are
+        // skipped during the walk so the serialised output has no holes.
+        // Tracks the first DFS-visited child of each parent in firstChildOf
+        // so the emit pass can rewrite parent.link unconditionally — clearing
+        // any stale link bytes carried over from when an item was last in a
+        // tile object chain (e.g. before pickup) on non-container items.
+        private static int VisitDfs(int src, List<int> order, Dictionary<int, int> remap, Dictionary<int, int> firstChildOf)
         {
             order.Add(src);
             int newIdx = order.Count;
             remap[src] = newIdx;
 
             int child = ExtractBits10(playerdat.pdat, InvOff(src) + 6, 6); // src.link
+            int firstVisited = 0;
             while (child != 0 && !remap.ContainsKey(child))
             {
-                VisitDfs(child, order, remap);
+                if (ItemIdAt(child) == 0)
+                {
+                    // Hop past the empty slot via its .next without recursing.
+                    child = ExtractBits10(playerdat.pdat, InvOff(child) + 4, 6);
+                    continue;
+                }
+                if (firstVisited == 0) firstVisited = child;
+                VisitDfs(child, order, remap, firstChildOf);
                 child = ExtractBits10(playerdat.pdat, InvOff(child) + 4, 6); // child.next
             }
+            firstChildOf[src] = firstVisited;
             return newIdx;
+        }
+
+        private static int ItemIdAt(int slot)
+        {
+            int o = InvOff(slot);
+            int w = playerdat.pdat[o] | (playerdat.pdat[o + 1] << 8);
+            return w & 0x1FF;
+        }
+
+        // Walk the source .next chain past any empty (item_id=0) slots and
+        // return the first non-empty slot index (or 0 if the chain ends in
+        // empties). Defends against unbounded chains.
+        private static int SkipEmpties(int slot)
+        {
+            int hops = 0;
+            while (slot != 0 && ItemIdAt(slot) == 0 && hops < 1024)
+            {
+                slot = ExtractBits10(playerdat.pdat, InvOff(slot) + 4, 6);
+                hops++;
+            }
+            return slot;
         }
 
         private static int InvOff(int slot) => playerdat.InventoryPtr + (slot - 1) * 8;

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Underworld
+{
+    /// <summary>
+    /// Top-level save-game orchestrator. Writes all five save files to {BasePath}/SAVE{slot}/.
+    /// UW1 saves omit SCD.ARK (UW1 has no script compiler data file).
+    /// </summary>
+    public static class SaveGame
+    {
+        public static void Save(int slot, string description)
+        {
+            if (slot < 1 || slot > 4)
+                throw new ArgumentOutOfRangeException(nameof(slot), slot, "slot must be 1..4");
+
+            string saveDir = Path.Combine(UWClass.BasePath, $"SAVE{slot}");
+            Directory.CreateDirectory(saveDir);
+
+            File.WriteAllBytes(Path.Combine(saveDir, "DESC"), Encoding.ASCII.GetBytes(description ?? "Quick save"));
+            File.WriteAllBytes(Path.Combine(saveDir, "PLAYER.DAT"), PlayerDatWriter.Serialize());
+            File.WriteAllBytes(Path.Combine(saveDir, "BGLOBALS.DAT"), BGlobalWriter.Serialize(bglobal.bGlobals));
+            File.WriteAllBytes(Path.Combine(saveDir, "LEV.ARK"), LevArkWriter.Serialize());
+
+            if (UWClass._RES == UWClass.GAME_UW2)
+            {
+                string sourceFolder = playerdat.currentfolder;
+                File.WriteAllBytes(Path.Combine(saveDir, "SCD.ARK"), ScdArkWriter.Serialize(sourceFolder));
+            }
+        }
+    }
+}

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -66,7 +66,7 @@ namespace Underworld
                 if (firstChar != 0) descByte = firstChar;
             }
             File.WriteAllBytes(Path.Combine(saveDir, "DESC"), new[] { descByte });
-            File.WriteAllBytes(Path.Combine(saveDir, "PLAYER.DAT"), PlayerDatWriter.Serialize());
+            File.WriteAllBytes(Path.Combine(saveDir, "PLAYER.DAT"), PatchPlayerLinkInSerialised(PlayerDatWriter.Serialize()));
             File.WriteAllBytes(Path.Combine(saveDir, "BGLOBALS.DAT"), BGlobalWriter.Serialize(bglobal.bGlobals));
             File.WriteAllBytes(Path.Combine(saveDir, "LEV.ARK"), LevArkWriter.Serialize());
 
@@ -145,6 +145,36 @@ namespace Underworld
             // the marker bits at byte 1 and the whoami sentinel at byte 26.
             playerdat.pdat[pp + 1]  = (byte)(playerdat.pdat[pp + 1] | 0x20);
             playerdat.pdat[pp + 26] = 0xFD;
+        }
+
+        /// <summary>
+        /// DOS UW.EXE stores the avatar's pdat `link` field = 1 — a self-
+        /// reference that DOS reads as "this character HAS inventory" when
+        /// populating paperdoll/backpack on Journey Onward. The port's load
+        /// code at uimanager_mainmenu.cs:283 forces LevelObjects[1].link = 0
+        /// to prevent in-memory chain cycles, and that 0 propagates back to
+        /// pdat[0xDB-0xDC] on save → DOS renders an empty inventory.
+        ///
+        /// We can't write link=1 to in-memory pdat permanently because the
+        /// port's own loader would re-read it and hit the cycle on the next
+        /// Journey Onward. So serialise PLAYER.DAT once, patch the link
+        /// bytes in the SERIALISED ciphertext only, write that to disk, and
+        /// leave in-memory pdat untouched.
+        ///
+        /// pdat post-encryption layout for UW1: bytes 0..0xD2 are XOR-
+        /// encrypted with a position-dependent key; pdat[0xD3+] is plain.
+        /// PlayerObjectStoragePTR = 0xD5, so bytes 6-7 of the player obj
+        /// copy live at file offsets 0xDB and 0xDC — both in the plaintext
+        /// region. We can write to them directly without touching the seed.
+        /// </summary>
+        private static byte[] PatchPlayerLinkInSerialised(byte[] serialised)
+        {
+            int linkOff = playerdat.PlayerObjectStoragePTR + 6;
+            if (linkOff + 1 >= serialised.Length) return serialised;
+            // Set link bits 6-15 = 1, preserve owner bits 0-5 of byte 6.
+            serialised[linkOff]     = (byte)((serialised[linkOff] & 0x3F) | 0x40);
+            serialised[linkOff + 1] = 0;
+            return serialised;
         }
 
         private static void ReattachPlayerToCurrentTile(int _)

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -20,7 +20,22 @@ namespace Underworld
 
             StashLiveStateToPdat();
 
-            File.WriteAllBytes(Path.Combine(saveDir, "DESC"), Encoding.ASCII.GetBytes(description ?? "Quick save"));
+            // DESC in UW1 DOS saves is a single byte — seemingly an in-use/slot
+            // indicator rather than a textual description. Writing a multi-byte
+            // ASCII description leaves trailing junk that DOS interprets
+            // inconsistently when enumerating save slots.
+            //
+            // We pack the first character of `description` into the single
+            // byte when possible; the UI doesn't actually surface the string
+            // in the DOS load picker anyway (it shows "Save 1", "Save 2" etc.
+            // based on slot number).
+            byte descByte = 0x01;
+            if (!string.IsNullOrEmpty(description))
+            {
+                byte firstChar = Encoding.ASCII.GetBytes(description.Substring(0, 1))[0];
+                if (firstChar != 0) descByte = firstChar;
+            }
+            File.WriteAllBytes(Path.Combine(saveDir, "DESC"), new[] { descByte });
             File.WriteAllBytes(Path.Combine(saveDir, "PLAYER.DAT"), PlayerDatWriter.Serialize());
             File.WriteAllBytes(Path.Combine(saveDir, "BGLOBALS.DAT"), BGlobalWriter.Serialize(bglobal.bGlobals));
             File.WriteAllBytes(Path.Combine(saveDir, "LEV.ARK"), LevArkWriter.Serialize());

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -18,8 +18,37 @@ namespace Underworld
             string saveDir = Path.Combine(UWClass.BasePath, $"SAVE{slot}");
             Directory.CreateDirectory(saveDir);
 
+            // Detach the player from its tile's object chain FIRST so the
+            // pdat stash (which copies LevelObjects[1] bytes into pdat) sees
+            // a clean .next = 0 player rather than the chain-inserted
+            // next = <previous head> that PlacePlayerInTile produced during
+            // play. DOS expects the player object to have next = 0.
+            int savedChainHead = DetachPlayerFromCurrentTile();
             StashLiveStateToPdat();
 
+            // DOS UW.EXE never writes the player (slot 1) into a tile's
+            // indexObjectList — it tracks player position separately via the
+            // mouse/motion path. The port's PlacePlayerInTile intentionally
+            // inserts slot 1 at the chain head for in-game collision, and
+            // without this detach step the serialised LEV.ARK contains a
+            // tile whose first-object-in-chain points at slot 1, which DOS
+            // treats as an invalid object list ("problems in object list"
+            // error, render bails out with wall/floor/ceiling textures
+            // missing).
+            try
+            {
+                WriteAllSaveFiles(saveDir, description);
+            }
+            finally
+            {
+                // Re-insert slot 1 so in-memory game state stays consistent
+                // if the user keeps playing after saving.
+                ReattachPlayerToCurrentTile(savedChainHead);
+            }
+        }
+
+        private static void WriteAllSaveFiles(string saveDir, string description)
+        {
             // DESC in UW1 DOS saves is a single byte — seemingly an in-use/slot
             // indicator rather than a textual description. Writing a multi-byte
             // ASCII description leaves trailing junk that DOS interprets
@@ -45,6 +74,63 @@ namespace Underworld
                 string sourceFolder = playerdat.currentfolder;
                 File.WriteAllBytes(Path.Combine(saveDir, "SCD.ARK"), ScdArkWriter.Serialize(sourceFolder));
             }
+        }
+
+        /// <summary>
+        /// Unlink slot 1 (player) from its current tile's object chain and
+        /// return the chain head as it was before the detach, so the caller
+        /// can restore it. The tile head is rewritten to slot 1's .next,
+        /// and slot 1's .next is cleared so the serialised slot looks like
+        /// a DOS-format untethered player slot.
+        /// </summary>
+        private static int DetachPlayerFromCurrentTile()
+        {
+            if (UWTileMap.current_tilemap == null ||
+                UWTileMap.current_tilemap.LevelObjects == null ||
+                UWTileMap.current_tilemap.LevelObjects[1] == null)
+            {
+                return 0;
+            }
+            int tx = motion.playerMotionParams.x_0 >> 8;
+            int ty = motion.playerMotionParams.y_2 >> 8;
+            if (!UWTileMap.ValidTile(tx, ty)) return 0;
+            var tile = UWTileMap.current_tilemap.Tiles[tx, ty];
+            int prevHead = tile.indexObjectList;
+            ObjectRemover_OLD.RemoveObjectFromLinkedList(
+                tile.indexObjectList, 1,
+                UWTileMap.current_tilemap.LevelObjects,
+                tile.Ptr + 2);
+            // Clear slot 1's next so a freshly loaded save has a clean player
+            // slot with no dangling chain pointer.
+            UWTileMap.current_tilemap.LevelObjects[1].next = 0;
+
+            // DOS UW.EXE writes mobile slot 1 with item_id bit 6 cleared
+            // (port stores 0x7F = 127 / Avatar; DOS stores 0x3F = 63, an
+            // invisible placeholder NPC). If we save id=127 at slot 1, DOS
+            // happily loads but then renders an Avatar NPC at the player's
+            // own position — the Avatar mesh fills the camera frustum,
+            // producing the "no textures, just dark surfaces" appearance.
+            // Match DOS by clearing bit 6 of the slot-1 item_id.
+            var pobj = UWTileMap.current_tilemap.LevelObjects[1];
+            pobj.DataBuffer[pobj.PTR] = (byte)(pobj.DataBuffer[pobj.PTR] & 0x3F);
+            return prevHead;
+        }
+
+        private static void ReattachPlayerToCurrentTile(int _)
+        {
+            if (UWTileMap.current_tilemap == null ||
+                UWTileMap.current_tilemap.LevelObjects == null ||
+                UWTileMap.current_tilemap.LevelObjects[1] == null)
+            {
+                return;
+            }
+            int tx = motion.playerMotionParams.x_0 >> 8;
+            int ty = motion.playerMotionParams.y_2 >> 8;
+            if (!UWTileMap.ValidTile(tx, ty)) return;
+            var tile = UWTileMap.current_tilemap.Tiles[tx, ty];
+            // PlacePlayerInTile's head-insert logic: obj.next = current head, head = 1.
+            UWTileMap.current_tilemap.LevelObjects[1].next = (short)tile.indexObjectList;
+            tile.indexObjectList = 1;
         }
 
         /// <summary>

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -18,6 +18,8 @@ namespace Underworld
             string saveDir = Path.Combine(UWClass.BasePath, $"SAVE{slot}");
             Directory.CreateDirectory(saveDir);
 
+            StashLiveStateToPdat();
+
             File.WriteAllBytes(Path.Combine(saveDir, "DESC"), Encoding.ASCII.GetBytes(description ?? "Quick save"));
             File.WriteAllBytes(Path.Combine(saveDir, "PLAYER.DAT"), PlayerDatWriter.Serialize());
             File.WriteAllBytes(Path.Combine(saveDir, "BGLOBALS.DAT"), BGlobalWriter.Serialize(bglobal.bGlobals));
@@ -27,6 +29,38 @@ namespace Underworld
             {
                 string sourceFolder = playerdat.currentfolder;
                 File.WriteAllBytes(Path.Combine(saveDir, "SCD.ARK"), ScdArkWriter.Serialize(sourceFolder));
+            }
+        }
+
+        /// <summary>
+        /// Copies live runtime state back into pdat so the serialised player.dat reflects
+        /// the current game state. The port keeps player position in motion.playerMotionParams
+        /// and player-object fields in UWTileMap.current_tilemap.LevelObjects[1]; these are
+        /// never written back to pdat during play, so without this stash the serialised
+        /// player.dat preserves load-time values and restoring yields a stale/zero position.
+        /// </summary>
+        private static void StashLiveStateToPdat()
+        {
+            playerdat.XCoordinate = motion.playerMotionParams.x_0;
+            playerdat.YCoordinate = motion.playerMotionParams.y_2;
+            playerdat.Z = motion.playerMotionParams.z_4;
+            playerdat.SetAt16(0x5B, motion.PlayerHeadingMinor_dseg_8294);
+
+            // RelatedToMotionState: high 5 bits = tilestate25, low 3 bits = swim state.
+            // Swim state is already written to pdat by motion updates; refresh tilestate only.
+            int swimBits = playerdat.RelatedToMotionState & 0x7;
+            playerdat.RelatedToMotionState = (motion.playerMotionParams.tilestate25 << 3) | swimBits;
+
+            // Copy the 27-byte player object (general + NPC extra) from the live LevelObjects[1]
+            // back into pdat[PlayerObjectStoragePTR..]. This is the inverse of the load-time
+            // copy at uimanager_mainmenu.cs:275-278.
+            if (UWTileMap.current_tilemap != null && UWTileMap.current_tilemap.LevelObjects[1] != null)
+            {
+                var playerObj = UWTileMap.current_tilemap.LevelObjects[1];
+                for (int i = 0; i <= 0x1A; i++)
+                {
+                    playerdat.pdat[playerdat.PlayerObjectStoragePTR + i] = playerObj.DataBuffer[playerObj.PTR + i];
+                }
             }
         }
     }

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -23,7 +23,7 @@ namespace Underworld
             // a clean .next = 0 player rather than the chain-inserted
             // next = <previous head> that PlacePlayerInTile produced during
             // play. DOS expects the player object to have next = 0.
-            int savedChainHead = DetachPlayerFromCurrentTile();
+            DetachPlayerFromCurrentTile();
             StashLiveStateToPdat();
             ApplySlot1Markers();
 
@@ -43,8 +43,11 @@ namespace Underworld
             finally
             {
                 // Re-insert slot 1 so in-memory game state stays consistent
-                // if the user keeps playing after saving.
-                ReattachPlayerToCurrentTile(savedChainHead);
+                // if the user keeps playing after saving. The post-detach
+                // tile.indexObjectList already holds the previous chain
+                // head (sans slot 1), so head-inserting slot 1 restores the
+                // PlacePlayerInTile invariant — no saved-head value needed.
+                ReattachPlayerToCurrentTile();
             }
         }
 
@@ -78,25 +81,24 @@ namespace Underworld
         }
 
         /// <summary>
-        /// Unlink slot 1 (player) from its current tile's object chain and
-        /// return the chain head as it was before the detach, so the caller
-        /// can restore it. The tile head is rewritten to slot 1's .next,
-        /// and slot 1's .next is cleared so the serialised slot looks like
-        /// a DOS-format untethered player slot.
+        /// Unlink slot 1 (player) from its current tile's object chain so
+        /// the serialised LEV.ARK slot looks like a DOS-format untethered
+        /// player slot. RemoveObjectFromLinkedList rewrites tile.indexObjectList
+        /// to slot 1's old .next (or leaves it alone if slot 1 was mid-chain
+        /// with the parent's .next rewritten). slot 1's .next is then cleared.
         /// </summary>
-        private static int DetachPlayerFromCurrentTile()
+        private static void DetachPlayerFromCurrentTile()
         {
             if (UWTileMap.current_tilemap == null ||
                 UWTileMap.current_tilemap.LevelObjects == null ||
                 UWTileMap.current_tilemap.LevelObjects[1] == null)
             {
-                return 0;
+                return;
             }
             int tx = motion.playerMotionParams.x_0 >> 8;
             int ty = motion.playerMotionParams.y_2 >> 8;
-            if (!UWTileMap.ValidTile(tx, ty)) return 0;
+            if (!UWTileMap.ValidTile(tx, ty)) return;
             var tile = UWTileMap.current_tilemap.Tiles[tx, ty];
-            int prevHead = tile.indexObjectList;
             ObjectRemover_OLD.RemoveObjectFromLinkedList(
                 tile.indexObjectList, 1,
                 UWTileMap.current_tilemap.LevelObjects,
@@ -104,7 +106,6 @@ namespace Underworld
             // Clear slot 1's next so a freshly loaded save has a clean player
             // slot with no dangling chain pointer.
             UWTileMap.current_tilemap.LevelObjects[1].next = 0;
-            return prevHead;
         }
 
         /// <summary>
@@ -177,7 +178,7 @@ namespace Underworld
             return serialised;
         }
 
-        private static void ReattachPlayerToCurrentTile(int _)
+        private static void ReattachPlayerToCurrentTile()
         {
             if (UWTileMap.current_tilemap == null ||
                 UWTileMap.current_tilemap.LevelObjects == null ||

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -25,6 +25,7 @@ namespace Underworld
             // play. DOS expects the player object to have next = 0.
             int savedChainHead = DetachPlayerFromCurrentTile();
             StashLiveStateToPdat();
+            ApplySlot1Markers();
 
             // DOS UW.EXE never writes the player (slot 1) into a tile's
             // indexObjectList — it tracks player position separately via the
@@ -103,17 +104,47 @@ namespace Underworld
             // Clear slot 1's next so a freshly loaded save has a clean player
             // slot with no dangling chain pointer.
             UWTileMap.current_tilemap.LevelObjects[1].next = 0;
-
-            // DOS UW.EXE writes mobile slot 1 with item_id bit 6 cleared
-            // (port stores 0x7F = 127 / Avatar; DOS stores 0x3F = 63, an
-            // invisible placeholder NPC). If we save id=127 at slot 1, DOS
-            // happily loads but then renders an Avatar NPC at the player's
-            // own position — the Avatar mesh fills the camera frustum,
-            // producing the "no textures, just dark surfaces" appearance.
-            // Match DOS by clearing bit 6 of the slot-1 item_id.
-            var pobj = UWTileMap.current_tilemap.LevelObjects[1];
-            pobj.DataBuffer[pobj.PTR] = (byte)(pobj.DataBuffer[pobj.PTR] & 0x3F);
             return prevHead;
+        }
+
+        /// <summary>
+        /// Apply the DOS-format slot-1 player markers AFTER the pdat stash so
+        /// the byte-0 mask doesn't propagate into pdat (DOS keeps
+        /// pdat[0xD5]=0x7F = avatar item_id while masking LEV.ARK slot1[0] to
+        /// 0x3F = invisible placeholder; cross-file mismatch on byte 0 is
+        /// expected, but bytes 1..26 must match between the two stores).
+        ///
+        /// Markers DOS writes for the player avatar:
+        ///   - LEV.ARK slot1 byte 0: item_id bit 6 cleared (127 → 63)
+        ///   - LEV.ARK slot1 byte 1: doordir flag set (bit 5 of high byte)
+        ///   - LEV.ARK slot1 byte 26 (npc_whoami): 0xFD sentinel
+        ///   - pdat 0xD5+1, 0xD5+26: same as LEV.ARK (markers go in both)
+        ///   - pdat 0xD5+0: untouched (stays 0x7F = avatar)
+        ///
+        /// Without these, DOS UW.EXE renders the Avatar NPC mesh at the
+        /// player's own world position — the camera ends up inside the mesh,
+        /// producing the "wall/floor/ceiling textures missing" symptom.
+        /// </summary>
+        private static void ApplySlot1Markers()
+        {
+            if (UWTileMap.current_tilemap == null ||
+                UWTileMap.current_tilemap.LevelObjects == null ||
+                UWTileMap.current_tilemap.LevelObjects[1] == null)
+            {
+                return;
+            }
+            var pobj = UWTileMap.current_tilemap.LevelObjects[1];
+            int p0 = pobj.PTR;
+            byte[] buf = pobj.DataBuffer;
+            buf[p0]      = (byte)(buf[p0] & 0x3F);
+            buf[p0 + 1]  = (byte)(buf[p0 + 1] | 0x20);
+            buf[p0 + 26] = 0xFD;
+
+            int pp = playerdat.PlayerObjectStoragePTR;
+            // pdat byte 0 (item_id) stays as the avatar (0x7F); only mirror
+            // the marker bits at byte 1 and the whoami sentinel at byte 26.
+            playerdat.pdat[pp + 1]  = (byte)(playerdat.pdat[pp + 1] | 0x20);
+            playerdat.pdat[pp + 26] = 0xFD;
         }
 
         private static void ReattachPlayerToCurrentTile(int _)

--- a/src/savegame/ScdArkWriter.cs
+++ b/src/savegame/ScdArkWriter.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+
+namespace Underworld
+{
+    // Step 1 findings (investigated 2026-04-19):
+    //
+    // SCD.ARK is a UW2-format multi-block ARK container with exactly 16 blocks (0x10).
+    // Header layout is identical to LEV.ARK (UW2 case in DataLoader.LoadUWBlock):
+    //   Bytes 0-3:              NoOfBlocks (Int32 LE) = 16
+    //   Bytes 4-5:              2 padding bytes (0x0000)
+    //   Bytes 6 .. 6+(N*4)-1:  offsets[N]          (N × Int32 LE)
+    //   Bytes 6+(N*4) ..
+    //          6+(N*8)-1:       compressionFlags[N] (N × Int32 LE; all 0 = uncompressed in SAVE0)
+    //   Bytes 6+(N*8) ..
+    //          6+(N*12)-1:      dataLengths[N]      (N × Int32 LE)
+    //   Bytes 6+(N*12) ..
+    //          6+(N*16)-1:      reservedSpace[N]    (N × Int32 LE; mirrors dataLengths in SAVE0)
+    //
+    // File size of SAVE0/SCD.ARK: 8950 bytes.
+    // Blocks 0-15 are all present and uncompressed; sizes range from 324 to 1668 bytes.
+    //
+    // In-memory representation: scd.scd_data is UWBlock[] of length 16.
+    // Blocks are loaded lazily per-demand in ProcessSCDArk; after processing, unmodified blocks
+    // are set back to null (scd.cs:67). There is NO persistent "source byte array" like
+    // LevArkLoader.lev_ark_file_data — each call re-reads from disk.
+    //
+    // Writer strategy: read the source SCD.ARK bytes from disk (BasePath + folder + "/SCD.ARK"),
+    // then for each block overlay any live scd_data[i] entry that is non-null (those are the
+    // blocks the game has mutated during the session). Reassemble the UW2 ARK container
+    // uncompressed, preserving reservedSpace from the source header.
+    //
+    // UW1 has no SCD.ARK — Serialize() returns an empty array for UW1.
+
+    /// <summary>
+    /// Rebuilds a SCD.ARK container from in-memory game state (UW2 only).
+    /// Mutated blocks come from scd.scd_data[i]; unvisited blocks are preserved
+    /// verbatim from the source file on disk.
+    /// </summary>
+    public static class ScdArkWriter
+    {
+        private const int ScdBlockCount = 16; // 0x10 — fixed in UW2
+
+        /// <summary>
+        /// Serialize the SCD.ARK for the given save folder.
+        /// Returns an empty array for UW1 (no SCD.ARK).
+        /// </summary>
+        /// <param name="folder">Save-game subfolder, e.g. "SAVE0".</param>
+        public static byte[] Serialize(string folder)
+        {
+            if (UWClass._RES != UWClass.GAME_UW2)
+                return new byte[0];
+
+            var path = Path.Combine(UWClass.BasePath, folder, "SCD.ARK");
+            if (!File.Exists(path))
+                return new byte[0];
+
+            byte[] source = File.ReadAllBytes(path);
+
+            // Read the actual block count from the source header (must equal 16).
+            int noOfBlocks = (int)Loader.getAt(source, 0, 32);
+
+            // Gather each block's raw bytes: prefer live scd_data[i] if present.
+            byte[][] blockData = new byte[noOfBlocks][];
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                // Check for a live (possibly mutated) block in memory.
+                UWBlock live = (scd.scd_data != null && i < scd.scd_data.Length)
+                    ? scd.scd_data[i]
+                    : null;
+
+                if (live?.Data != null && live.DataLen > 0)
+                {
+                    blockData[i] = live.Data;
+                }
+                else
+                {
+                    // Fall back: extract block from source bytes.
+                    DataLoader.LoadUWBlock(source, i, 0, out UWBlock uwb);
+                    blockData[i] = (uwb?.DataLen > 0) ? uwb.Data : null;
+                }
+            }
+
+            // Preserve reservedSpace from the source header.
+            int[] reserved = new int[noOfBlocks];
+            if (source.Length >= 6 + noOfBlocks * 16)
+            {
+                for (int i = 0; i < noOfBlocks; i++)
+                {
+                    reserved[i] = (int)Loader.getAt(source, 6 + (i * 4) + (noOfBlocks * 12), 32);
+                }
+            }
+
+            // Compute layout: header = 6 + noOfBlocks*16 bytes.
+            int headerSize = 6 + noOfBlocks * 16;
+            int[] offsets = new int[noOfBlocks];
+            int[] flags   = new int[noOfBlocks]; // all 0 = uncompressed
+            int[] lengths = new int[noOfBlocks];
+
+            int cursor = headerSize;
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                {
+                    offsets[i] = cursor;
+                    flags[i]   = DataLoader.UW2_NOCOMPRESSION; // 0
+                    lengths[i] = blockData[i].Length;
+                    cursor += blockData[i].Length;
+                }
+                // else: offsets[i] = 0, flags[i] = 0, lengths[i] = 0 (absent block)
+            }
+
+            // Write output.
+            using var ms = new MemoryStream(cursor);
+            using var bw = new BinaryWriter(ms);
+
+            bw.Write((int)noOfBlocks);
+            bw.Write((short)0); // 2 padding bytes
+
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(offsets[i]);
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(flags[i]);
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(lengths[i]);
+            for (int i = 0; i < noOfBlocks; i++) bw.Write(reserved[i]);
+
+            for (int i = 0; i < noOfBlocks; i++)
+            {
+                if (blockData[i] != null && blockData[i].Length > 0)
+                    bw.Write(blockData[i]);
+            }
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/src/ui/uimanager_flasks.cs
+++ b/src/ui/uimanager_flasks.cs
@@ -36,6 +36,7 @@ namespace Underworld
 
         public static void RefreshHealthFlask()
         {
+            if (instance == null) return;
             int level = (int)((float)((float)playerdat.play_hp / (float)playerdat.max_hp) * 12f);
             int startOffset = 0;
             if (playerdat.play_poison > 0)
@@ -57,6 +58,7 @@ namespace Underworld
 
         public static void RefreshManaFlask()
         {
+            if (instance == null) return;
             int level = (int)((float)((float)playerdat.play_mana / (float)playerdat.max_mana) * 12f);
             int startOffset = 25;
             for (int i = 0; i < 13; i++)

--- a/src/ui/uimanager_flasks.cs
+++ b/src/ui/uimanager_flasks.cs
@@ -36,7 +36,7 @@ namespace Underworld
 
         public static void RefreshHealthFlask()
         {
-            if (instance == null) return;
+            if (instance == null) return; // reachable from InitEmptyPlayer in tests, before the Godot scene wires up the singleton
             int level = (int)((float)((float)playerdat.play_hp / (float)playerdat.max_hp) * 12f);
             int startOffset = 0;
             if (playerdat.play_poison > 0)
@@ -58,7 +58,7 @@ namespace Underworld
 
         public static void RefreshManaFlask()
         {
-            if (instance == null) return;
+            if (instance == null) return; // see RefreshHealthFlask
             int level = (int)((float)((float)playerdat.play_mana / (float)playerdat.max_mana) * 12f);
             int startOffset = 25;
             for (int i = 0; i < 13; i++)

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -263,16 +263,18 @@ namespace Underworld
         /// <param name="folder"></param>
         public void JourneyOnwards(string folder)
         {
+            GD.Print($"[JourneyOnwards] enter folder={folder}");
             playerdat.previousLightLevel = -1;
             playerdat.currentfolder = folder;
             playerdat.LoadPlayerDat(datafolder: folder);
-            
-            // //Common launch actions            
+            GD.Print("[JourneyOnwards] after LoadPlayerDat");
+
+            // //Common launch actions
             UWTileMap.LoadTileMap(
                     newLevelNo: playerdat.dungeon_level - 1,
                     datafolder: folder,
                     newGameSession: true);
-
+            GD.Print("[JourneyOnwards] after LoadTileMap");
 
             //add player object data to the map
             for (int i = 0; i <= 0x1A; i++)
@@ -283,10 +285,11 @@ namespace Underworld
             playerdat.playerObject.link = 0;//prevents infinite loops.
             playerdat.playerObject.tileX = playerdat.playerObject.npc_xhome;
             playerdat.playerObject.tileY = playerdat.playerObject.npc_yhome;
+            GD.Print($"[JourneyOnwards] after 27-byte copy+fixups; tileX={playerdat.playerObject.tileX} tileY={playerdat.playerObject.tileY} next={playerdat.playerObject.next} link={playerdat.playerObject.link}");
 
             if (folder.ToUpper() == "DATA")
             {
-                //default start locations.                
+                //default start locations.
                 switch (UWClass._RES)
                 {
                     case UWClass.GAME_UW2:
@@ -298,15 +301,19 @@ namespace Underworld
                         Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
                         break;
                 }
+                GD.Print("[JourneyOnwards] after Teleportation (new game path)");
             }
             else
             {
                 playerdat.PlacePlayerInTile(playerdat.playerObject.tileX, playerdat.playerObject.tileY);
+                GD.Print("[JourneyOnwards] after PlacePlayerInTile (restore path)");
             }
 
             //Update weight display
             uimanager.RefreshWeightDisplay();
+            GD.Print("[JourneyOnwards] after RefreshWeightDisplay");
             playerdat.PlayerStatusUpdate();
+            GD.Print("[JourneyOnwards] after PlayerStatusUpdate");
 
             //restore some UI elements that have been previously hidden as part of the splash intro
             uimanager.EnableDisable(uimanager.instance.uw1UI, UWClass._RES != UWClass.GAME_UW2);
@@ -314,27 +321,30 @@ namespace Underworld
             uimanager.EnableDisable(uimanager.instance.PanelInventory,true);
             uimanager.EnableDisable(uimanager.instance.ManaFlaskPanel,true);
             uimanager.EnableDisable(uimanager.instance.HealthFlaskPanel,true);
-            
+
 
             uimanager.OpenedContainerIndex = -1;//clear slot graphics
-            uimanager.SetOpenedContainer(0, -1); 
+            uimanager.SetOpenedContainer(0, -1);
             uimanager.BackPackStart = 0;
             uimanager.EnableDisable(uimanager.instance.ArrowUp, false);
             uimanager.EnableDisable(uimanager.instance.ArrowDown, false);
+            GD.Print("[JourneyOnwards] after UI enable/disable block");
 
             if (!playerdat.MusicEnabled)
             {
-                MusicStreamPlayer.Instance.Stop(); 
+                MusicStreamPlayer.Instance.Stop();
             }
             instance.InitViews();
             SetPanelMode(0);
-            
+            GD.Print("[JourneyOnwards] after InitViews+SetPanelMode");
+
             //Apply player motion on game load.
             motion.PlayerMotion(0x40);
             if (UWClass._RES == UWClass.GAME_UW2)
             {//In UW2 the theme music will always change on game load or if coming from main menu. In UW1 it will only happen when loading a game from the options menu. In that case the call to change themes is in the ui code for the options menu
                 XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic(0));
             }
+            GD.Print("[JourneyOnwards] after PlayerMotion — load complete");
         }
 
         private void _on_create_character_gui_input(InputEvent @event)

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -264,16 +264,18 @@ namespace Underworld
         /// <param name="folder"></param>
         public void JourneyOnwards(string folder)
         {
+            GD.Print($"[JourneyOnwards] enter folder={folder}");
             playerdat.previousLightLevel = -1;
             playerdat.currentfolder = folder;
             playerdat.LoadPlayerDat(datafolder: folder);
-            
-            // //Common launch actions            
+            GD.Print("[JourneyOnwards] after LoadPlayerDat");
+
+            // //Common launch actions
             UWTileMap.LoadTileMap(
                     newLevelNo: playerdat.dungeon_level - 1,
                     datafolder: folder,
                     newGameSession: true);
-
+            GD.Print("[JourneyOnwards] after LoadTileMap");
 
             //add player object data to the map
             for (int i = 0; i <= 0x1A; i++)
@@ -284,10 +286,11 @@ namespace Underworld
             playerdat.playerObject.link = 0;//prevents infinite loops.
             playerdat.playerObject.tileX = playerdat.playerObject.npc_xhome;
             playerdat.playerObject.tileY = playerdat.playerObject.npc_yhome;
+            GD.Print($"[JourneyOnwards] after 27-byte copy+fixups; tileX={playerdat.playerObject.tileX} tileY={playerdat.playerObject.tileY} next={playerdat.playerObject.next} link={playerdat.playerObject.link}");
 
             if (folder.ToUpper() == "DATA")
             {
-                //default start locations.                
+                //default start locations.
                 switch (UWClass._RES)
                 {
                     case UWClass.GAME_UW2:
@@ -299,15 +302,19 @@ namespace Underworld
                         Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
                         break;
                 }
+                GD.Print("[JourneyOnwards] after Teleportation (new game path)");
             }
             else
             {
                 playerdat.PlacePlayerInTile(playerdat.playerObject.tileX, playerdat.playerObject.tileY);
+                GD.Print("[JourneyOnwards] after PlacePlayerInTile (restore path)");
             }
 
             //Update weight display
             uimanager.RefreshWeightDisplay();
+            GD.Print("[JourneyOnwards] after RefreshWeightDisplay");
             playerdat.PlayerStatusUpdate();
+            GD.Print("[JourneyOnwards] after PlayerStatusUpdate");
 
             //restore some UI elements that have been previously hidden as part of the splash intro
             uimanager.EnableDisable(uimanager.instance.uw1UI, UWClass._RES != UWClass.GAME_UW2);
@@ -315,27 +322,30 @@ namespace Underworld
             uimanager.EnableDisable(uimanager.instance.PanelInventory,true);
             uimanager.EnableDisable(uimanager.instance.ManaFlaskPanel,true);
             uimanager.EnableDisable(uimanager.instance.HealthFlaskPanel,true);
-            
+
 
             uimanager.OpenedContainerIndex = -1;//clear slot graphics
-            uimanager.SetOpenedContainer(0, -1); 
+            uimanager.SetOpenedContainer(0, -1);
             uimanager.BackPackStart = 0;
             uimanager.EnableDisable(uimanager.instance.ArrowUp, false);
             uimanager.EnableDisable(uimanager.instance.ArrowDown, false);
+            GD.Print("[JourneyOnwards] after UI enable/disable block");
 
             if (!playerdat.MusicEnabled)
             {
-                MusicStreamPlayer.Instance.Stop(); 
+                MusicStreamPlayer.Instance.Stop();
             }
             instance.InitViews();
             SetPanelMode(0);
-            
+            GD.Print("[JourneyOnwards] after InitViews+SetPanelMode");
+
             //Apply player motion on game load.
             motion.PlayerMotion(0x40);
             if (UWClass._RES == UWClass.GAME_UW2)
             {//In UW2 the theme music will always change on game load or if coming from main menu. In UW1 it will only happen when loading a game from the options menu. In that case the call to change themes is in the ui code for the options menu
                 XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic(0));
             }
+            GD.Print("[JourneyOnwards] after PlayerMotion — load complete");
         }
 
         private void _on_create_character_gui_input(InputEvent @event)

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -295,7 +295,13 @@ namespace Underworld
                         break;
                     default:
                         //main.gamecam.Position = new Vector3(-38f, 4.2f, 2.2f);
-                        Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
+                        // DOS UW.EXE chargen spawns the Avatar at tile (32, 2) —
+                        // the centre of the starting room. (32, 1) puts the
+                        // player jammed against the north wall, which looks
+                        // fine in the port but produces awful renders when the
+                        // save is loaded in DOS UW.EXE (backed-against-wall
+                        // view = mostly wall surface at close range).
+                        Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 2);
                         break;
                 }
             }

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -264,18 +264,15 @@ namespace Underworld
         /// <param name="folder"></param>
         public void JourneyOnwards(string folder)
         {
-            GD.Print($"[JourneyOnwards] enter folder={folder}");
             playerdat.previousLightLevel = -1;
             playerdat.currentfolder = folder;
             playerdat.LoadPlayerDat(datafolder: folder);
-            GD.Print("[JourneyOnwards] after LoadPlayerDat");
 
             // //Common launch actions
             UWTileMap.LoadTileMap(
                     newLevelNo: playerdat.dungeon_level - 1,
                     datafolder: folder,
                     newGameSession: true);
-            GD.Print("[JourneyOnwards] after LoadTileMap");
 
             //add player object data to the map
             for (int i = 0; i <= 0x1A; i++)
@@ -286,7 +283,6 @@ namespace Underworld
             playerdat.playerObject.link = 0;//prevents infinite loops.
             playerdat.playerObject.tileX = playerdat.playerObject.npc_xhome;
             playerdat.playerObject.tileY = playerdat.playerObject.npc_yhome;
-            GD.Print($"[JourneyOnwards] after 27-byte copy+fixups; tileX={playerdat.playerObject.tileX} tileY={playerdat.playerObject.tileY} next={playerdat.playerObject.next} link={playerdat.playerObject.link}");
 
             if (folder.ToUpper() == "DATA")
             {
@@ -302,19 +298,15 @@ namespace Underworld
                         Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
                         break;
                 }
-                GD.Print("[JourneyOnwards] after Teleportation (new game path)");
             }
             else
             {
                 playerdat.PlacePlayerInTile(playerdat.playerObject.tileX, playerdat.playerObject.tileY);
-                GD.Print("[JourneyOnwards] after PlacePlayerInTile (restore path)");
             }
 
             //Update weight display
             uimanager.RefreshWeightDisplay();
-            GD.Print("[JourneyOnwards] after RefreshWeightDisplay");
             playerdat.PlayerStatusUpdate();
-            GD.Print("[JourneyOnwards] after PlayerStatusUpdate");
 
             //restore some UI elements that have been previously hidden as part of the splash intro
             uimanager.EnableDisable(uimanager.instance.uw1UI, UWClass._RES != UWClass.GAME_UW2);
@@ -329,7 +321,6 @@ namespace Underworld
             uimanager.BackPackStart = 0;
             uimanager.EnableDisable(uimanager.instance.ArrowUp, false);
             uimanager.EnableDisable(uimanager.instance.ArrowDown, false);
-            GD.Print("[JourneyOnwards] after UI enable/disable block");
 
             if (!playerdat.MusicEnabled)
             {
@@ -337,7 +328,6 @@ namespace Underworld
             }
             instance.InitViews();
             SetPanelMode(0);
-            GD.Print("[JourneyOnwards] after InitViews+SetPanelMode");
 
             //Apply player motion on game load.
             motion.PlayerMotion(0x40);
@@ -345,7 +335,6 @@ namespace Underworld
             {//In UW2 the theme music will always change on game load or if coming from main menu. In UW1 it will only happen when loading a game from the options menu. In that case the call to change themes is in the ui code for the options menu
                 XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic(0));
             }
-            GD.Print("[JourneyOnwards] after PlayerMotion — load complete");
         }
 
         private void _on_create_character_gui_input(InputEvent @event)

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -263,18 +263,15 @@ namespace Underworld
         /// <param name="folder"></param>
         public void JourneyOnwards(string folder)
         {
-            GD.Print($"[JourneyOnwards] enter folder={folder}");
             playerdat.previousLightLevel = -1;
             playerdat.currentfolder = folder;
             playerdat.LoadPlayerDat(datafolder: folder);
-            GD.Print("[JourneyOnwards] after LoadPlayerDat");
 
             // //Common launch actions
             UWTileMap.LoadTileMap(
                     newLevelNo: playerdat.dungeon_level - 1,
                     datafolder: folder,
                     newGameSession: true);
-            GD.Print("[JourneyOnwards] after LoadTileMap");
 
             //add player object data to the map
             for (int i = 0; i <= 0x1A; i++)
@@ -285,7 +282,6 @@ namespace Underworld
             playerdat.playerObject.link = 0;//prevents infinite loops.
             playerdat.playerObject.tileX = playerdat.playerObject.npc_xhome;
             playerdat.playerObject.tileY = playerdat.playerObject.npc_yhome;
-            GD.Print($"[JourneyOnwards] after 27-byte copy+fixups; tileX={playerdat.playerObject.tileX} tileY={playerdat.playerObject.tileY} next={playerdat.playerObject.next} link={playerdat.playerObject.link}");
 
             if (folder.ToUpper() == "DATA")
             {
@@ -301,19 +297,15 @@ namespace Underworld
                         Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
                         break;
                 }
-                GD.Print("[JourneyOnwards] after Teleportation (new game path)");
             }
             else
             {
                 playerdat.PlacePlayerInTile(playerdat.playerObject.tileX, playerdat.playerObject.tileY);
-                GD.Print("[JourneyOnwards] after PlacePlayerInTile (restore path)");
             }
 
             //Update weight display
             uimanager.RefreshWeightDisplay();
-            GD.Print("[JourneyOnwards] after RefreshWeightDisplay");
             playerdat.PlayerStatusUpdate();
-            GD.Print("[JourneyOnwards] after PlayerStatusUpdate");
 
             //restore some UI elements that have been previously hidden as part of the splash intro
             uimanager.EnableDisable(uimanager.instance.uw1UI, UWClass._RES != UWClass.GAME_UW2);
@@ -328,7 +320,6 @@ namespace Underworld
             uimanager.BackPackStart = 0;
             uimanager.EnableDisable(uimanager.instance.ArrowUp, false);
             uimanager.EnableDisable(uimanager.instance.ArrowDown, false);
-            GD.Print("[JourneyOnwards] after UI enable/disable block");
 
             if (!playerdat.MusicEnabled)
             {
@@ -336,7 +327,6 @@ namespace Underworld
             }
             instance.InitViews();
             SetPanelMode(0);
-            GD.Print("[JourneyOnwards] after InitViews+SetPanelMode");
 
             //Apply player motion on game load.
             motion.PlayerMotion(0x40);
@@ -344,7 +334,6 @@ namespace Underworld
             {//In UW2 the theme music will always change on game load or if coming from main menu. In UW1 it will only happen when loading a game from the options menu. In that case the call to change themes is in the ui code for the options menu
                 XMIMusic.ChangeTheme(XMIMusic.PickLevelThemeMusic(0));
             }
-            GD.Print("[JourneyOnwards] after PlayerMotion — load complete");
         }
 
         private void _on_create_character_gui_input(InputEvent @event)

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -294,7 +294,13 @@ namespace Underworld
                         break;
                     default:
                         //main.gamecam.Position = new Vector3(-38f, 4.2f, 2.2f);
-                        Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 1);
+                        // DOS UW.EXE chargen spawns the Avatar at tile (32, 2) —
+                        // the centre of the starting room. (32, 1) puts the
+                        // player jammed against the north wall, which looks
+                        // fine in the port but produces awful renders when the
+                        // save is loaded in DOS UW.EXE (backed-against-wall
+                        // view = mostly wall surface at close range).
+                        Teleportation.InitialisePlayerOnLevelOrPositionChange(32, 2);
                         break;
                 }
             }

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -401,10 +401,25 @@ namespace Underworld
                                         string description = System.IO.File.Exists(descPath)
                                             ? System.IO.File.ReadAllText(descPath)
                                             : $"Save {extra_arg_0}";
-                                        SaveGame.Save((int)extra_arg_0, description);
+                                        int stringId;
+                                        try
+                                        {
+                                            SaveGame.Save((int)extra_arg_0, description);
+                                            stringId = GameStrings.str_save_game_succeeded_;
+                                        }
+                                        catch (System.IO.IOException ex)
+                                        {
+                                            GD.PrintErr($"SaveGame.Save failed: {ex}");
+                                            stringId = GameStrings.str_save_game_failed_;
+                                        }
+                                        catch (System.UnauthorizedAccessException ex)
+                                        {
+                                            GD.PrintErr($"SaveGame.Save failed: {ex}");
+                                            stringId = GameStrings.str_save_game_failed_;
+                                        }
                                         listsaves();
                                         instance.scroll.Clear();
-                                        AddToMessageScroll(GameStrings.GetString(1, GameStrings.str_save_game_succeeded_));
+                                        AddToMessageScroll(GameStrings.GetString(1, stringId));
                                         ReturnToGameFromOptions();
                                         break;
                                     }

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -293,13 +293,29 @@ namespace Underworld
                         {   //at main menu. will switch to menu specified by arg0
                             switch (extra_arg_0)
                             {
-                                case 1://switch to save menu
+                                case 0://switch to save menu
                                     {
                                         CurrentGameOptionMenu = OptionMenus.SaveMenu;
                                         SetGameOptionsBackground((int)OptionButtonIndices.AllSaveButtons);
                                         SetGameOptionButtons(
                                             new int[]{
                                                 (int)OptionButtonIndices.SaveGameOff,
+                                                (int)OptionButtonIndices.Save1Off,
+                                                (int)OptionButtonIndices.Save2Off,
+                                                (int)OptionButtonIndices.Save3Off,
+                                                (int)OptionButtonIndices.Save4Off,
+                                                (int)OptionButtonIndices.CancelOff,
+                                                -1});
+                                        listsaves();
+                                        break;
+                                    }
+                                case 1://switch to restore menu
+                                    {
+                                        CurrentGameOptionMenu = OptionMenus.RestoreMenu;
+                                        SetGameOptionsBackground((int)OptionButtonIndices.AllSaveButtons);
+                                        SetGameOptionButtons(
+                                            new int[]{
+                                                (int)OptionButtonIndices.RestoreGameLabel,
                                                 (int)OptionButtonIndices.Save1Off,
                                                 (int)OptionButtonIndices.Save2Off,
                                                 (int)OptionButtonIndices.Save3Off,

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -293,13 +293,13 @@ namespace Underworld
                         {   //at main menu. will switch to menu specified by arg0
                             switch (extra_arg_0)
                             {
-                                case 1://switch to restore menu
+                                case 1://switch to save menu
                                     {
-                                        CurrentGameOptionMenu = OptionMenus.RestoreMenu;
+                                        CurrentGameOptionMenu = OptionMenus.SaveMenu;
                                         SetGameOptionsBackground((int)OptionButtonIndices.AllSaveButtons);
                                         SetGameOptionButtons(
                                             new int[]{
-                                                (int)OptionButtonIndices.RestoreGameLabel,
+                                                (int)OptionButtonIndices.SaveGameOff,
                                                 (int)OptionButtonIndices.Save1Off,
                                                 (int)OptionButtonIndices.Save2Off,
                                                 (int)OptionButtonIndices.Save3Off,
@@ -385,6 +385,35 @@ namespace Underworld
                                     }
                             }
 
+                            break;
+                        }
+                    case OptionMenus.SaveMenu:
+                        {
+                            switch (extra_arg_0)
+                            {
+                                case 1:
+                                case 2:
+                                case 3:
+                                case 4://save to chosen slot
+                                    {
+                                        // Description uses existing slot name if present, otherwise a default.
+                                        var descPath = System.IO.Path.Combine(UWClass.BasePath, $"SAVE{extra_arg_0}", "DESC");
+                                        string description = System.IO.File.Exists(descPath)
+                                            ? System.IO.File.ReadAllText(descPath)
+                                            : $"Save {extra_arg_0}";
+                                        SaveGame.Save((int)extra_arg_0, description);
+                                        listsaves();
+                                        instance.scroll.Clear();
+                                        AddToMessageScroll(GameStrings.GetString(1, GameStrings.str_save_game_succeeded_));
+                                        ReturnToGameFromOptions();
+                                        break;
+                                    }
+                                case 5://cancel and return to top
+                                    {
+                                        ReturnToTopOptionsMenu();
+                                        break;
+                                    }
+                            }
                             break;
                         }
                     case OptionMenus.RestoreMenu:

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -418,20 +418,31 @@ namespace Underworld
                                             ? System.IO.File.ReadAllText(descPath)
                                             : $"Save {extra_arg_0}";
                                         int stringId;
-                                        try
+                                        if (UWClass._RES != UWClass.GAME_UW1)
                                         {
-                                            SaveGame.Save((int)extra_arg_0, description);
-                                            stringId = GameStrings.str_save_game_succeeded_;
-                                        }
-                                        catch (System.IO.IOException ex)
-                                        {
-                                            GD.PrintErr($"SaveGame.Save failed: {ex}");
+                                            // UW2 save is unsupported pending an upstream UW2 lev.ark compressor.
+                                            // Writing uncompressed UW2 blocks would fail DOS load (>80 uncompressed
+                                            // blocks crash vanilla UW2.EXE). Until the compressor is ported, refuse.
+                                            GD.PrintErr("UW2 save pending upstream compressor — not yet supported");
                                             stringId = GameStrings.str_save_game_failed_;
                                         }
-                                        catch (System.UnauthorizedAccessException ex)
+                                        else
                                         {
-                                            GD.PrintErr($"SaveGame.Save failed: {ex}");
-                                            stringId = GameStrings.str_save_game_failed_;
+                                            try
+                                            {
+                                                SaveGame.Save((int)extra_arg_0, description);
+                                                stringId = GameStrings.str_save_game_succeeded_;
+                                            }
+                                            catch (System.IO.IOException ex)
+                                            {
+                                                GD.PrintErr($"SaveGame.Save failed: {ex}");
+                                                stringId = GameStrings.str_save_game_failed_;
+                                            }
+                                            catch (System.UnauthorizedAccessException ex)
+                                            {
+                                                GD.PrintErr($"SaveGame.Save failed: {ex}");
+                                                stringId = GameStrings.str_save_game_failed_;
+                                            }
                                         }
                                         listsaves();
                                         instance.scroll.Clear();

--- a/src/utility/ObjectCreator.cs
+++ b/src/utility/ObjectCreator.cs
@@ -169,6 +169,12 @@ namespace Underworld
         /// <param name="a_tilemap">Really should remove this?</param>
         public static void RenderObject(uwObject obj, UWTileMap a_tilemap)
         {
+            // LevelObjects[1] is the player's own slot. Restoring a save inserts the
+            // player into the tile's indexObjectList via PlacePlayerInTile, so without
+            // this filter the player's adventurer sprite (item_id=127) renders at
+            // their own position — visible as a smiley in front of the camera.
+            if (obj.index == 1) return;
+
             bool unimplemented = true;
             var name = $"{obj.index}_{GameStrings.GetObjectNounUW(obj.item_id)}";
             var newNode = new Node3D();

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -65,4 +65,40 @@ public class AutomapNotesRoundTripTests : System.IDisposable
         Assert.Equal((byte)3, result[54 + 0x32]);
         Assert.Equal((byte)4, result[54 + 0x34]);
     }
+
+    [Fact]
+    public void LevArkWriter_Uw1_NewNoteInMemory_SurvivesFullSerializeAndReextract()
+    {
+        Underworld.UWClass.BasePath = System.IO.Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        // Load the UW1 DATA/LEV.ARK so the writer has a source ARK to pass through.
+        Assert.True(Underworld.LevArkLoader.LoadLevArkFileData(folder: "DATA"));
+
+        // Seed an in-memory note for level 0 that wasn't in the source ARK.
+        Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+        Underworld.automapnote.automapsnotes[0] = new Underworld.automapnote();
+        Underworld.automapnote.automapsnotes[0].notes.Add(
+            new Underworld.automapnote.mapnotetext("INTEGRATION TEST NOTE", 10, 20));
+
+        // Run the full writer.
+        byte[] rewritten = Underworld.LevArkWriter.Serialize();
+
+        // Swap the source to the rewritten bytes and re-extract block 36 (level 0 notes).
+        byte[] originalFile = Underworld.LevArkLoader.lev_ark_file_data;
+        Underworld.LevArkLoader.lev_ark_file_data = rewritten;
+        try
+        {
+            var reloaded = new Underworld.automapnote(0, Underworld.UWClass.GAME_UW1);
+            Assert.Single(reloaded.notes);
+            Assert.Equal("INTEGRATION TEST NOTE", reloaded.notes[0].notetext);
+            Assert.Equal(10, reloaded.notes[0].posX);
+            Assert.Equal(20, reloaded.notes[0].posY);
+        }
+        finally
+        {
+            Underworld.LevArkLoader.lev_ark_file_data = originalFile;
+            Underworld.automapnote.automapsnotes = null;
+        }
+    }
 }

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+[Collection("UWClassState")]
+public class AutomapNotesRoundTripTests : System.IDisposable
+{
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+
+    public AutomapNotesRoundTripTests()
+    {
+        _origBasePath = Underworld.UWClass.BasePath;
+        _origRes = Underworld.UWClass._RES;
+    }
+
+    public void Dispose()
+    {
+        Underworld.UWClass.BasePath = _origBasePath;
+        Underworld.UWClass._RES = _origRes;
+    }
+
+    [Fact]
+    public void Serialize_EmptyNotes_ReturnsEmptyByteArray()
+    {
+        var note = new Underworld.automapnote();
+        byte[] result = note.Serialize();
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Serialize_OneNote_Writes54Bytes_NullTerminatedStringAtOffset0PosAt0x32()
+    {
+        var note = new Underworld.automapnote();
+        note.notes.Add(new Underworld.automapnote.mapnotetext("hello", 42, 7));
+        byte[] result = note.Serialize();
+
+        Assert.Equal(54, result.Length);
+        Assert.Equal((byte)'h', result[0]);
+        Assert.Equal((byte)'e', result[1]);
+        Assert.Equal((byte)'l', result[2]);
+        Assert.Equal((byte)'l', result[3]);
+        Assert.Equal((byte)'o', result[4]);
+        Assert.Equal((byte)0, result[5]);
+        Assert.Equal((byte)42, result[0x32]);
+        Assert.Equal((byte)0, result[0x33]);
+        Assert.Equal((byte)7, result[0x34]);
+        Assert.Equal((byte)0, result[0x35]);
+    }
+
+    [Fact]
+    public void Serialize_TwoNotes_EmitsBackToBack108Bytes_SecondNoteAtOffset54()
+    {
+        var note = new Underworld.automapnote();
+        note.notes.Add(new Underworld.automapnote.mapnotetext("A", 1, 2));
+        note.notes.Add(new Underworld.automapnote.mapnotetext("B", 3, 4));
+        byte[] result = note.Serialize();
+
+        Assert.Equal(108, result.Length);
+        Assert.Equal((byte)'A', result[0]);
+        Assert.Equal((byte)'B', result[54]);
+        Assert.Equal((byte)1, result[0x32]);
+        Assert.Equal((byte)2, result[0x34]);
+        Assert.Equal((byte)3, result[54 + 0x32]);
+        Assert.Equal((byte)4, result[54 + 0x34]);
+    }
+}

--- a/tests/Underworld.Save.Tests/BGlobalRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/BGlobalRoundTripTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Round-trip tests for BGlobalWriter: load → serialize → byte-identical.
+/// </summary>
+public class BGlobalRoundTripTests
+{
+    /// <summary>
+    /// Load UW2 BGLOBALS.DAT, serialize via BGlobalWriter, assert byte-identical to original.
+    /// </summary>
+    [Fact]
+    public void Uw2BGlobals_ByteIdentical_AfterSerialize()
+    {
+        // Arrange
+        var fixtureFile = TestData.Uw2Save0("BGLOBALS.DAT");
+        byte[] originalBytes = File.ReadAllBytes(fixtureFile);
+
+        // Set up UWClass for LoadGlobals
+        UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        UWClass._RES = Loader.GAME_UW2;
+
+        // Load the globals
+        bglobal.LoadGlobals("SAVE0");
+        var loadedGlobals = bglobal.bGlobals;
+
+        // Act
+        byte[] serialized = BGlobalWriter.Serialize(loadedGlobals);
+
+        // Assert
+        Assert.Equal(originalBytes, serialized);
+    }
+
+    /// <summary>
+    /// Empty array should return empty byte array.
+    /// </summary>
+    [Fact]
+    public void Serialize_EmptyArray_ReturnsEmptyByteArray()
+    {
+        // Arrange
+        var emptyGlobals = Array.Empty<bglobal.BablGlobal>();
+
+        // Act
+        byte[] result = BGlobalWriter.Serialize(emptyGlobals);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    /// <summary>
+    /// One slot with ConversationNo=7, Size=0 writes exactly 4 bytes: {0x07, 0x00, 0x00, 0x00}.
+    /// </summary>
+    [Fact]
+    public void Serialize_OneSlotZeroSize_Writes4Bytes()
+    {
+        // Arrange
+        var oneSlot = new bglobal.BablGlobal[]
+        {
+            new bglobal.BablGlobal
+            {
+                ConversationNo = 7,
+                Size = 0,
+                Globals = new short[0]
+            }
+        };
+
+        // Act
+        byte[] result = BGlobalWriter.Serialize(oneSlot);
+
+        // Assert
+        byte[] expected = { 0x07, 0x00, 0x00, 0x00 };
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/Underworld.Save.Tests/BGlobalRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/BGlobalRoundTripTests.cs
@@ -6,8 +6,24 @@ namespace Underworld.Save.Tests;
 /// <summary>
 /// Round-trip tests for BGlobalWriter: load → serialize → byte-identical.
 /// </summary>
-public class BGlobalRoundTripTests
+[Collection("UWClassState")]
+public class BGlobalRoundTripTests : IDisposable
 {
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+
+    public BGlobalRoundTripTests()
+    {
+        _origBasePath = UWClass.BasePath;
+        _origRes = UWClass._RES;
+    }
+
+    public void Dispose()
+    {
+        UWClass.BasePath = _origBasePath;
+        UWClass._RES = _origRes;
+    }
+
     /// <summary>
     /// Load UW2 BGLOBALS.DAT, serialize via BGlobalWriter, assert byte-identical to original.
     /// </summary>

--- a/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
@@ -11,12 +11,14 @@ public class LevArkRoundTripTests : IDisposable
     private readonly string _origBasePath;
     private readonly byte _origRes;
     private readonly byte[] _origLevArkFileData;
+    private readonly UWTileMap[] _origDungeons;
 
     public LevArkRoundTripTests()
     {
         _origBasePath = Underworld.UWClass.BasePath;
         _origRes = Underworld.UWClass._RES;
         _origLevArkFileData = Underworld.LevArkLoader.lev_ark_file_data;
+        _origDungeons = Underworld.UWTileMap.dungeons;
     }
 
     public void Dispose()
@@ -24,6 +26,7 @@ public class LevArkRoundTripTests : IDisposable
         Underworld.UWClass.BasePath = _origBasePath;
         Underworld.UWClass._RES = _origRes;
         Underworld.LevArkLoader.lev_ark_file_data = _origLevArkFileData;
+        Underworld.UWTileMap.dungeons = _origDungeons;
     }
 
     [Fact]
@@ -76,6 +79,74 @@ public class LevArkRoundTripTests : IDisposable
 
         int compareLen = Math.Min(originalBlock0.Data.Length, reloadedBlock0.Data.Length);
         Assert.True(compareLen > 0, "Re-loaded block 0 must have data");
+
+        for (int i = 0; i < compareLen; i++)
+        {
+            Assert.True(originalBlock0.Data[i] == reloadedBlock0.Data[i],
+                $"Byte mismatch at 0x{i:X4}: original=0x{originalBlock0.Data[i]:X2}, reloaded=0x{reloadedBlock0.Data[i]:X2}");
+        }
+    }
+
+    [Fact]
+    public void Uw2VisitedLevel_Serialize_UsesLiveDungeonBuffer()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+
+        LevArkLoader.LoadLevArkFileData(folder: "SAVE0");
+
+        // Populate dungeons[0] with a loaded UWTileMap so the writer takes the live-data path.
+        UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+        UWTileMap.dungeons[0] = new UWTileMap(0);
+
+        Assert.NotNull(UWTileMap.dungeons[0].lev_ark_block?.Data);
+
+        // Mutate a known safe byte (0x7BFF — last byte before the "uw" sentinel at 0x7C06-0x7C07).
+        const int SafeOffset = 0x7BFF;
+        byte originalByte = UWTileMap.dungeons[0].lev_ark_block.Data[SafeOffset];
+        byte modifiedByte = (byte)(originalByte ^ 0xFF);
+        UWTileMap.dungeons[0].lev_ark_block.Data[SafeOffset] = modifiedByte;
+
+        // Serialize and replace in-memory ARK data.
+        byte[] rewritten = LevArkWriter.Serialize();
+        Assert.NotNull(rewritten);
+        LevArkLoader.lev_ark_file_data = rewritten;
+
+        // Re-extract block 0 and verify the mutation was preserved.
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+        Assert.NotNull(reloadedBlock0?.Data);
+        Assert.True(reloadedBlock0.Data.Length > SafeOffset,
+            "Re-loaded block 0 must be large enough to contain offset 0x7BFF");
+        Assert.Equal(modifiedByte, reloadedBlock0.Data[SafeOffset]);
+    }
+
+    [Fact]
+    public void Uw1FullArk_Reassemble_Block0ReadBackIdentically()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        Assert.NotNull(originalBlock0);
+        Assert.NotNull(originalBlock0.Data);
+        Assert.True(originalBlock0.DataLen > 0, "UW1 block 0 DataLen should be > 0");
+
+        // Reassemble the full ARK — no dungeons[] are loaded, so all blocks pass through from source.
+        byte[] rewritten = LevArkWriter.Serialize();
+
+        Assert.NotNull(rewritten);
+
+        // Replace in-memory ARK data and re-extract block 0.
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        Assert.NotNull(reloadedBlock0);
+        Assert.NotNull(reloadedBlock0.Data);
+
+        int compareLen = Math.Min(originalBlock0.Data.Length, reloadedBlock0.Data.Length);
+        Assert.True(compareLen > 0, "Re-loaded UW1 block 0 must have data");
 
         for (int i = 0; i < compareLen; i++)
         {

--- a/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+// Share a collection with other UWClass-state tests to serialise them and avoid static-state races.
+[Collection("UWClassState")]
+public class LevArkRoundTripTests : IDisposable
+{
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+    private readonly byte[] _origLevArkFileData;
+
+    public LevArkRoundTripTests()
+    {
+        _origBasePath = Underworld.UWClass.BasePath;
+        _origRes = Underworld.UWClass._RES;
+        _origLevArkFileData = Underworld.LevArkLoader.lev_ark_file_data;
+    }
+
+    public void Dispose()
+    {
+        Underworld.UWClass.BasePath = _origBasePath;
+        Underworld.UWClass._RES = _origRes;
+        Underworld.LevArkLoader.lev_ark_file_data = _origLevArkFileData;
+    }
+
+    [Fact]
+    public void Uw2Level0_LoadExtractReserialize_TilemapBlockIdentical()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+
+        LevArkLoader.LoadLevArkFileData(folder: "SAVE0");
+        UWBlock block = LevArkLoader.LoadLevArkBlock(0);
+
+        Assert.NotNull(block);
+        Assert.NotNull(block.Data);
+        Assert.True(block.DataLen > 0, "Block 0 DataLen should be > 0");
+
+        byte[] rewritten = LevArkWriter.SerializeLevelBlock(block);
+
+        Assert.NotNull(rewritten);
+        int compareLen = Math.Min(rewritten.Length, block.Data.Length);
+        for (int i = 0; i < compareLen; i++)
+        {
+            Assert.True(block.Data[i] == rewritten[i],
+                $"Byte mismatch at 0x{i:X4}: original=0x{block.Data[i]:X2}, rewritten=0x{rewritten[i]:X2}");
+        }
+    }
+
+    [Fact]
+    public void Uw2FullArk_Reassemble_BlocksAtDocumentedOffsetsReadBackIdentically()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+
+        LevArkLoader.LoadLevArkFileData(folder: "SAVE0");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        Assert.NotNull(originalBlock0);
+        Assert.NotNull(originalBlock0.Data);
+
+        // Reassemble the full ARK — no dungeons[] are loaded, so all blocks pass through from source.
+        byte[] rewritten = LevArkWriter.Serialize();
+
+        Assert.NotNull(rewritten);
+
+        // Replace in-memory ARK data and re-extract block 0.
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        Assert.NotNull(reloadedBlock0);
+        Assert.NotNull(reloadedBlock0.Data);
+
+        int compareLen = Math.Min(originalBlock0.Data.Length, reloadedBlock0.Data.Length);
+        Assert.True(compareLen > 0, "Re-loaded block 0 must have data");
+
+        for (int i = 0; i < compareLen; i++)
+        {
+            Assert.True(originalBlock0.Data[i] == reloadedBlock0.Data[i],
+                $"Byte mismatch at 0x{i:X4}: original=0x{originalBlock0.Data[i]:X2}, reloaded=0x{reloadedBlock0.Data[i]:X2}");
+        }
+    }
+}

--- a/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
@@ -154,4 +154,208 @@ public class LevArkRoundTripTests : IDisposable
                 $"Byte mismatch at 0x{i:X4}: original=0x{originalBlock0.Data[i]:X2}, reloaded=0x{reloadedBlock0.Data[i]:X2}");
         }
     }
+
+    // Progressive regression test for the "DOS UW.EXE rejects port-saved LEV.ARK"
+    // bug (observable symptoms: missing inventory, wrong textures, wrong map
+    // location in UW.EXE after restoring a save written by the port).
+    //
+    // Baseline: load DATA, construct UWTileMap via the same path LoadTileMap
+    // does (but stop before BuildTileMapUW / GenerateObjects / PlacePlayerInTile),
+    // serialize, compare level 0 block byte-for-byte with original DATA.
+    //
+    // The constructor just calls LoadLevArkBlock — if this test fails, the
+    // problem is earlier than any gameplay code.
+    [Fact]
+    public void Uw1DungeonCtor_FromData_SerializeBlock0_IdenticalToDataBytes()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+        byte[] originalBytes = (byte[])originalBlock0.Data.Clone();
+
+        // Populate dungeons[0] the way the game does on first level load.
+        UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+        UWTileMap.dungeons[0] = new UWTileMap(0);
+
+        byte[] rewritten = LevArkWriter.Serialize();
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        int compareLen = Math.Min(originalBytes.Length, reloadedBlock0.Data.Length);
+        int firstDiff = -1;
+        int diffCount = 0;
+        for (int i = 0; i < compareLen; i++)
+        {
+            if (originalBytes[i] != reloadedBlock0.Data[i])
+            {
+                if (firstDiff == -1) firstDiff = i;
+                diffCount++;
+            }
+        }
+        Assert.True(diffCount == 0,
+            $"UW1 level 0 byte-identity lost after dungeon ctor + Serialize: {diffCount} diffs, first at 0x{firstDiff:X4}");
+    }
+
+    // Next step: after UWTileMap ctor, also run BuildTileMapUW — which calls
+    // BuildObjectListUW, propagates obj.tileX/tileY from the tile chains, and
+    // runs CleanUp. If this step introduces byte mutations, the culprit is
+    // inside BuildTileMapUW.
+    [Fact]
+    public void Uw1DungeonCtor_AndBuildTileMap_SerializeBlock0_IdenticalToDataBytes()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+        byte[] originalBytes = (byte[])originalBlock0.Data.Clone();
+
+        UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+        UWTileMap.dungeons[0] = new UWTileMap(0);
+        UWTileMap.current_tilemap = UWTileMap.dungeons[0];
+
+        // Run the tilemap / object-list / cleanup phases of LoadTileMap.
+        UWTileMap.dungeons[0].BuildTileMapUW(
+            levelNo: 0,
+            tex_ark: UWTileMap.dungeons[0].tex_ark_block,
+            ovl_ark: UWTileMap.dungeons[0].ovl_ark_block);
+
+        byte[] rewritten = LevArkWriter.Serialize();
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        int compareLen = Math.Min(originalBytes.Length, reloadedBlock0.Data.Length);
+        int firstDiff = -1;
+        int diffCount = 0;
+        for (int i = 0; i < compareLen; i++)
+        {
+            if (originalBytes[i] != reloadedBlock0.Data[i])
+            {
+                if (firstDiff == -1) firstDiff = i;
+                diffCount++;
+            }
+        }
+        Assert.True(diffCount == 0,
+            $"UW1 level 0 byte-identity lost after BuildTileMapUW + Serialize: {diffCount} diffs, first at 0x{firstDiff:X4}");
+    }
+
+    // Next step: mimic the player-stash copy that uimanager_mainmenu.cs:277-282
+    // performs (copying 27 bytes of pdat back into playerObject's DataBuffer).
+    // Uses InitEmptyPlayer so pdat is all zeros (which itself is a hypothetical
+    // "empty character" scenario); the copy writes those zeros into slot 1.
+    [Fact]
+    public void Uw1_AddPlayerStashToSlot1_DiffsLocalisedToMobile1()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+        byte[] originalBytes = (byte[])originalBlock0.Data.Clone();
+
+        UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+        UWTileMap.dungeons[0] = new UWTileMap(0);
+        UWTileMap.current_tilemap = UWTileMap.dungeons[0];
+        UWTileMap.dungeons[0].BuildTileMapUW(
+            levelNo: 0,
+            tex_ark: UWTileMap.dungeons[0].tex_ark_block,
+            ovl_ark: UWTileMap.dungeons[0].ovl_ark_block);
+
+        playerdat.InitEmptyPlayer("TestPlayer");
+
+        // Simulate uimanager_mainmenu.cs:277-282 — copy pdat's player-object
+        // storage bytes into the live slot 1 buffer.
+        for (int i = 0; i <= 0x1A; i++)
+        {
+            playerdat.playerObject.DataBuffer[playerdat.playerObject.PTR + i] =
+                playerdat.pdat[playerdat.PlayerObjectStoragePTR + i];
+        }
+
+        byte[] rewritten = LevArkWriter.Serialize();
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        int compareLen = Math.Min(originalBytes.Length, reloadedBlock0.Data.Length);
+        // Tally diffs per region instead of failing on first diff.
+        int mobile1Diffs = 0, otherDiffs = 0;
+        int firstOtherDiff = -1;
+        int mobile1Start = 0x4000 + 27;
+        int mobile1End = mobile1Start + 27;
+        for (int i = 0; i < compareLen; i++)
+        {
+            if (originalBytes[i] == reloadedBlock0.Data[i]) continue;
+            if (i >= mobile1Start && i < mobile1End) mobile1Diffs++;
+            else
+            {
+                if (firstOtherDiff == -1) firstOtherDiff = i;
+                otherDiffs++;
+            }
+        }
+        // Player stash should only touch mobile#1; any diffs outside that slot
+        // indicate a bug elsewhere in this flow.
+        Assert.True(otherDiffs == 0,
+            $"Player stash leaked byte changes outside slot 1: {otherDiffs} diffs, first at 0x{firstOtherDiff:X4}");
+    }
+
+    // Next step: add PlacePlayerInTile. Expect this to modify the target tile's
+    // indexObjectList (bytes 2-3 of that tile's entry) and the player slot's
+    // .next field — but nothing else. Anything outside those regions is a bug.
+    [Fact]
+    public void Uw1_AddPlacePlayerInTile_DiffsLocalisedToPlayerAndOneTile()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWBlock originalBlock0 = LevArkLoader.LoadLevArkBlock(0);
+        byte[] originalBytes = (byte[])originalBlock0.Data.Clone();
+
+        UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+        UWTileMap.dungeons[0] = new UWTileMap(0);
+        UWTileMap.current_tilemap = UWTileMap.dungeons[0];
+        UWTileMap.dungeons[0].BuildTileMapUW(
+            levelNo: 0,
+            tex_ark: UWTileMap.dungeons[0].tex_ark_block,
+            ovl_ark: UWTileMap.dungeons[0].ovl_ark_block);
+
+        playerdat.InitEmptyPlayer("TestPlayer");
+        for (int i = 0; i <= 0x1A; i++)
+        {
+            playerdat.playerObject.DataBuffer[playerdat.playerObject.PTR + i] =
+                playerdat.pdat[playerdat.PlayerObjectStoragePTR + i];
+        }
+        playerdat.playerObject.item_id = 127;
+        playerdat.playerObject.link = 0;
+
+        // Default UW1 start tile.
+        const int StartX = 32;
+        const int StartY = 1;
+        playerdat.PlacePlayerInTile(newTileX: StartX, newTileY: StartY, previousTileX: -1, previousTileY: -1);
+
+        byte[] rewritten = LevArkWriter.Serialize();
+        LevArkLoader.lev_ark_file_data = rewritten;
+        UWBlock reloadedBlock0 = LevArkLoader.LoadLevArkBlock(0);
+
+        // Categorise diffs: slot 1 (mobile#1), target tile's entry, "other".
+        int compareLen = Math.Min(originalBytes.Length, reloadedBlock0.Data.Length);
+        int mobile1Diffs = 0, targetTileDiffs = 0, otherDiffs = 0;
+        int firstOtherDiff = -1;
+        int mobile1Start = 0x4000 + 27, mobile1End = mobile1Start + 27;
+        int targetTileOff = (StartY * 64 + StartX) * 4;
+        for (int i = 0; i < compareLen; i++)
+        {
+            if (originalBytes[i] == reloadedBlock0.Data[i]) continue;
+            if (i >= mobile1Start && i < mobile1End) mobile1Diffs++;
+            else if (i >= targetTileOff && i < targetTileOff + 4) targetTileDiffs++;
+            else
+            {
+                if (firstOtherDiff == -1) firstOtherDiff = i;
+                otherDiffs++;
+            }
+        }
+        Assert.True(otherDiffs == 0,
+            $"PlacePlayerInTile leaked byte changes outside slot 1 and target tile ({StartX},{StartY}): {otherDiffs} diffs, first at 0x{firstOtherDiff:X4}");
+    }
 }

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -38,10 +38,14 @@ public class PlayerDatRoundTripTests : IDisposable
 
         // File length mirrors the load loop in playerdatutil.cs:Load: slot i lives at
         // PTR = InventoryPtr + (i-1)*8, so N populated slots occupy N*8 bytes past InventoryPtr.
-        int expectedLen = Underworld.playerdat.InventoryPtr
-            + Underworld.PlayerDatWriter.LastPopulatedInventorySlot() * 8;
+        // Floor of one zero slot is enforced by SerializeUw1Canonical to avoid the
+        // DOS UW.EXE Journey-Onward hang when PLAYER.DAT ends exactly at InventoryPtr.
+        int slotsExpected = Math.Max(Underworld.PlayerDatWriter.LastPopulatedInventorySlot(), 1);
+        int expectedLen = Underworld.playerdat.InventoryPtr + slotsExpected * 8;
         Assert.Equal(expectedLen, decrypted.Length);
-        for (int i = 0; i < expectedLen; i++)
+        // Compare only the populated header region; padded trailing slot is
+        // zeros and is not present in the in-memory pdat at the same offset.
+        for (int i = 0; i < Underworld.playerdat.InventoryPtr; i++)
         {
             Assert.True(originalPdat[i] == decrypted[i],
                 $"Byte mismatch at 0x{i:X4}: expected 0x{originalPdat[i]:X2}, got 0x{decrypted[i]:X2}");
@@ -258,5 +262,25 @@ public class PlayerDatRoundTripTests : IDisposable
         var s1 = ReadSlotFromDecrypted(decrypted, 1);
         Assert.Equal(130, s1.itemId);
         Assert.Equal(0, s1.link);  // out-of-range slot resolves to 0 (no link)
+    }
+
+    [Fact]
+    public void Uw1Serialize_EmptyInventory_PadsToAtLeastOneSlot()
+    {
+        // DOS UW.EXE hangs at "You reenter the Abyss..." when PLAYER.DAT
+        // ends exactly at InventoryPtr (0x138) with zero inventory slots.
+        // A fresh port chargen with no items in BP0..BP7 + paperdoll used
+        // to produce a 312-byte file. Verified empirically against UW.EXE
+        // under js-dos that one zero slot (file >= 0x140 = 320 bytes) is
+        // sufficient to unstick the load path.
+        SetupUw1WithPdat();
+        // Leave BP0..BP7 + paperdoll all zero — no items anywhere.
+
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        Assert.NotNull(encrypted);
+        Assert.True(
+            encrypted.Length >= Underworld.playerdat.InventoryPtr + 8,
+            $"empty-inventory PLAYER.DAT must be at least {Underworld.playerdat.InventoryPtr + 8} bytes " +
+            $"to unstick DOS UW.EXE Journey-Onward; got {encrypted.Length}");
     }
 }

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -95,15 +95,16 @@ public class PlayerDatRoundTripTests : IDisposable
     }
 
     [Fact]
-    public void Uw1InitEmptyPlayer_PdatD3IsDosChargenValue()
+    public void Uw1InitEmptyPlayer_PdatD3IsShadesDatLightIndex()
     {
         Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
         Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
         Underworld.playerdat.InitEmptyPlayer("TestGronk");
 
-        // DOS chargen writes 0x08 at pdat[0xD3]; leaving 0 hangs DOS load.
-        // Semantics TBD — see docs/save-architecture.md §5.
-        Assert.Equal(0x08, Underworld.playerdat.pdat[0xD3]);
+        // pdat[0xD3] = ShadeCutOff (per Hank/RE on PR #33). Valid range
+        // 0..7 indexes shades.dat (96 bytes / 12 bytes per entry).
+        // Chargen default is 3 = Light. See docs/save-architecture.md §5.
+        Assert.Equal(0x03, Underworld.playerdat.pdat[0xD3]);
     }
 
     [Fact]
@@ -116,5 +117,146 @@ public class PlayerDatRoundTripTests : IDisposable
         // UW2 chargen must not touch UW1-specific marker bytes; the gates
         // in InitEmptyPlayer leave pdat[0xD3] zero on UW2.
         Assert.Equal(0x00, Underworld.playerdat.pdat[0xD3]);
+    }
+
+    // -------------------------------------------------------------------------
+    // PlayerDatWriter behavioural regressions (Hank's PR #33 review)
+    //
+    // These tests synthesise specific in-memory inventory states and assert
+    // the writer produces correct output. They cover the three concrete
+    // failure modes Hank reported / the code-review identified:
+    //   - is_quant link follow-as-slot (Alfred's letter at link=514)
+    //   - sack-class bit-0 toggle corrupting nested item 143 (runebag)
+    //   - out-of-range slot reference throwing IndexOutOfRange
+    // -------------------------------------------------------------------------
+
+    private static void SetupUw1WithPdat()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+    }
+
+    // Write a single 8-byte inventory slot record at the given slot index
+    // (1-based, per the load loop convention).
+    private static void WriteSlot(int slot, int item_id, bool is_quant, int link, int next, int qual = 0)
+    {
+        int o = Underworld.playerdat.InventoryPtr + (slot - 1) * 8;
+        int word0 = (item_id & 0x1FF) | (is_quant ? 0x8000 : 0);
+        Underworld.playerdat.pdat[o]     = (byte)(word0 & 0xFF);
+        Underworld.playerdat.pdat[o + 1] = (byte)((word0 >> 8) & 0xFF);
+        // pos word at +2 — leave at 0 (we don't care for chain tests).
+        Underworld.playerdat.pdat[o + 2] = 0;
+        Underworld.playerdat.pdat[o + 3] = 0;
+        // word2: bits 0-5 quality, bits 6-15 next
+        int word2 = (qual & 0x3F) | ((next & 0x3FF) << 6);
+        Underworld.playerdat.pdat[o + 4] = (byte)(word2 & 0xFF);
+        Underworld.playerdat.pdat[o + 5] = (byte)((word2 >> 8) & 0xFF);
+        // word3: bits 0-5 owner=0, bits 6-15 link
+        int word3 = ((link & 0x3FF) << 6);
+        Underworld.playerdat.pdat[o + 6] = (byte)(word3 & 0xFF);
+        Underworld.playerdat.pdat[o + 7] = (byte)((word3 >> 8) & 0xFF);
+    }
+
+    private static void SetBp0(int slot)
+    {
+        // BP0 pointer at pdat[0x10E], 10-bit slot in bits 6-15
+        int w = (slot & 0x3FF) << 6;
+        Underworld.playerdat.pdat[0x10E] = (byte)(w & 0xFF);
+        Underworld.playerdat.pdat[0x10F] = (byte)((w >> 8) & 0xFF);
+    }
+
+    private static (int itemId, bool isQuant, int next, int link) ReadSlotFromDecrypted(byte[] pdat, int slot)
+    {
+        int o = Underworld.playerdat.InventoryPtr + (slot - 1) * 8;
+        int w0 = pdat[o] | (pdat[o + 1] << 8);
+        int item_id = w0 & 0x1FF;
+        bool isq = (w0 & 0x8000) != 0;
+        int next = (pdat[o + 4] | (pdat[o + 5] << 8)) >> 6;
+        int link = (pdat[o + 6] | (pdat[o + 7] << 8)) >> 6;
+        return (item_id, isq, next & 0x3FF, link & 0x3FF);
+    }
+
+    [Fact]
+    public void Uw1Serialize_IsQuantLinkAtTopLevel_LeavesLinkVerbatim()
+    {
+        // Alfred's letter case: top-level item with is_quant=1 and link=514
+        // (= property 2). The DFS must NOT follow link as a slot reference;
+        // the emit pass must preserve the literal link value.
+        SetupUw1WithPdat();
+        // BP0 → slot 1 = Alfred's letter (id 312, is_quant=1, link 514)
+        SetBp0(1);
+        WriteSlot(slot: 1, item_id: 312, is_quant: true, link: 514, next: 0);
+
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        var s1 = ReadSlotFromDecrypted(decrypted, 1);
+        Assert.Equal(312, s1.itemId);
+        Assert.True(s1.isQuant);
+        Assert.Equal(514, s1.link);  // preserved verbatim, not walked-as-slot
+    }
+
+    [Fact]
+    public void Uw1Serialize_NestedSackInsidePack_KeepsItem143()
+    {
+        // Hank's Carrying-Backpack scenario: BP0 = pack 130, with a runebag
+        // (item 143, classindex 0xF) inside. The writer must NOT clear bit 0
+        // on the runebag (it's not an open/closed pair — items 140-143 are
+        // distinct items per src/objects/container.cs:26 classindex≤0xB rule).
+        SetupUw1WithPdat();
+        SetBp0(1);
+        // slot 1 = pack (id 130, link → slot 2)
+        WriteSlot(slot: 1, item_id: 130, is_quant: false, link: 2, next: 0);
+        // slot 2 = runebag inside pack (id 143)
+        WriteSlot(slot: 2, item_id: 143, is_quant: false, link: 0, next: 0);
+
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        var s1 = ReadSlotFromDecrypted(decrypted, 1);
+        var s2 = ReadSlotFromDecrypted(decrypted, 2);
+        Assert.Equal(130, s1.itemId);  // pack kept as-is (already even, no toggle)
+        Assert.Equal(143, s2.itemId);  // runebag NOT corrupted to 142
+    }
+
+    [Fact]
+    public void Uw1Serialize_TopLevelOpenSack_ClosedOnSerialise()
+    {
+        // Counter-test: the close-bit toggle SHOULD fire for top-level
+        // sack-class items 128-139 (classindex 0..0xB). An open sack (129)
+        // at BP0 must be saved as closed (128).
+        SetupUw1WithPdat();
+        SetBp0(1);
+        WriteSlot(slot: 1, item_id: 129, is_quant: false, link: 0, next: 0);
+
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        var s1 = ReadSlotFromDecrypted(decrypted, 1);
+        Assert.Equal(128, s1.itemId);  // closed
+    }
+
+    [Fact]
+    public void Uw1Serialize_OutOfRangeLinkSlot_DoesNotThrow()
+    {
+        // A top-level non-quant container with link pointing at slot 600
+        // (out of port pdat range) must not throw IndexOutOfRange. Either
+        // the bounds check returns 0 silently or the result is well-defined
+        // and exception-free.
+        SetupUw1WithPdat();
+        SetBp0(1);
+        // slot 1 = pack with link → slot 600 (well past pdat 512-slot limit)
+        WriteSlot(slot: 1, item_id: 130, is_quant: false, link: 600, next: 0);
+
+        // Should NOT throw.
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        Assert.NotNull(encrypted);
+        Assert.True(encrypted.Length >= Underworld.playerdat.InventoryPtr);
+
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+        var s1 = ReadSlotFromDecrypted(decrypted, 1);
+        Assert.Equal(130, s1.itemId);
+        Assert.Equal(0, s1.link);  // out-of-range slot resolves to 0 (no link)
     }
 }

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+// Share a collection with other UWClass-state tests to serialise them and avoid static-state races.
+[Collection("UWClassState")]
+public class PlayerDatRoundTripTests : IDisposable
+{
+    // Save/restore UWClass static state so tests don't leak to other collections.
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+
+    public PlayerDatRoundTripTests()
+    {
+        _origBasePath = Underworld.UWClass.BasePath;
+        _origRes = Underworld.UWClass._RES;
+    }
+
+    public void Dispose()
+    {
+        Underworld.UWClass.BasePath = _origBasePath;
+        Underworld.UWClass._RES = _origRes;
+    }
+
+    [Fact]
+    public void Uw1InitEmptyPlayer_SerializeDecrypt_ByteIdenticalInPopulatedRegion()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+
+        byte[] originalPdat = (byte[])Underworld.playerdat.pdat.Clone();
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        int expectedLen = Underworld.playerdat.InventoryPtr
+            + (Underworld.PlayerDatWriter.LastPopulatedInventorySlot() + 1) * 8;
+        Assert.Equal(expectedLen, decrypted.Length);
+        for (int i = 0; i < expectedLen; i++)
+        {
+            Assert.True(originalPdat[i] == decrypted[i],
+                $"Byte mismatch at 0x{i:X4}: expected 0x{originalPdat[i]:X2}, got 0x{decrypted[i]:X2}");
+        }
+    }
+
+    [Fact]
+    public void Uw2InitEmptyPlayer_SerializeDecrypt_ByteIdenticalInPopulatedRegion()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+
+        byte[] originalPdat = (byte[])Underworld.playerdat.pdat.Clone();
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] decrypted = Underworld.playerdat.EncryptDecryptUW2(encrypted, encrypted[0]);
+
+        int expectedLen = Underworld.playerdat.InventoryPtr
+            + (Underworld.PlayerDatWriter.LastPopulatedInventorySlot() + 1) * 8;
+        Assert.Equal(expectedLen, decrypted.Length);
+        for (int i = 0; i < expectedLen; i++)
+        {
+            Assert.True(originalPdat[i] == decrypted[i],
+                $"Byte mismatch at 0x{i:X4}: expected 0x{originalPdat[i]:X2}, got 0x{decrypted[i]:X2}");
+        }
+    }
+}

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -71,4 +71,50 @@ public class PlayerDatRoundTripTests : IDisposable
                 $"Byte mismatch at 0x{i:X4}: expected 0x{originalPdat[i]:X2}, got 0x{decrypted[i]:X2}");
         }
     }
+
+    // -------------------------------------------------------------------------
+    // DOS round-trip marker guards
+    //
+    // Regression guards for the UW1 DOS round-trip byte-level fixes
+    // (see docs/save-architecture.md "UW1 DOS round-trip"). If a future
+    // refactor zeroes these markers, DOS UW.EXE will refuse to load
+    // port-written saves but the in-port loader won't notice.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Uw1InitEmptyPlayer_DetailLevelDefaultsToVeryHigh()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+
+        // pdat[0xB6] bits 4-5 = UW1 graphics detail level. DOS chargen sets
+        // it to Very High (3); 0 (Low) renders DOS-loaded saves flat-shaded.
+        Assert.Equal(3, Underworld.playerdat.DetailLevel);
+        Assert.Equal(0x30, Underworld.playerdat.pdat[0xB6] & 0x30);
+    }
+
+    [Fact]
+    public void Uw1InitEmptyPlayer_PdatD3IsDosChargenValue()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+
+        // DOS chargen writes 0x08 at pdat[0xD3]; leaving 0 hangs DOS load.
+        // Semantics TBD — see docs/save-architecture.md §5.
+        Assert.Equal(0x08, Underworld.playerdat.pdat[0xD3]);
+    }
+
+    [Fact]
+    public void Uw2InitEmptyPlayer_DoesNotTouchUw1Markers()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+        Underworld.playerdat.InitEmptyPlayer("TestGronk");
+
+        // UW2 chargen must not touch UW1-specific marker bytes; the gates
+        // in InitEmptyPlayer leave pdat[0xD3] zero on UW2.
+        Assert.Equal(0x00, Underworld.playerdat.pdat[0xD3]);
+    }
 }

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -36,8 +36,10 @@ public class PlayerDatRoundTripTests : IDisposable
         byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
         byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
 
+        // File length mirrors the load loop in playerdatutil.cs:Load: slot i lives at
+        // PTR = InventoryPtr + (i-1)*8, so N populated slots occupy N*8 bytes past InventoryPtr.
         int expectedLen = Underworld.playerdat.InventoryPtr
-            + (Underworld.PlayerDatWriter.LastPopulatedInventorySlot() + 1) * 8;
+            + Underworld.PlayerDatWriter.LastPopulatedInventorySlot() * 8;
         Assert.Equal(expectedLen, decrypted.Length);
         for (int i = 0; i < expectedLen; i++)
         {
@@ -58,8 +60,10 @@ public class PlayerDatRoundTripTests : IDisposable
         byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
         byte[] decrypted = Underworld.playerdat.EncryptDecryptUW2(encrypted, encrypted[0]);
 
+        // File length mirrors the load loop in playerdatutil.cs:Load: slot i lives at
+        // PTR = InventoryPtr + (i-1)*8, so N populated slots occupy N*8 bytes past InventoryPtr.
         int expectedLen = Underworld.playerdat.InventoryPtr
-            + (Underworld.PlayerDatWriter.LastPopulatedInventorySlot() + 1) * 8;
+            + Underworld.PlayerDatWriter.LastPopulatedInventorySlot() * 8;
         Assert.Equal(expectedLen, decrypted.Length);
         for (int i = 0; i < expectedLen; i++)
         {

--- a/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
+++ b/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
@@ -164,30 +164,31 @@ public class SaveGameOrchestratorTests : IDisposable
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void Save_DescContainsExactAsciiBytes()
+    public void Save_DescIsExactlyOneByte()
     {
+        // DOS UW.EXE writes a single-byte DESC file (an in-use flag, not a
+        // user-visible description). Writing more than one byte causes the
+        // DOS load picker to read trailing junk.
         SetupUw1State();
         UWClass.BasePath = _tempRoot;
-        const string desc = "test desc";
 
-        SaveGame.Save(3, desc);
+        SaveGame.Save(3, "test desc");
 
-        string written = File.ReadAllText(Path.Combine(_tempRoot, "SAVE3", "DESC"), Encoding.ASCII);
-        Assert.Equal(desc, written);
+        byte[] raw = File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE3", "DESC"));
+        Assert.Equal(1, raw.Length);
     }
 
     [Fact]
-    public void Save_DescContainsNoNullTerminator()
+    public void Save_DescEncodesFirstCharacter()
     {
         SetupUw1State();
         UWClass.BasePath = _tempRoot;
-        const string desc = "no null";
 
-        SaveGame.Save(4, desc);
+        SaveGame.Save(4, "hello");
 
         byte[] raw = File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE4", "DESC"));
-        Assert.Equal(Encoding.ASCII.GetByteCount(desc), raw.Length);
-        Assert.DoesNotContain((byte)0x00, raw);
+        Assert.Single(raw);
+        Assert.Equal((byte)'h', raw[0]);
     }
 
     // -------------------------------------------------------------------------
@@ -228,18 +229,19 @@ public class SaveGameOrchestratorTests : IDisposable
     [Fact]
     public void Save_Uw2_OverwritesExistingFiles()
     {
-        // First save
+        // DESC is a single byte (DOS format) — the first character encodes
+        // something close to a slot-in-use flag. Overwrite must still replace
+        // the byte, not append.
         SetupUw2State();
         UWClass.BasePath = _tempRoot;
         SaveGame.Save(3, "first");
 
         string descPath = Path.Combine(_tempRoot, "SAVE3", "DESC");
-        Assert.Equal("first", File.ReadAllText(descPath, Encoding.ASCII));
+        Assert.Equal(new byte[] { (byte)'f' }, File.ReadAllBytes(descPath));
 
-        // Second save — must overwrite DESC (re-setup state since BasePath changed)
         SetupUw2State();
         UWClass.BasePath = _tempRoot;
         SaveGame.Save(3, "second");
-        Assert.Equal("second", File.ReadAllText(descPath, Encoding.ASCII));
+        Assert.Equal(new byte[] { (byte)'s' }, File.ReadAllBytes(descPath));
     }
 }

--- a/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
+++ b/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Integration tests for SaveGame.Save — verifies that all five files are written
+/// correctly, SCD.ARK is skipped for UW1, and invalid slot throws.
+/// </summary>
+[Collection("UWClassState")]
+public class SaveGameOrchestratorTests : IDisposable
+{
+    // Saved UWClass static state
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+    private readonly string _origCurrentFolder;
+    private readonly byte[] _origLevArkFileData;
+    private readonly UWTileMap[] _origDungeons;
+    private readonly UWBlock[] _origScdData;
+    private readonly bglobal.BablGlobal[] _origBGlobals;
+
+    // Temp directory created per-test-class, deleted in Dispose
+    private readonly string _tempRoot;
+
+    public SaveGameOrchestratorTests()
+    {
+        _origBasePath       = UWClass.BasePath;
+        _origRes            = UWClass._RES;
+        _origCurrentFolder  = playerdat.currentfolder;
+        _origLevArkFileData = LevArkLoader.lev_ark_file_data;
+        _origDungeons       = UWTileMap.dungeons;
+        _origScdData        = scd.scd_data;
+        _origBGlobals       = bglobal.bGlobals;
+
+        _tempRoot = Path.Combine(Path.GetTempPath(), "uw-save-test-" + Guid.NewGuid());
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        UWClass.BasePath               = _origBasePath;
+        UWClass._RES                   = _origRes;
+        playerdat.currentfolder        = _origCurrentFolder;
+        LevArkLoader.lev_ark_file_data = _origLevArkFileData;
+        UWTileMap.dungeons             = _origDungeons;
+        scd.scd_data                   = _origScdData;
+        bglobal.bGlobals               = _origBGlobals;
+
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Set up minimal UW1 state using real game data (LEV.ARK from DATA).
+    /// BasePath is set to the real UW1 path; caller must redirect it to _tempRoot
+    /// only AFTER calling this.
+    /// </summary>
+    private void SetupUw1State()
+    {
+        UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        UWClass._RES     = UWClass.GAME_UW1;
+        playerdat.InitEmptyPlayer("TestSave");
+        bglobal.bGlobals = Array.Empty<bglobal.BablGlobal>();
+        // Load real UW1 lev_ark_file_data so AssembleUW1Ark doesn't crash.
+        LevArkLoader.LoadLevArkFileData(folder: "DATA");
+        UWTileMap.dungeons = null;
+        scd.scd_data = null;
+        playerdat.currentfolder = "DATA";
+    }
+
+    /// <summary>
+    /// Set up minimal UW2 state using real SAVE0 data.
+    /// Uses InitEmptyPlayer (Godot-free) + direct bglobal/lev loading.
+    /// Copies SCD.ARK from SAVE0 into _tempRoot/SAVE0/ so ScdArkWriter can find it
+    /// when BasePath is redirected.
+    /// </summary>
+    private void SetupUw2State()
+    {
+        UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        UWClass._RES     = UWClass.GAME_UW2;
+        playerdat.InitEmptyPlayer("TestSaveUW2");
+        bglobal.LoadGlobals("SAVE0");
+        LevArkLoader.LoadLevArkFileData(folder: "SAVE0");
+        UWTileMap.dungeons = null;
+        scd.scd_data = null;
+        playerdat.currentfolder = "SAVE0";
+
+        // Copy SCD.ARK from the real SAVE0 into the temp SAVE0 folder so
+        // ScdArkWriter (which reads from BasePath/folder/SCD.ARK) can find it
+        // after we redirect BasePath to _tempRoot.
+        string srcScd = Path.Combine(TestData.UW2GogRoot, "UW2", "SAVE0", "SCD.ARK");
+        string dstDir  = Path.Combine(_tempRoot, "SAVE0");
+        Directory.CreateDirectory(dstDir);
+        File.Copy(srcScd, Path.Combine(dstDir, "SCD.ARK"), overwrite: true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid-slot tests — no game state required
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(-1)]
+    public void Save_InvalidSlot_ThrowsArgumentOutOfRangeException(int slot)
+    {
+        UWClass.BasePath = _tempRoot;
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SaveGame.Save(slot, "test"));
+        Assert.Equal("slot", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    public void Save_InvalidSlot_DoesNotCreateSaveDirectory(int slot)
+    {
+        UWClass.BasePath = _tempRoot;
+        try { SaveGame.Save(slot, "test"); } catch (ArgumentOutOfRangeException) { }
+        Assert.False(Directory.Exists(Path.Combine(_tempRoot, $"SAVE{slot}")));
+    }
+
+    // -------------------------------------------------------------------------
+    // UW1 tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Save_Uw1_WritesExpectedFilesExceptScdArk()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;  // redirect output to temp dir
+
+        SaveGame.Save(1, "uw1 save test");
+
+        string saveDir = Path.Combine(_tempRoot, "SAVE1");
+        Assert.True(File.Exists(Path.Combine(saveDir, "DESC")),         "DESC missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "PLAYER.DAT")),  "PLAYER.DAT missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "BGLOBALS.DAT")),"BGLOBALS.DAT missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "LEV.ARK")),      "LEV.ARK missing");
+        // SCD.ARK must NOT be written for UW1
+        Assert.False(File.Exists(Path.Combine(saveDir, "SCD.ARK")),    "SCD.ARK must not exist for UW1");
+    }
+
+    [Fact]
+    public void Save_Uw1_FilesHaveNonZeroSize()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(2, "uw1 size check");
+
+        string saveDir = Path.Combine(_tempRoot, "SAVE2");
+        Assert.True(new FileInfo(Path.Combine(saveDir, "PLAYER.DAT")).Length > 0, "PLAYER.DAT empty");
+        Assert.True(new FileInfo(Path.Combine(saveDir, "LEV.ARK")).Length > 0,    "LEV.ARK empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // DESC tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Save_DescContainsExactAsciiBytes()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+        const string desc = "test desc";
+
+        SaveGame.Save(3, desc);
+
+        string written = File.ReadAllText(Path.Combine(_tempRoot, "SAVE3", "DESC"), Encoding.ASCII);
+        Assert.Equal(desc, written);
+    }
+
+    [Fact]
+    public void Save_DescContainsNoNullTerminator()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+        const string desc = "no null";
+
+        SaveGame.Save(4, desc);
+
+        byte[] raw = File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE4", "DESC"));
+        Assert.Equal(Encoding.ASCII.GetByteCount(desc), raw.Length);
+        Assert.DoesNotContain((byte)0x00, raw);
+    }
+
+    // -------------------------------------------------------------------------
+    // UW2 tests — use real SAVE0 fixture
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Save_Uw2_WritesAllFiveFiles()
+    {
+        SetupUw2State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(1, "uw2 save test");
+
+        string saveDir = Path.Combine(_tempRoot, "SAVE1");
+        Assert.True(File.Exists(Path.Combine(saveDir, "DESC")),         "DESC missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "PLAYER.DAT")),  "PLAYER.DAT missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "BGLOBALS.DAT")),"BGLOBALS.DAT missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "LEV.ARK")),      "LEV.ARK missing");
+        Assert.True(File.Exists(Path.Combine(saveDir, "SCD.ARK")),      "SCD.ARK missing for UW2");
+    }
+
+    [Fact]
+    public void Save_Uw2_AllFilesNonZeroSize()
+    {
+        SetupUw2State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(2, "uw2 size check");
+
+        string saveDir = Path.Combine(_tempRoot, "SAVE2");
+        foreach (var fname in new[] { "DESC", "PLAYER.DAT", "BGLOBALS.DAT", "LEV.ARK", "SCD.ARK" })
+        {
+            Assert.True(new FileInfo(Path.Combine(saveDir, fname)).Length > 0, $"{fname} is empty");
+        }
+    }
+
+    [Fact]
+    public void Save_Uw2_OverwritesExistingFiles()
+    {
+        // First save
+        SetupUw2State();
+        UWClass.BasePath = _tempRoot;
+        SaveGame.Save(3, "first");
+
+        string descPath = Path.Combine(_tempRoot, "SAVE3", "DESC");
+        Assert.Equal("first", File.ReadAllText(descPath, Encoding.ASCII));
+
+        // Second save — must overwrite DESC (re-setup state since BasePath changed)
+        SetupUw2State();
+        UWClass.BasePath = _tempRoot;
+        SaveGame.Save(3, "second");
+        Assert.Equal("second", File.ReadAllText(descPath, Encoding.ASCII));
+    }
+}

--- a/tests/Underworld.Save.Tests/ScdArkRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/ScdArkRoundTripTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+// Share collection with other UWClass-state tests to serialise them and avoid static-state races.
+[Collection("UWClassState")]
+public class ScdArkRoundTripTests : IDisposable
+{
+    private readonly string _origBasePath;
+    private readonly byte _origRes;
+    private readonly Underworld.UWBlock[] _origScdData;
+
+    public ScdArkRoundTripTests()
+    {
+        _origBasePath = Underworld.UWClass.BasePath;
+        _origRes      = Underworld.UWClass._RES;
+        _origScdData  = Underworld.scd.scd_data;
+    }
+
+    public void Dispose()
+    {
+        Underworld.UWClass.BasePath = _origBasePath;
+        Underworld.UWClass._RES     = _origRes;
+        Underworld.scd.scd_data     = _origScdData;
+    }
+
+    [Fact]
+    public void Uw2Scd_LoadAndSerialize_ByteIdentical()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES     = Underworld.UWClass.GAME_UW2;
+
+        // Ensure no stale in-memory blocks influence the round-trip.
+        Underworld.scd.scd_data = null;
+
+        byte[] original = File.ReadAllBytes(TestData.Uw2Save0("SCD.ARK"));
+
+        byte[] rewritten = ScdArkWriter.Serialize("SAVE0");
+
+        Assert.Equal(original, rewritten);
+    }
+}

--- a/tests/Underworld.Save.Tests/SmokeTest.cs
+++ b/tests/Underworld.Save.Tests/SmokeTest.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Smoke test to verify test infrastructure and fixture accessibility.
+/// </summary>
+public class SmokeTest
+{
+    /// <summary>
+    /// Verify that BGLOBALS.DAT exists at the expected UW2/SAVE0 path.
+    /// </summary>
+    [Fact]
+    public void Uw2Save0BGlobalsExists()
+    {
+        var path = TestData.Uw2Save0("BGLOBALS.DAT");
+        Assert.True(File.Exists(path),
+            $"BGLOBALS.DAT not found at {path}. RepoRoot resolved to: {TestData.RepoRoot}");
+    }
+}

--- a/tests/Underworld.Save.Tests/TestData.cs
+++ b/tests/Underworld.Save.Tests/TestData.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Test fixtures and path resolution for save-game tests.
+/// </summary>
+public static class TestData
+{
+    /// <summary>
+    /// Resolves the repository root by walking up from AppContext.BaseDirectory.
+    /// Uses sentinel-based lookup: stops at the first directory containing Underworld.csproj.
+    /// </summary>
+    public static string RepoRoot
+    {
+        get
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+            while (current != null)
+            {
+                if (File.Exists(Path.Combine(current.FullName, "Underworld.csproj")))
+                {
+                    return current.FullName;
+                }
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException(
+                $"Could not locate repo root (Underworld.csproj) walking up from {AppContext.BaseDirectory}");
+        }
+    }
+
+    /// <summary>
+    /// GOG game data root: resolved as RepoRoot/../UW2GOG.
+    /// </summary>
+    public static string UW2GogRoot => Path.GetFullPath(Path.Combine(RepoRoot, "..", "UW2GOG"));
+
+    /// <summary>
+    /// Returns the path to a file in UW2/SAVE0 (the first save slot).
+    /// </summary>
+    public static string Uw2Save0(string filename) => Path.Combine(UW2GogRoot, "UW2", "SAVE0", filename);
+
+    /// <summary>
+    /// Returns the path to a file in UW1/DATA.
+    /// </summary>
+    public static string Uw1Data(string filename) => Path.Combine(UW2GogRoot, "UW1", "DATA", filename);
+}

--- a/tests/Underworld.Save.Tests/UWClassStateCollection.cs
+++ b/tests/Underworld.Save.Tests/UWClassStateCollection.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// xUnit collection marker: serialises tests that mutate UWClass static state
+/// (BasePath, _RES, playerdat.pdat, etc.) so they don't race across test classes.
+/// </summary>
+[CollectionDefinition("UWClassState")]
+public class UWClassStateCollection { }

--- a/tests/Underworld.Save.Tests/Underworld.Save.Tests.csproj
+++ b/tests/Underworld.Save.Tests/Underworld.Save.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Underworld.Save.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Underworld.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Save-game write path, **scoped to UW1 only**. UW2 is UI-gated pending an upstream UW2 lev.ark compressor. UW1's `lev.ark` is uncompressed by format spec, so the DOS compression issue doesn't apply and this PR can move forward independently.

Design rationale, file layout, and known limitations are in [`docs/save-architecture.md`](docs/save-architecture.md).

## What ships (UW1 only)

`SaveGame.Save(int slot, string description)` writes DESC, PLAYER.DAT, BGLOBALS.DAT, and LEV.ARK to `{BasePath}/SAVE{slot}/`. UI entry is the Save Game button in the Options panel; clicking it while running UW2 prints the existing "save failed" message and refuses to write.

Writers live in a new `src/savegame/` directory. UW2 writers (`ScdArkWriter`, UW2 paths in `LevArkWriter` / `PlayerDatWriter`) remain in the tree with tests — they're re-enabled by removing one `if` in `uimanager_options.cs` once the upstream compressor lands.

## Key design decision (Option B — consolidate at save-time)

The DOS game writes save state in two tiers (continuous partial writeback to \`DATA/\` + wholesale copy to \`SAVE{n}/\` at save-menu time). This PR does one-shot serialisation from in-memory state. Rationale in \`docs/save-architecture.md\`; short version is the port already holds all relevant slices of state in RAM and the two-tier flow would scatter writebacks across unrelated gameplay code.

## Bug fixes in existing code (small and surgical)

- **\`PlacePlayerInTile\` idempotent head-check** — motion inserts the player into every new tile; restoring a save re-inserted them, creating \`LevelObjects[1].next = 1\` → infinite loop in the trigger walker. UW1 didn't hit this (no trigger walker on restore); the fix doesn't affect non-restore behaviour.
- **\`ObjectCreator.RenderObject\` skips \`LevelObjects[1]\`** — after \`PlacePlayerInTile\` the player's adventurer sprite rendered in front of their own camera. Filter affects only slot 1.
- **\`uimanager_flasks\` null guards** — chargen / \`InitEmptyPlayer\` now work outside a running Godot scene (needed for xUnit tests).
- **\`automapnote.Serialize\` + \`LevArkWriter\` reconstructs note blocks** — newly-created automap notes used to pass through from the source ARK unchanged on save, silently losing them. Writer now emits live notes.
- **\`automapnote\` loader off-by-one** — \`GetUpperBound(0)/54\` silently truncated single-note blocks to zero notes. Fixed to use \`Length/54\`.

## Known limitations

- **Automap visited-tile state (colouring) still passes through from source ARK.** Map notes are fixed; visited-tile shading is a follow-up.
- **DOS round-trip not yet verified** via DOSBox. UW1 format is DOS-compatible in principle but end-to-end testing is pending.
- **No atomic write** — partial failure leaves a corrupted \`SAVE{n}/\`. Follow-up: tmp-dir + rename.
- **UI polish** — description defaults to \`\"Save {slot}\"\`; no text-input prompt; Save-menu overwrites without confirm.

## Test plan

Unit + integration tests in new \`tests/Underworld.Save.Tests/\` (xUnit):

- [x] \`BGlobalRoundTripTests\` — real UW2 SAVE0 fixture byte-identical round-trip + empty/one-slot cases
- [x] \`PlayerDatRoundTripTests\` — UW1 and UW2 \`InitEmptyPlayer\` serialise → decrypt → byte-compare
- [x] \`LevArkRoundTripTests\` — per-block extraction round-trip + full-container (UW1 + UW2) + visited-level round-trip
- [x] \`ScdArkRoundTripTests\` — UW2 SAVE0 real-fixture round-trip (retained for when compressor lands)
- [x] \`SaveGameOrchestratorTests\` — all files UW2 / UW1 SCD absent / invalid slot / DESC content
- [x] \`AutomapNotesRoundTripTests\` — \`Serialize\` unit tests + full \`LevArkWriter\` integration

27 save tests + 80 Sfx tests = 107/107 passing. 0 build errors.

- [x] Manual UW1 playthrough: new game → move → drop item → save → quit → restore → state preserved
- [x] Manual UW2 playthrough (before UI gate): same flow, verified end-to-end after \`PlacePlayerInTile\` idempotence fix

## Next steps tracked separately

Bug fixes discovered during code review will land as separate small PRs:
- Free-list allocation guard off-by-one
- \`obj.instance\` not cleared on level teardown (transient twin-NPC flicker)
- \`KillCritter\` ignores \`SpecialDeathCases\` mode-0 return (Golem-revival style)
- DOS cross-compat for UW2 lev.ark (free-list Ptr invariant, freed-slot zeroing, integrity check at save) — defer until the compressor lands