### PR TITLE
fix(world): clear uwObject.instance on level teardown

### DIFF
--- a/src/World/tilemap.cs
+++ b/src/World/tilemap.cs
@@ -342,6 +342,23 @@ namespace Underworld
 
         public static void DestroyTileMapAndContents(Node3D the_tiles)
         {
+            // Clear uwObject.instance references before freeing the scene nodes they
+            // point at. Without this, LevelObjects[].instance retains stale references
+            // to QueueFree'd nodes until ObjectCreator.RenderObject overwrites them on
+            // the next level load — a one-frame window where touching instance.uwnode
+            // dereferences a freed Godot node. Mirrors the per-object cleanup already
+            // in objectInstance.RedrawFull.
+            if (current_tilemap != null && current_tilemap.LevelObjects != null)
+            {
+                foreach (var obj in current_tilemap.LevelObjects)
+                {
+                    if (obj != null && obj.instance != null)
+                    {
+                        obj.instance = null;
+                    }
+                }
+            }
+
             //Clear out old data
             foreach (var child in the_tiles.GetChildren())
             {


### PR DESCRIPTION
## Summary

\`DestroyTileMapAndContents\` (\`src/World/tilemap.cs:343\`) \`QueueFree()\`'s the scene children of both \`the_tiles\` and \`ObjectCreator.worldobjects\`, but leaves the matching \`uwObject.instance\` fields pointing at the freed nodes. Until \`ObjectCreator.RenderObject\` overwrites them on the next level load, anything that dereferences \`obj.instance.uwnode\` (or just null-checks \`obj.instance\`) acts on a freed Godot node. The window is typically a single frame, which matches the one-frame flicker seen during level transitions.

## Fix

Walk \`current_tilemap.LevelObjects[]\` and null out \`instance\` before \`QueueFree\`'ing the scene nodes, mirroring the per-object cleanup already in \`objectInstance.RedrawFull\` at \`src/objects/objectinstance.cs:31-38\`.

## Test

No xUnit coverage: the fix requires a running Godot scene and the existing \`Underworld.Sfx.Tests\` suite doesn't exercise \`DestroyTileMapAndContents\`. Verified by inspection and by the existing \`RedrawFull\` pattern.

## Context

Discovered during an audit of object lifetime management in the save-game work (#33). Flagged looking for "twin NPC" duplication symptoms Hank described from the old Unity port. The port doesn't have persistent NPC duplication — that bug-class was already eliminated by the level-cache architecture — but the stale-reference window is the closest analogue and worth closing.