### PR TITLE
fix(world): free-list allocation guard loses last pool slot

### DIFF
--- a/src/utility/ObjectFreeLists.cs
+++ b/src/utility/ObjectFreeLists.cs
@@ -23,7 +23,7 @@ namespace Underworld
             {
                 case ObjectListType.StaticList:
                     //Move PTR down, get object at that point.
-                    if (UWTileMap.current_tilemap.StaticFreeListPtr<=1)
+                    if (UWTileMap.current_tilemap.StaticFreeListPtr<=0)
                     {
                         return 0;
                     }
@@ -31,7 +31,7 @@ namespace Underworld
                     //Debug.Print($"Allocating Static {UWTileMap.current_tilemap.StaticFreeListObject} Pointer decremented to {UWTileMap.current_tilemap.StaticFreeListPtr}");
                     return UWTileMap.current_tilemap.StaticFreeListObject;
                 case ObjectListType.MobileList:
-                    if (UWTileMap.current_tilemap.MobileFreeListPtr<=1)
+                    if (UWTileMap.current_tilemap.MobileFreeListPtr<=0)
                     {
                         return 0;
                     }


### PR DESCRIPTION
## Summary

\`ObjectFreeLists.GetAvailableObjectSlot\` guards with \`Ptr <= 1\`, refusing to allocate when exactly one slot remains in the free list. The port stores the pointer with the "one past top" invariant (Ptr == 1 means one free slot at index 0, Ptr == 0 means empty), so the correct guard is \`Ptr <= 0\`. The current behaviour silently shrinks both the mobile and static free-list pools by one slot.

## Fix

Two one-character changes in \`src/utility/ObjectFreeLists.cs\`:

\`\`\`csharp
- if (UWTileMap.current_tilemap.StaticFreeListPtr<=1)
+ if (UWTileMap.current_tilemap.StaticFreeListPtr<=0)

- if (UWTileMap.current_tilemap.MobileFreeListPtr<=1)
+ if (UWTileMap.current_tilemap.MobileFreeListPtr<=0)
\`\`\`

No test added — the fix is self-evident from the pointer invariant and the accessor layout in \`tilemap.cs\` (\`StaticFreeListObject\` reads at \`0x74FC + Ptr*2\`, so \`Ptr=0\` maps to the first valid slot at offset \`0x74FC\`).

## Context

Discovered during an audit of free-list management in the save-game work (#33). The bug is long-standing but subtle: most saves never approach the pool limits so the shrink goes unnoticed. Included here as a standalone fix independent of the save-game PR since it applies regardless of whether saving is enabled.