### PR TITLE
fix(npc): KillCritter respects SpecialDeathCases mode 0 return

### DIFF
--- a/src/npc/npcdeath.cs
+++ b/src/npc/npcdeath.cs
@@ -647,12 +647,18 @@ namespace Underworld
 
 
         /// <summary>
-        /// Outright kills an npc
+        /// Outright kills an npc, unless SpecialDeathCases mode 0 signals "stay alive"
+        /// (e.g. Thorlson regenerates, Golem becomes non-hostile instead of dying).
         /// </summary>
         /// <param name="critter"></param>
         public static void KillCritter(uwObject critter)
         {
-            SpecialDeathCases(critter, 0);
+            if (!SpecialDeathCases(critter, 0))
+            {
+                // e.g. Thorlson (npc_whoami == 0xB) and Golem (0x16) set HP / state
+                // inside SpecialDeathCases and signal "do not proceed with death".
+                return;
+            }
             SpecialDeathCases(critter, 1);
             DropRemainsAndLoot(critter);
             //remove from tile and free object


### PR DESCRIPTION
## Summary

\`SpecialDeathCases\` is documented at \`src/npc/npcdeath.cs:16\` as returning "true if NPC should die, otherwise false to stay alive." In \`SpecialDeathCasesUW1\`, the mode-0 branches for Thorlson (\`npc_whoami == 0xB\`) and Golem (\`0x16\`) use that contract to reset HP and combat state without actually dying. \`KillCritter\` at \`src/npc/npcdeath.cs:653\` ignores both return values and runs \`DropRemainsAndLoot\` + \`DeleteObjectFromTile\` anyway — nullifying the revival logic for any caller that goes through this entry point.

Current callers: \`scd_killnpcs\`, \`tomb.cs\`.

## Fix

Early-return from \`KillCritter\` when mode 0 returns \`false\`, mirroring the pattern at \`src/npc/npcai.cs:363\` where combat's own death path already respects the signal.

\`\`\`csharp
if (!SpecialDeathCases(critter, 0)) return;
SpecialDeathCases(critter, 1);
DropRemainsAndLoot(critter);
ObjectRemover_OLD.DeleteObjectFromTile_DEPRECIATED(...);
\`\`\`

## Test

No xUnit coverage: the fix requires Godot-runtime NPC state. Verified by inspection against the existing combat-path pattern and the documented return-value contract.

## Context

Discovered during an audit of object-lifetime management in the save-game work (#33). Latent until a caller actually attempts to \`KillCritter\` a Thorlson or Golem, which current codepaths don't commonly do — but the contract violation should be fixed before it becomes observable.