### PR TITLE
Motion collison handlers

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -201,23 +201,10 @@ public partial class main : Node3D
 			{
 				//Debug.Print($"{PitTimer - LastPitTimer}");
 				EasyMoveFrameIncrement += (byte)((GlobalPITTimer >> 4) - (LastPitTimer >> 4));  //every 16 pits?
-				AnimationFrameDeltaIncrement = (byte)((GlobalPITTimer >> 6) - (LastPitTimer >> 6));//every 63 pits?
-																								   // ClockIncrement = 0x5;//i've added this to temporarily control motion frame rate.
-																								   // if ((playerdat.MagicalMotionAbilities & 0x4) !=0)
-																								   // {
-																								   // 	//Hack for levitate
-				ClockIncrement = 0x19;//ignore original calc
-									  // }
+				AnimationFrameDeltaIncrement = (byte)((GlobalPITTimer >> 6) - (LastPitTimer >> 6));//every 63 pits? This controls how often NPCs and mobile objects move. It could stand to be faster.
 
-				//HACK the above appears to be what should be happening in vanilla code but is very slow to process, but the below gives the appearance of normal movement but may cause frame rate issues. 
-				//Issues caused by this hacking.
-				//-Levitation does not work going north ->a higher increment fixes the motionparams.y0 but makes other motion really fast.
-				//-A clock increment of 1 will cause strafing to fail when moving to the east!
-				//This whole section will need to be fixed in the future.				
-				// EasyMoveFrameIncrement = 1;
-				// AnimationFrameDeltaIncrement = 1;
-				//ClockIncrement = 0xF;
-				//ClockIncrement = ClockIncrement * 4;
+				ClockIncrement = 0x19;//ignore original calc since it's too slow. This value is choosen since dosbox debugger shows this value when breaking on motion code often (with some variation)
+				//Setting value too low prevents some motion in certain directions from working.
 			}
 
 			if (ClockIncrement != 0)

--- a/main.cs
+++ b/main.cs
@@ -280,6 +280,7 @@ public partial class main : Node3D
 
 	static void GameObjectLoop(byte ClockIncrement, byte AnimationFrameDelta, bool EasyMove)
 	{
+		playerdat.play_hp = 20;
 		motion.CameraBobZAdjust_dseg_67d6_33CE = 0;
 		motion.RelatedToClockIncrement_67d6_742 += ClockIncrement;
 		motion.CameraIsBobbing_dseg_67d6_33c6 = false;

--- a/main.cs
+++ b/main.cs
@@ -470,21 +470,16 @@ public partial class main : Node3D
 							//This is an NPC on the map	
 							var n = (npc)obj.instance;
 							bool result;
-							// if ((obj.item_id==124) && (UWClass._RES == UWClass.GAME_UW1) )
-							// {
-							// 	result = false;//currently the slasher is bugging out.
-							// }
-							// else
-							// {
-							result = npc.NPCInitialProcess(obj);
-							//}
+
+							result = npc.NPCInitialProcess(critter: obj);
+
 
 							if (n != null)
 							{
 								if (obj.instance != null)
 								{
 									var CalcedFacing = npc.CalculateFacingAngleToNPC(obj);
-									n.SetAnimSprite(obj.npc_animation, obj.AnimationFrame, CalcedFacing);
+									n.SetAnimSprite(animationNo: obj.npc_animation, frameNo: obj.AnimationFrame, relativeHeading: CalcedFacing);
 								}
 							}
 							if (result == false)
@@ -499,14 +494,11 @@ public partial class main : Node3D
 					}
 					else
 					{
-						//if (motion.MotionSingleStepEnabled)
-						//{
 						//This is a projectile
-						if (motion.MotionProcessing(obj) == false)
+						if (motion.MotionProcessing(projectile: obj, SpecialMotionHandler: MotionHandler.ObjectMotionHandler) == false)
 						{
 							break;
 						}
-						//}
 					}
 					if (initialnextframe == obj.NextFrame_0XA_Bit0123)
 					{

--- a/main.cs
+++ b/main.cs
@@ -280,7 +280,7 @@ public partial class main : Node3D
 
 	static void GameObjectLoop(byte ClockIncrement, byte AnimationFrameDelta, bool EasyMove)
 	{
-		playerdat.play_hp = playerdat.max_hp;
+		//playerdat.play_hp = playerdat.max_hp;
 		motion.CameraBobZAdjust_dseg_67d6_33CE = 0;
 		motion.RelatedToClockIncrement_67d6_742 += ClockIncrement;
 		motion.CameraIsBobbing_dseg_67d6_33c6 = false;

--- a/main.cs
+++ b/main.cs
@@ -280,7 +280,7 @@ public partial class main : Node3D
 
 	static void GameObjectLoop(byte ClockIncrement, byte AnimationFrameDelta, bool EasyMove)
 	{
-		playerdat.play_hp = 20;
+		playerdat.play_hp = playerdat.max_hp;
 		motion.CameraBobZAdjust_dseg_67d6_33CE = 0;
 		motion.RelatedToClockIncrement_67d6_742 += ClockIncrement;
 		motion.CameraIsBobbing_dseg_67d6_33c6 = false;

--- a/src/npc/npcai.cs
+++ b/src/npc/npcai.cs
@@ -170,6 +170,12 @@ namespace Underworld
 
         public static int MaxAnimFrame;
         public static bool RelatedToMotionCollision_dseg_67d6_224E;//needs to be set in 1413:ABF
+        
+        //Used by collision handlers. unknown impact, 
+        public static bool dseg_2682;
+        public static bool dseg_2684;
+
+
         public static bool IsNPCActive_dseg_67d6_2234;
         static bool dseg_67d6_225E;
         static bool HasCurrobjHeadingChanged_dseg_67d6_2242;

--- a/src/npc/npcai.cs
+++ b/src/npc/npcai.cs
@@ -166,7 +166,7 @@ namespace Underworld
             }
         }
 
-        public static byte[] SpecialMotionHandler;
+        public static MotionHandler SpecialMotionHandler;
 
         public static int MaxAnimFrame;
         public static bool RelatedToMotionCollision_dseg_67d6_224E;//needs to be set in 1413:ABF
@@ -234,19 +234,19 @@ namespace Underworld
                 if (critterObjectDat.isFlier(critter.item_id))
                 {
                     //special setup for flying ai    
-                    SpecialMotionHandler = UWMotionParamArray.DSEG_26C6_FlyingNPCMotionHandler;
+                    SpecialMotionHandler = MotionHandler.FlierNPCMotionHandler; //UWMotionParamArray.DSEG_26C6_FlyingNPCMotionHandler;
                 }
                 else
                 {
                     if (critterObjectDat.isSwimmer(critter.item_id))
                     {
                         //special setup for swimming ai
-                        SpecialMotionHandler = UWMotionParamArray.DSEG_26DE_SwimmingNPCMotionHandler;
+                        SpecialMotionHandler = MotionHandler.SwimmerNPCMotionHandler; //UWMotionParamArray.DSEG_26DE_SwimmingNPCMotionHandler;
                     }
                     else
                     {
                         //default ai (26ba in uw2,  285C in uw1 ) //seg007_17A2_2207
-                        SpecialMotionHandler = UWMotionParamArray.DSEG_26BA_LandNPCMotionHandler;
+                        SpecialMotionHandler = MotionHandler.LandNPCMotionHandler; //UWMotionParamArray.DSEG_26BA_LandNPCMotionHandler;
                     }
                 }
 
@@ -254,17 +254,17 @@ namespace Underworld
                 {
                     //Set values in motion arrays (defined in previous section. ). This protects fire resistant creatures from being damaged by lava.
                     //seg007_17A2_222B
-                    var tmp = Loader.getAt(SpecialMotionHandler, 2, 16);
+                    var tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 2, 16);
                     tmp = tmp & 0xFFDF;
-                    Loader.setAt(SpecialMotionHandler, 2, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 2, 16, (int)tmp);
 
-                    tmp = Loader.getAt(SpecialMotionHandler, 6, 16);
+                    tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 6, 16);
                     tmp = tmp & 0xFFDF;
-                    Loader.setAt(SpecialMotionHandler, 6, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 6, 16, (int)tmp);
 
-                    tmp = Loader.getAt(SpecialMotionHandler, 0, 16);
+                    tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 0, 16);
                     tmp = tmp | 0x20;
-                    Loader.setAt(SpecialMotionHandler, 0, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 0, 16, (int)tmp);
 
                 }
 
@@ -319,17 +319,17 @@ namespace Underworld
                 if ((commonObjDat.scaleresistances(critter.item_id) & 8) != 0)
                 {
                     //Restore original bits in Special Motion Handler. These were preivously changed for fire resistant critters.
-                    var tmp = Loader.getAt(SpecialMotionHandler, 2, 16);
+                    var tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 2, 16);
                     tmp = tmp | 0x20;
-                    Loader.setAt(SpecialMotionHandler, 2, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 2, 16, (int)tmp);
 
-                    tmp = Loader.getAt(SpecialMotionHandler, 6, 16);
+                    tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 6, 16);
                     tmp = tmp = tmp | 0x20;
-                    Loader.setAt(SpecialMotionHandler, 6, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 6, 16, (int)tmp);
 
-                    tmp = Loader.getAt(SpecialMotionHandler, 0, 16);
+                    tmp = Loader.getAt(SpecialMotionHandler.handlerdata, 0, 16);
                     tmp = tmp & 0xFFDF;
-                    Loader.setAt(SpecialMotionHandler, 0, 16, (int)tmp);
+                    Loader.setAt(SpecialMotionHandler.handlerdata, 0, 16, (int)tmp);
                 }
                 //seg007_17A2_2392:
                 //To update globals after motion has taken place

--- a/src/npc/npcai.cs
+++ b/src/npc/npcai.cs
@@ -169,12 +169,12 @@ namespace Underworld
         public static MotionHandler SpecialMotionHandler;
 
         public static int MaxAnimFrame;
-        public static bool RelatedToMotionCollision_dseg_67d6_224E;//needs to be set in 1413:ABF
+        public static bool RelatedToMotionCollision_dseg_67d6_224E;//needs to be set in 1413:ABF, likely flags the npc has collided during motion.
         
         //Used by collision handlers. unknown impact, 
         public static bool dseg_2682;
         public static bool dseg_2684;
-
+        public static short dseg_2636;
 
         public static bool IsNPCActive_dseg_67d6_2234;
         static bool dseg_67d6_225E;

--- a/src/npc/pathfind.cs
+++ b/src/npc/pathfind.cs
@@ -245,7 +245,7 @@ namespace Underworld
                     tile1_X_arg0: 0, tile1_Y_arg2: 0,
                     tile2_X_arg4: currTileX_arg0, tile2_Y_arg6: currTileY_arg2,
                     tile3_X_arg8: NeighbourTileX, tile3_Y_argA: NeighbourTileY,
-                    argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                    argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                     ProbablyHeight_arg10: CurrFloorHeight_arg4,
                     arg12: ref tmp,
                     PathDistanceResult_arg16: ref ProbablyPathDistance_var1E);
@@ -330,7 +330,7 @@ namespace Underworld
                                     tile1_X_arg0: TileRecord_var1C.X0, tile1_Y_arg2: TileRecord_var1C.Y1,
                                     tile2_X_arg4: Tile2X_var1, tile2_Y_arg6: Tile2Y_var2,
                                     tile3_X_arg8: NeighbourTileX, tile3_Y_argA: NeighbourTileY,
-                                    argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                                    argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                                     ProbablyHeight_arg10: TileRecord_var1C.Z2,
                                     arg12: ref Height_var1F,
                                     PathDistanceResult_arg16: ref ProbablyPathDistance_var1E);
@@ -393,7 +393,7 @@ namespace Underworld
                                                 tile1_X_arg0: Tile2X_var1, tile1_Y_arg2: Tile2Y_var2,
                                                 tile2_X_arg4: NeighbourTileX, tile2_Y_arg6: NeighbourTileY,
                                                 tile3_X_arg8: 0, tile3_Y_argA: 0,
-                                                argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                                                argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                                                 ProbablyHeight_arg10: NeighbourPathTile.Z2,
                                                 arg12: ref tmp, PathDistanceResult_arg16: ref ProbablyPathDistance_var1E);
                                             NeighbourPathTile.Z2 = tmp;
@@ -1344,7 +1344,7 @@ namespace Underworld
                     tile1_X_arg0: Step3.X0, tile1_Y_arg2: Step3.Y1,
                     tile2_X_arg4: Step2.X0, tile2_Y_arg6: Step2.Y1,
                     tile3_X_arg8: 0, tile3_Y_argA: 0,
-                    argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                    argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                     ProbablyHeight_arg10: Step3.Z2,
                     arg12: ref xVar3,
                     PathDistanceResult_arg16: ref varE);
@@ -1389,7 +1389,7 @@ namespace Underworld
                         tile1_X_arg0: 0, tile1_Y_arg2: 0,
                         tile2_X_arg4: FinalPath56.finalpath[0].X0, tile2_Y_arg6: FinalPath56.finalpath[0].Y1,
                         tile3_X_arg8: FinalPath56.finalpath[1].X0, tile3_Y_argA: FinalPath56.finalpath[1].Y1,
-                        argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                        argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                         ProbablyHeight_arg10: FinalPath56.finalpath[0].Z2, arg12: ref height1,
                         PathDistanceResult_arg16: ref var2);
                     FinalPath56.finalpath[1].Z2 = height1;
@@ -1418,7 +1418,7 @@ namespace Underworld
                         tile1_X_arg0: Prev3.X0, tile1_Y_arg2: Prev3.Y1,
                         tile2_X_arg4: Prev2.X0, tile2_Y_arg6: Prev2.Y1,
                         tile3_X_arg8: Prev1.X0, tile3_Y_argA: Prev1.Y1,
-                        argC: (int)Loader.getAt(npc.SpecialMotionHandler, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler, 6, 16),
+                        argC: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 4, 16), argE: (int)Loader.getAt(npc.SpecialMotionHandler.handlerdata, 6, 16),
                         ProbablyHeight_arg10: Prev3.Z2, arg12: ref height,
                         PathDistanceResult_arg16: ref var2);
                     Prev2.Z2 = height;

--- a/src/physics/motion.cs
+++ b/src/physics/motion.cs
@@ -50,7 +50,7 @@ namespace Underworld
             if (commonObjDat.maybeMagicObjectFlag(projectile.item_id))
             {
                 //UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 = 0x1000;  //MaybeSpecialMotionObjectDatFlag_dseg_67d6_26D2 = 0x1000;
-                SpecialMotionHandler.table01 = 0x100;
+                SpecialMotionHandler.table01 = 0x1000;
             }
             else
             {

--- a/src/physics/motion.cs
+++ b/src/physics/motion.cs
@@ -264,7 +264,10 @@ namespace Underworld
                         }
 
                         //seg030_2BB7_99F:
-                        projectile = PlacedObjectCollision_seg030_2BB7_10BC(projectile, projectile.tileX, projectile.tileY, 0);
+                        projectile = PlacedObjectCollision_seg030_2BB7_10BC(
+                            projectile: projectile, 
+                            tileX: projectile.tileX, tileY: projectile.tileY, 
+                            arg8: 0);
                         if (projectile == null)
                         {
                             return false;
@@ -365,8 +368,49 @@ namespace Underworld
 
         static uwObject MoveObjectToMobileObjectList_seg030_2BB7_B0C(uwObject toMove)
         {
-            Debug.Print("move from static to mobile");
-            return toMove;
+            //Debug.Print($"move {toMove.a_name} {toMove.index} from static to mobile");
+            var tile = UWTileMap.current_tilemap.Tiles[toMove.tileX, toMove.tileY];
+
+            var next = tile.indexObjectList;
+
+            var slot = ObjectFreeLists.GetAvailableObjectSlot(ObjectFreeLists.ObjectListType.MobileList);
+            if (slot != 0)
+            {
+                var newObj = UWTileMap.current_tilemap.LevelObjects[slot];    
+                for (int i = 0; i<8; i++)
+                {
+                    //copy props
+                    newObj.DataBuffer[newObj.PTR+i] = toMove.DataBuffer[toMove.PTR + i];
+                }
+                ObjectCreator.InitMobileObject(newObj, toMove.tileX, toMove.tileY);
+                newObj.npc_hp = (byte)toMove.quality;
+                if (toMove.majorclass != 5)
+                {
+                    if (commonObjDat.rendertype(toMove.item_id) != 2)
+                    {
+                        newObj.npc_whoami = toMove.heading; //to backup object identification status
+                    }
+                }
+                if (newObj.majorclass == 7)
+                {
+                    Debug.Print("moving an animation overaly. Change it's links");
+                }
+                ObjectRemover_OLD.DeleteObjectFromTile_DEPRECIATED(toMove.tileX, toMove.tileY, toMove.index, true);
+
+                //insert object to tile.
+                newObj.next = tile.indexObjectList;
+                tile.indexObjectList = newObj.index;
+                ObjectCreator.RenderObject(newObj, UWTileMap.current_tilemap);
+                newObj.tileX = tile.tileX; newObj.tileY = tile.tileY;
+                Debug.Print($"returning {newObj.index}");
+                return newObj;
+            }
+            else
+            {
+                Debug.Print("unable to move object to mobile list. Returning object itself on the static list.");
+                return toMove;    
+            }            
+            
         }
 
         static uwObject ObjectHitsFloorTile_seg030_2BB7_DDF(uwObject projectile)

--- a/src/physics/motion.cs
+++ b/src/physics/motion.cs
@@ -17,7 +17,13 @@ namespace Underworld
                 collisionTable[i] = new CollisionRecord(i);
             }
         }
-        public static bool MotionProcessing(uwObject projectile)
+
+        /// <summary>
+        /// Calculate motion for a projectile.
+        /// </summary>
+        /// <param name="projectile"></param>
+        /// <returns></returns>
+        public static bool MotionProcessing(uwObject projectile, MotionHandler SpecialMotionHandler)
         {
             ObjectHasHalted = false;
             if (!UWTileMap.ValidTile(projectile.tileX, projectile.tileY))
@@ -43,11 +49,13 @@ namespace Underworld
 
             if (commonObjDat.maybeMagicObjectFlag(projectile.item_id))
             {
-                UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 = 0x1000;  //MaybeSpecialMotionObjectDatFlag_dseg_67d6_26D2 = 0x1000;
+                //UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 = 0x1000;  //MaybeSpecialMotionObjectDatFlag_dseg_67d6_26D2 = 0x1000;
+                SpecialMotionHandler.table01 = 0x100;
             }
             else
             {
-                UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 = 0;//MaybeSpecialMotionObjectDatFlag_dseg_67d6_26D2 = 0;
+                //UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 = 0;//MaybeSpecialMotionObjectDatFlag_dseg_67d6_26D2 = 0;
+                SpecialMotionHandler.table01 = 0;
             }
 
             UWMotionParamArray MotionParams = new();
@@ -57,9 +65,9 @@ namespace Underworld
             //     Debug.Print($"Initial {projectile.a_name} Tile ({projectile.tileX},{projectile.tileY}), Position({projectile.xpos},{projectile.ypos},{projectile.zpos}) NPC_HP:{projectile.npc_hp} ProjectileHeading:{projectile.ProjectileHeading} UNKA_0123:{projectile.NextFrame_0XA_Bit0123} UNK_456:{projectile.TileState_0XA_Bit456} Coords ({projectile.CoordinateX},{projectile.CoordinateY},{projectile.CoordinateZ}) UNK13_0_6:{projectile.UnkBit_0X13_Bit0to6} UNK13_7:{projectile.UnkBit_0X13_Bit7} ProjectileSpeed:{projectile.Projectile_Speed}, ProjectilePitch:{projectile.Projectile_Pitch}");
             // }
 
-            InitMotionParams(projectile, MotionParams);
+            InitMotionParams(projectile: projectile, MotionParams: MotionParams);
 
-            CalculateMotion_TopLevel(projectile, MotionParams, UWMotionParamArray.DSEG_27B2_SpecialMotionHandling);
+            CalculateMotion_TopLevel(projectile: projectile, MotionParams: MotionParams, SpecialMotionHandler: MotionHandler.ObjectMotionHandler);
 
             //store current x/y homes in globals                        
             var result = ApplyProjectileMotion(projectile, MotionParams);

--- a/src/physics/motion_calc.cs
+++ b/src/physics/motion_calc.cs
@@ -313,7 +313,7 @@ namespace Underworld
 
             MotionCalcArray.x0 = (ushort)(MotionParams.x_0 >> 5);
             MotionCalcArray.y2 = (ushort)(MotionParams.y_2 >> 5);
-            MotionCalcArray.z4_base = (ushort)(MotionParams.z_4 >> 3);
+            MotionCalcArray.z4 = (ushort)(MotionParams.z_4 >> 3);
 
             UWMotionParamArray.RelatedToMotionX_dseg_67d6_3FE = (short)((MotionParams.x_0 & 0x1F) << 8);
             UWMotionParamArray.RelatedToMotionY_dseg_67d6_400 = (short)((MotionParams.y_2 & 0x1F) << 8);
@@ -352,11 +352,11 @@ namespace Underworld
                 //int terrain = TerrainDatLoader.GetTerrainTypeNo(tile);
                 UWMotionParamArray.TileAttributesArray[4] = (short)((int)(tile.tileType) | (int)(tile.floorHeight << 4) | (int)(TerrainDatLoader.GetTerrainTypeNo(tile) << 8));
             }
-
+            //SEG_028_2941_423
             seg028_2941_2CF_terrainrelated(distance_arg0);
 
             MotionCalcArray.UnkE = MotionCalcArray.UnkC_terrain;
-            MotionCalcArray.Unk11 = MotionCalcArray.Unk10_relatedtotileheight;
+            MotionCalcArray.Unk11 = MotionCalcArray.Unk10_relatedtotileheight; //set in previous function
 
             //seg028_2941_449
             if (MotionCalcArray.Radius8 != 0)
@@ -760,6 +760,7 @@ namespace Underworld
                     {
                         //seg031_2CFA_180F:
                         //Debug.Print($"Call motion code at {UWMotionParamArray.dseg_67d6_26c2_LikeMagicProjectile8} with param {var2}");
+                        //TODO. other functions are called here as delegates. I need to add support for Seg008_104D (a stop motion function on the player that may be related to the bridge multiple collison bug)
                         result = NPCMotionCollision_seg006_1413_ABF(critter: projectile, arg0: var2, motionparams: MotionParams);
                         if (result)
                         {
@@ -1110,7 +1111,7 @@ namespace Underworld
             }
             else
             {
-                return 0x10;//bit 12, is jumping
+                return 0x10;//bit 12, is jumping (also up on a bridge)
             }
         }
 

--- a/src/physics/motion_calc.cs
+++ b/src/physics/motion_calc.cs
@@ -12,7 +12,7 @@ namespace Underworld
         /// <param name="MotionParams"></param>
         /// <param name="MaybeMagicObjectFlag"></param>
         /// <returns></returns>
-        public static bool CalculateMotion_TopLevel(uwObject projectile, UWMotionParamArray MotionParams, byte[] SpecialMotionHandler)
+        public static bool CalculateMotion_TopLevel(uwObject projectile, UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {
             //seg006_1413_D6A            
             MotionParams.speed_12 = (byte)(projectile.Projectile_Speed << 4);
@@ -29,7 +29,7 @@ namespace Underworld
         /// </summary>
         /// <param name="projectile"></param>
         /// <param name="MotionParams"></param>        
-        static void CalculateMotion(uwObject projectile, UWMotionParamArray MotionParams, byte[] SpecialMotionHandler)
+        static void CalculateMotion(uwObject projectile, UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {
             int collisionCounter = 0;
             UWMotionParamArray.PtrTo26D2_DSEG_26B8_MotionHandler = SpecialMotionHandler;
@@ -57,16 +57,16 @@ namespace Underworld
                     {
 
                         //seg031_2CFA_59:
-                        if (ProcessCollisions_seg031_2CFA_12B8(MotionParams, 1) != 0)
+                        if (ProcessCollisions_seg031_2CFA_12B8(MotionParams: MotionParams, arg0: 1, SpecialMotionHandler: SpecialMotionHandler) != 0)
                         {
                             //seg031_2CFA_64
-                            DoTileCollisionMaybe_seg031_2CFA_179C(projectile, MotionParams);
+                            DoTileCollisionMaybe_seg031_2CFA_179C(projectile: projectile, SpecialMotionHandler: SpecialMotionHandler, MotionParams: MotionParams);
                         }
                         collisionCounter++;
                     }
                 }
                 //seg031_2CFA_73:  
-                StoreNewXYZH_seg031_2CFA_800(MotionParams);
+                StoreNewXYZH_seg031_2CFA_800(MotionParams: MotionParams, SpecialMotionHandler: SpecialMotionHandler);
                 return;
             }
         }
@@ -677,7 +677,7 @@ namespace Underworld
         /// Updates x,y,z positions and heading
         /// </summary>
         /// <param name="MotionParams"></param>
-        static void StoreNewXYZH_seg031_2CFA_800(UWMotionParamArray MotionParams)
+        static void StoreNewXYZH_seg031_2CFA_800(UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {
             MotionParams.x_0 = (short)((MotionCalcArray.x0 << 5) + (UWMotionParamArray.RelatedToMotionX_dseg_67d6_3FE >> 8));
             MotionParams.y_2 = (short)((MotionCalcArray.y2 << 5) + (UWMotionParamArray.RelatedToMotionY_dseg_67d6_400 >> 8));
@@ -699,7 +699,7 @@ namespace Underworld
             MotionParams.heading_1E = MotionCalcArray.Heading6_base;
         }
 
-        static int ProcessCollisions_seg031_2CFA_12B8(UWMotionParamArray MotionParams, int arg0)
+        static int ProcessCollisions_seg031_2CFA_12B8(UWMotionParamArray MotionParams, int arg0, MotionHandler SpecialMotionHandler)
         {
             var var1 = 0;
             var var2 = 0;
@@ -724,16 +724,16 @@ namespace Underworld
 
             if (MotionParams.unk_a_pitch == 0)
             {
-                var2 = LikelyTranslateXY_seg031_2CFA_8A6(MotionParams, 0, arg0);
+                var2 = LikelyTranslateXY_seg031_2CFA_8A6(MotionParams: MotionParams, arg0: 0, si_arg2: arg0);
             }
             else
             {
-                var2 = MAYBEGRAVITYZ_seg031_2CFA_1138(MotionParams, 0, arg0);
+                var2 = MAYBEGRAVITYZ_seg031_2CFA_1138(MotionParams: MotionParams, arg0: 0, arg2: arg0, SpecialMotionHandler: SpecialMotionHandler);
             }
 
             if (var1 != 0)
             {
-                var si = GetCollisionHeightState_seg031_2CFA_13B2(MotionParams);
+                var si = GetCollisionHeightState_seg031_2CFA_13B2(MotionParams: MotionParams, SpecialMotionHandler: SpecialMotionHandler);
                 UWMotionParamArray.MotionParam0x25_dseg_67d6_26A9 = MotionParams.tilestate25;
                 MotionParams.tilestate25 = GetTileState(si);
             }
@@ -743,29 +743,30 @@ namespace Underworld
 
 
 
-        static void DoTileCollisionMaybe_seg031_2CFA_179C(uwObject projectile, UWMotionParamArray MotionParams)
+        static void DoTileCollisionMaybe_seg031_2CFA_179C(uwObject projectile, MotionHandler SpecialMotionHandler, UWMotionParamArray MotionParams)
         {
             var var3 = 0;
-            var var2 = GetCollisionHeightState_seg031_2CFA_13B2(MotionParams);
+            var var2 = GetCollisionHeightState_seg031_2CFA_13B2(MotionParams: MotionParams, SpecialMotionHandler: SpecialMotionHandler);
             UWMotionParamArray.MotionParam0x25_dseg_67d6_26A9 = MotionParams.tilestate25;
             MotionParams.tilestate25 = GetTileState(var2);
             if ((var2 & 0xC000) == 0)//var2 getting screwed up here?
             {//seg031_2CFA_17ED:
-                var tmp = UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0;
+                var tmp = SpecialMotionHandler.table01;
                 var2 = var2 & ~tmp;
                 var result = false;
                 if (var2 != 0)
                 {
-                    if ((UWMotionParamArray.dseg_67d6_26BA_MotionHandler2 & var2) != 0)
+                    if ((SpecialMotionHandler.table23 & var2) != 0)
                     {
                         //seg031_2CFA_180F:
                         //Debug.Print($"Call motion code at {UWMotionParamArray.dseg_67d6_26c2_LikeMagicProjectile8} with param {var2}");
                         //TODO. other functions are called here as delegates. I need to add support for Seg008_104D (a stop motion function on the player that may be related to the bridge multiple collison bug)
-                        result = NPCMotionCollision_seg006_1413_ABF(critter: projectile, arg0: var2, motionparams: MotionParams);
+                        //result = NPCMotionCollision_seg006_1413_ABF(critter: projectile, arg0: var2, motionparams: MotionParams);
+                        result = SpecialMotionHandler.HandlerFunction(obj: projectile, handler: SpecialMotionHandler, motionparams: MotionParams);
                         if (result)
                         {
                             //seg031_2CFA_1818:
-                            ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1);
+                            ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1, SpecialMotionHandler);
                             UWMotionParamArray.GravityCollisionRelated_dseg_67d6_414 = (short)(UWMotionParamArray.MAYBEcollisionOrGravity_dseg_67d6_40E + 1);
                             return;
                         }
@@ -774,7 +775,7 @@ namespace Underworld
                     if ((var2 & 0x700) != 0)
                     {//when var2>0 then 0, when var2==0 then 1,
                         //seg031_2CFA_1830: 
-                        seg031_2CFA_C5C(MotionParams, SBB(var2 & 0x400));
+                        seg031_2CFA_C5C(MotionParams: MotionParams, arg0: SBB(var2 & 0x400), SpecialMotionHandler: SpecialMotionHandler);
 
                         var3 = 1;
                         if (
@@ -792,7 +793,7 @@ namespace Underworld
             }
             else
             {//seg031_2CFA_17CE:
-                ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1);
+                ProcessCollisions_seg031_2CFA_12B8(MotionParams: MotionParams, arg0: -1, SpecialMotionHandler: SpecialMotionHandler);
                 if ((var2 & 0x4000) == 0)
                 {
                     //seg031_2CFA_17E4:           
@@ -948,7 +949,7 @@ namespace Underworld
             }
         }
 
-        static int MAYBEGRAVITYZ_seg031_2CFA_1138(UWMotionParamArray MotionParams, int arg0, int arg2)
+        static int MAYBEGRAVITYZ_seg031_2CFA_1138(UWMotionParamArray MotionParams, int arg0, int arg2, MotionHandler SpecialMotionHandler)
         {
             // Debug.Print($"Step {iteration} Gravity");
             var di = arg2;
@@ -1031,7 +1032,7 @@ namespace Underworld
                         else
                         {
                             //seg031_2CFA_12A1:
-                            DoCollision_seg031_2CFA_D1F(MotionParams);
+                            DoCollision_seg031_2CFA_D1F(MotionParams, SpecialMotionHandler);
                             return 0;
                         }
                     }
@@ -1045,7 +1046,7 @@ namespace Underworld
                     MotionParams.tilestate25 = 0x10;
                     if (MotionCalcArray.z4_base + si > UWMotionParamArray.CollisionZposHeightRelated_dseg_67d6_419)
                     {
-                        DoCollision_seg031_2CFA_D1F(MotionParams);
+                        DoCollision_seg031_2CFA_D1F(MotionParams, SpecialMotionHandler);
                         return 0;
                     }
                     else
@@ -1133,7 +1134,7 @@ namespace Underworld
             UWMotionParamArray.GravityCollisionRelated_dseg_67d6_414 = 0;
         }
 
-        static void seg031_2CFA_C5C(UWMotionParamArray MotionParams, int arg0)
+        static void seg031_2CFA_C5C(UWMotionParamArray MotionParams, int arg0, MotionHandler SpecialMotionHandler)
         {
             //Debug.Print("seg031_2CFA_C5C");
             if (MotionCalcArray.Unk17_base <= 0)
@@ -1157,7 +1158,7 @@ namespace Underworld
                     si = UWMotionParamArray.MotionGlobal_dseg_67d6_40A_indexer << 1;
                 }
                 //seg031_2CFA_C92:
-                ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1);
+                ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1, SpecialMotionHandler);
 
                 var result = HeadingRelated_seg031_2CFA_A49(MotionParams, (short)dseg_67d6_421[si]);
 
@@ -1176,7 +1177,7 @@ namespace Underworld
             else
             {
                 //seg031_2CFA_C69:
-                ProcessCollisions_seg031_2CFA_12B8(MotionParams, -1);
+                ProcessCollisions_seg031_2CFA_12B8(MotionParams: MotionParams, arg0: -1, SpecialMotionHandler: SpecialMotionHandler);
                 UWMotionParamArray.GravityCollisionRelated_dseg_67d6_414 = (short)(UWMotionParamArray.MAYBEcollisionOrGravity_dseg_67d6_40E + 1);
             }
         }

--- a/src/physics/motion_calc.cs
+++ b/src/physics/motion_calc.cs
@@ -15,7 +15,7 @@ namespace Underworld
         public static bool CalculateMotion_TopLevel(uwObject projectile, UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {
             //seg006_1413_D6A            
-            MotionParams.speed_12 = (byte)(projectile.Projectile_Speed << 4);
+            MotionParams.speed_12 = (sbyte)(projectile.Projectile_Speed << 4);
             CalculateMotion(
                 projectile: projectile,
                 MotionParams: MotionParams,

--- a/src/physics/motion_calc.cs
+++ b/src/physics/motion_calc.cs
@@ -762,7 +762,7 @@ namespace Underworld
                         //Debug.Print($"Call motion code at {UWMotionParamArray.dseg_67d6_26c2_LikeMagicProjectile8} with param {var2}");
                         //TODO. other functions are called here as delegates. I need to add support for Seg008_104D (a stop motion function on the player that may be related to the bridge multiple collison bug)
                         //result = NPCMotionCollision_seg006_1413_ABF(critter: projectile, arg0: var2, motionparams: MotionParams);
-                        result = SpecialMotionHandler.HandlerFunction(obj: projectile, handler: SpecialMotionHandler, motionparams: MotionParams);
+                        result = SpecialMotionHandler.HandlerFunction(obj: projectile, arg0: ref var2, motionparams: MotionParams);
                         if (result)
                         {
                             //seg031_2CFA_1818:

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -1206,11 +1206,11 @@ namespace Underworld
                                 var collision = collisionTable[UWMotionParamArray.ACollisionIndex_dseg_67d6_416]; 
                                 if (Math.Abs(MotionCalcArray.z4_base - collision.height) > MotionParams.unk_24)
                                 {
-                                    var3 = true;
+                                    var3 = false;
                                 }
                                 else
                                 {
-                                    var3 = false;
+                                    var3 = true;
                                 }
                                 if (var3)
                                 {

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -104,12 +104,12 @@ namespace Underworld
                         //seg031_2CFA_10FB: 
                         if (UWMotionParamArray.ACollisionIndex_dseg_67d6_416 != -1)
                         {
-                            var Dst = UWMotionParamArray.ACollisionIndex_dseg_67d6_416;
-                            MotionCalcArray.Unk14_collisoncount_base--;
+                            var Dst = UWMotionParamArray.ACollisionIndex_dseg_67d6_416;                            
                             for (int i = 0; i < 6; i++)
                             {
                                 CollisionRecord.Collisions_dseg_2520[(Dst * 6) + i] = CollisionRecord.Collisions_dseg_2520[(MotionCalcArray.Unk14_collisoncount_base * 6) + i];
                             }
+                            MotionCalcArray.Unk14_collisoncount_base--;
                         }
                     }
                     else
@@ -290,6 +290,7 @@ namespace Underworld
             UWMotionParamArray.ACollisionIndex_dseg_67d6_416 = -1;
             UWMotionParamArray.dseg_67d6_41D = 0x7f;
 
+            //seg031_2CFA_131
             if (MotionParams.unk_a_pitch > 0)
             {
                 //seg031_2CFA_136:
@@ -324,8 +325,8 @@ namespace Underworld
             {
                 //seg031_2CFA_133
                 if (MotionParams.unk_a_pitch == 0)
-                {//seg031_2CFA_1E0
-
+                {
+                    //seg031_2CFA_1E0
                     UWMotionParamArray.CollisionZposHeightRelated_dseg_67d6_419 = MotionCalcArray.Unk10_base;
 
                     //Jump when z4+param[24]<Calc11
@@ -341,24 +342,44 @@ namespace Underworld
                     }
 
                     //seg031_2CFA_20C:
-
-                    //when calc15 == 0
-                    //AND calc16>0
-                    //AND calc16<=calc14
-                    if (
-                        (MotionCalcArray.Unk15_base == 0)
-                        &&
-                        (MotionCalcArray.Unk16_collisionindex_base > 0)
-                        &&
-                        (MotionCalcArray.Unk16_collisionindex_base <= MotionCalcArray.Unk14_collisoncount_base)
-                    )
-                    {
-                        var1 = 1;
-                    }
-                    else
+                    if (MotionCalcArray.Unk15_base != 0)
                     {
                         var1 = 0;
                     }
+                    else
+                    {
+                        if (MotionCalcArray.Unk16_collisionindex_base <= 0)
+                        {
+                            var1 = 0;
+                        }
+                        else
+                        {
+                            if (MotionCalcArray.Unk16_collisionindex_base > MotionCalcArray.Unk14_collisoncount_base)
+                            {
+                                var1 = 0;
+                            }
+                            else
+                            {
+                                var1 = 1;
+                            }
+                        }   
+                    }
+
+
+                    // if (
+                    //     (MotionCalcArray.Unk15_base == 0)
+                    //     &&
+                    //     (MotionCalcArray.Unk16_collisionindex_base > 0)
+                    //     &&
+                    //     (MotionCalcArray.Unk16_collisionindex_base <= MotionCalcArray.Unk14_collisoncount_base)
+                    // )
+                    // {
+                    //     var1 = 1;
+                    // }
+                    // else
+                    // {
+                    //     var1 = 0;
+                    // }
 
                     var CollisionIndex_var_4 = 0;
                     while (MotionCalcArray.Unk14_collisoncount_base > CollisionIndex_var_4)//seg031_2CFA_38A
@@ -381,7 +402,7 @@ namespace Underworld
                                     //seg031_2CFA_2C0:
                                     if (collision_Var4.height > UWMotionParamArray.CollisionZposHeightRelated_dseg_67d6_419)
                                     {
-                                        //collisionrecordheight<(0x80-paramheight)
+                                        //seg031_2cf_2D9
                                         if (collision_Var4.height < (0x80 - MotionParams.height_23))
                                         {
                                             UWMotionParamArray.ACollisionIndex_dseg_67d6_416 = (sbyte)CollisionIndex_var_4;
@@ -423,9 +444,9 @@ namespace Underworld
                                 }
                             }
                         }
-
+                        //Seg031_387
                         CollisionIndex_var_4++;
-                    }
+                    }//end while
 
 
                 }
@@ -580,6 +601,7 @@ namespace Underworld
         /// <param name="isNPCArgA"></param>
         static void CreateCollisonRecord_Seg028_2941_A78(uwObject CollidingObject, long ListHead, int xArg6, int yArg8, bool isNPCArgA)
         {
+            Debug.Print($"adding collison record {CollidingObject.a_name}");
             if (MotionCalcArray.Unk14_collisoncount <= 8)
             {
                 int XCoordVar1;

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -30,7 +30,7 @@ namespace Underworld
                 var2 = var2 * UWMotionParamArray.dseg_67d6_412;
 
                 var2 = (var2 << 4) / (UWMotionParamArray.Gravity_Related_dseg_67d6_41F / 4);
-                MotionParams.speed_12 -= (byte)var2;
+                MotionParams.speed_12 -= (sbyte)var2;
             }
 
             //seg031_2CFA_D9A:
@@ -1071,7 +1071,7 @@ namespace Underworld
 
         static void seg031_2CFA_78A(UWMotionParamArray MotionParams, int arg0)
         {
-            MotionParams.speed_12 -= (byte)(UWMotionParamArray.GravityCollisionRelated_dseg_67d6_414 * UWMotionParamArray.dseg_67d6_412);
+            MotionParams.speed_12 -= (sbyte)(UWMotionParamArray.GravityCollisionRelated_dseg_67d6_414 * UWMotionParamArray.dseg_67d6_412);
             if (MotionParams.speed_12 > 0)
             {
                 if (InitialMotionCalc_seg031_2CFA_412(MotionParams, false, arg0))

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -1449,12 +1449,16 @@ namespace Underworld
             var var3 = 0;
             UWMotionParamArray.dseg_67d6_25C1 = 0;
             UWMotionParamArray.dseg_67d6_25C2 = 0;
-
+            bool first = false;
             //seg030_2BB7_10DB:
             while (true)
-            {
-
-                MotionCalcArray.PtrToMotionCalc = new byte[0x20];
+            {                
+                if (first)
+                {
+                    //I only need to set up the array ptr on the first loop
+                    MotionCalcArray.PtrToMotionCalc = new byte[0x20];    
+                    first = true;
+                }
                 MotionCalcArray.MotionArrayObjectIndexA = projectile.index;
 
                 if (commonObjDat.maybeMagicObjectFlag(projectile.item_id))
@@ -1596,13 +1600,29 @@ namespace Underworld
                                             //seg030_2BB7_1351:
                                             if (var3 != 0)
                                             {
+                                                //seg030_1357
                                                 var2 = 1;
                                                 //loop back to seg030_2BB7_10DB 
                                             }
                                             else
                                             {
+                                                //Seg030_135E
                                                 //make object mobile.
-                                                Debug.Print($"TODO Make {projectile.a_name} mobile");
+                                                projectile = MoveObjectToMobileObjectList_seg030_2BB7_B0C(projectile);
+                                                if (UWMotionParamArray.dseg_67d6_25C1 == 0)
+                                                {
+                                                    if (arg8 != 0)
+                                                    {
+                                                        //Seg030_13CE
+                                                        projectile.UnkBit_0X13_Bit0to6 = (short)(1 + Rng.r.Next(3));
+                                                        projectile.Projectile_Pitch = (short)(0xE + Rng.r.Next(3));
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    projectile.UnkBit_0X13_Bit0to6 = 3;
+                                                    projectile.ProjectileHeading = (ushort)(0xC0 + (Rng.r.Next(9)<<4));
+                                                }
                                                 break;//to seg030_2BB7_140A:
                                             }
                                         }

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -13,7 +13,7 @@ namespace Underworld
         /// <summary>
         /// Does/calls applicable collisions
         /// </summary>
-        public static void DoCollision_seg031_2CFA_D1F(UWMotionParamArray MotionParams)
+        public static void DoCollision_seg031_2CFA_D1F(UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {
             UWMotionParamArray.dseg_67d6_26A4 = 0;
             var projectile = UWTileMap.current_tilemap.LevelObjects[MotionCalcArray.MotionArrayObjectIndexA_base];
@@ -158,7 +158,7 @@ namespace Underworld
                         if (
                             (MotionParams.index_20 != 1)
                             &&
-                            ((UWMotionParamArray.PtrTo267D2_dseg_67d6_26B8_table0 & 0x1000) == 0x1000)
+                            ((SpecialMotionHandler.table01 & 0x1000) == 0x1000)
                         )
                         {
                             //seg031_2CFA_F7B:
@@ -1087,11 +1087,11 @@ namespace Underworld
         /// </summary>
         /// <param name="MotionParams"></param>
         /// <returns></returns>
-        static int GetCollisionHeightState_seg031_2CFA_13B2(UWMotionParamArray MotionParams)
+        static int GetCollisionHeightState_seg031_2CFA_13B2(UWMotionParamArray MotionParams, MotionHandler SpecialMotionHandler)
         {//function returns wrong result.
             var var2 = 0;
             var var3 = false;
-            var var4 = SBB(UWMotionParamArray.dseg_67d6_26BC_table4 & 0x80);
+            var var4 = SBB( SpecialMotionHandler.table45 & 0x80);
             var var6 = 0;
             UWMotionParamArray.dseg_67d6_26A5 = 0;
 
@@ -1099,7 +1099,7 @@ namespace Underworld
             ScanForCollisions(0, 0);
             SetCollisionTarget_seg031_2CFA_10E(MotionParams, 0);
             var si_result = MotionCalcArray.UnkC_terrain_base | MotionCalcArray.UnkE_base;
-            var var5 = SBB(si_result & UWMotionParamArray.dseg_67d6_26BC_table4);
+            var var5 = SBB(si_result & SpecialMotionHandler.table45);
 
             if (MotionCalcArray.Unk14_collisoncount_base > 0)
             {
@@ -1387,134 +1387,13 @@ namespace Underworld
                 }
             }
             return si_result;
-        }
-
-
-        static bool NPCMotionCollision_seg006_1413_ABF(uwObject critter, int arg0, UWMotionParamArray motionparams)
-        {
-            if ((arg0 & 0x1000) == 0)
-            {
-                //seg006_1413_AFB:  
-                if ((arg0 & 0x10) != 0)
-                {
-                    if ((arg0 & 0xF8) != 0x10)
-                    {
-                        //seg006_1413_B86:
-                        if (critter.UnkBit_0X15_Bit7 == 0)
-                        {
-                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                            UWMotionParamArray.dseg_67d6_260C = false;
-                            UWMotionParamArray.dseg_67d6_260A = false;
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        //seg006_1413_B0E: 
-                        //likely land based NPC has landed in water.
-                        npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                        npc.IsNPCActive_dseg_67d6_2234 = false;
-                        var tile = UWTileMap.current_tilemap.Tiles[motionparams.x_0 >> 8, motionparams.y_2 >> 8];
-                        //spawn a splash
-                        animo.SpawnAnimoInTile(subclassindex: 6, xpos: 3, ypos: 3, zpos: (short)(tile.floorHeight << 3), tileX: tile.tileX, tileY: tile.tileY);
-                        critter.npc_animation = npc.ANIMATION_DEATH;
-                        npc.GetCritterAnimationGlobalsForCurrObj(critter);
-                        critter.AnimationFrame = (byte)npc.MaxAnimFrame;
-                        critter.Projectile_Speed = 1;
-                        return true;
-                    }
-                }
-                //seg006_1413_BAC
-                if (
-                    ((arg0 & 0x800) != 0)
-                    &&
-                    ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x800) == 0)
-                )
-                {
-                    //seg006_1413:0BBA
-                    if (critter.UnkBit_0X15_Bit7 == 0)
-                    {
-                        //seg006_1413_BD3
-                        npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                        UWMotionParamArray.dseg_67d6_260C = false;
-                        UWMotionParamArray.dseg_67d6_260A = false;
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if (
-                     ((arg0 & 0x20) != 0)
-                     &&
-                      ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x20) == 0)
-                    )
-                    {
-                        if (critter.UnkBit_0X15_Bit7 == 0)
-                        {
-                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                            UWMotionParamArray.dseg_67d6_260C = false;
-                            UWMotionParamArray.dseg_67d6_260A = false;
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        if ((arg0 & 0x300) == 0)
-                        {
-                            if ((arg0 & 0x400) != 0)
-                            {
-                                var DoorCollision = FindClosedDoorCollision(ref UWMotionParamArray.DoorX_222E, ref UWMotionParamArray.DoorY_222F);
-                                if (DoorCollision == null)
-                                {
-                                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                                    npc.dseg_67d6_2269 = true;
-                                    npc.collisionObject = FindCollisionObject();
-                                }
-                                else
-                                {
-                                    npc.collisionObject = DoorCollision;
-                                    npc.RelatedToColliding_dseg_67d6_226F = true;
-                                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                                    npc.dseg_67d6_2269 = true;
-                                }
-                            }
-                            //seg006_1413_C7E
-                            return (npc.IsNPCActive_dseg_67d6_2234 && npc.RelatedToMotionCollision_dseg_67d6_224E);
-                        }
-                        else
-                        {
-                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                            return false;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (UWMotionParamArray.dseg_67d6_2614 == 0)
-                {
-                    UWMotionParamArray.dseg_67d6_2614 = -4;
-                }
-                critter.Projectile_Speed = 1;
-                npc.RelatedToMotionCollision_dseg_67d6_224E = true;
-                npc.IsNPCActive_dseg_67d6_2234 = false;
-                return false;
-            }
-        }
+        }        
 
         /// <summary>
         /// Returns the first object in the collision table.
         /// </summary>
         /// <returns></returns>
-        static uwObject FindCollisionObject()
+        public static uwObject FindCollisionObject()
         {
             if (MotionCalcArray.Unk15_base != 0)
             {
@@ -1533,7 +1412,7 @@ namespace Underworld
         /// <param name="DoorX"></param>
         /// <param name="DoorY"></param>
         /// <returns></returns>
-        static uwObject FindClosedDoorCollision(ref int DoorX, ref int DoorY)
+        public static uwObject FindClosedDoorCollision(ref int DoorX, ref int DoorY)
         {
             var si = 0;
             while (MotionCalcArray.Unk15_base > si)

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -601,7 +601,7 @@ namespace Underworld
         /// <param name="isNPCArgA"></param>
         static void CreateCollisonRecord_Seg028_2941_A78(uwObject CollidingObject, long ListHead, int xArg6, int yArg8, bool isNPCArgA)
         {
-            Debug.Print($"adding collison record {CollidingObject.a_name}");
+            //Debug.Print($"adding collison record {CollidingObject.a_name}");
             if (MotionCalcArray.Unk14_collisoncount <= 8)
             {
                 int XCoordVar1;

--- a/src/physics/motion_handlers.cs
+++ b/src/physics/motion_handlers.cs
@@ -1,0 +1,217 @@
+namespace Underworld
+{
+
+    /// <summary>
+    /// Handlers (for want of a better word) seem to handle what happens when an npc/player/object collides
+    /// </summary>
+    public class MotionHandler
+    {
+
+        // //These likey need to be references to delegate functions... In dosvalue at array +8 is a function call that triggers during collisions
+        // //public static byte[] DSEG_27B2_SpecialMotionHandling = new byte[8];
+        // public static byte[] DSEG_26BA_LandNPCMotionHandler = new byte[] { 0x0, 0x0, 0x30, 0x1F, 0x10, 0x10, 0x20, 0x0 };
+        // public static byte[] DSEG_26DE_SwimmingNPCMotionHandler = new byte[] { 0x10, 0, 0x28, 0x17, 0x10, 0x10, 0x20, 0 };
+        // public static byte[] DSEG_26C6_FlyingNPCMotionHandler = new byte[] { 0x0, 0x10, 0x0, 0x7, 0x80, 0x0, 0x0, 0x0 };
+        // public static byte[] PlayerMotionHandler_dseg_67d6_26AA = new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
+        public static MotionHandler PlayerMotionHandler;
+        public static MotionHandler LandNPCMotionHandler;
+        public static MotionHandler FlierNPCMotionHandler;
+        public static MotionHandler SwimmerNPCMotionHandler;
+        public static MotionHandler ObjectMotionHandler;
+
+        public byte[] handlerdata;
+
+        public delegate bool MotionHandlerCallback(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams);
+
+        public MotionHandlerCallback HandlerFunction;
+
+        static MotionHandler()
+        {
+            PlayerMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, _motionhandlerfunction: PlayerCallBackFunction);
+            LandNPCMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x0, 0x30, 0x1F, 0x10, 0x10, 0x20, 0x0 }, _motionhandlerfunction: LandBasedCallBackFunction);
+            FlierNPCMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x10, 0x0, 0x7, 0x80, 0x0, 0x0, 0x0 }, _motionhandlerfunction: FlierCallBackFunction);
+            SwimmerNPCMotionHandler = new(_handlerdata: new byte[] { 0x10, 0, 0x28, 0x17, 0x10, 0x10, 0x20, 0 }, _motionhandlerfunction: SwimmerCallBackFunction);
+            ObjectMotionHandler = new(new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, _motionhandlerfunction: ObjectCallBackFunction);
+        }
+
+        public MotionHandler(byte[] _handlerdata, MotionHandlerCallback _motionhandlerfunction)
+        {
+            handlerdata = _handlerdata;
+            HandlerFunction = _motionhandlerfunction;
+        }
+
+        static bool FlierCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        {
+            return true;
+        }
+
+        static bool SwimmerCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        {
+            return true;
+        }
+
+        static bool PlayerCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        {
+            return true;
+        }
+
+        static bool ObjectCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        {
+            return false;
+        }
+
+        static bool LandBasedCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        {
+            if ((handler.table01 & 0x1000) == 0)
+            {
+                //seg006_1413_AFB:  
+                if ((handler.table01 & 0x10) != 0)
+                {
+                    if ((handler.table01 & 0xF8) != 0x10)
+                    {
+                        //seg006_1413_B86:
+                        if (obj.UnkBit_0X15_Bit7 == 0)
+                        {
+                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                            UWMotionParamArray.dseg_67d6_260C = false;
+                            UWMotionParamArray.dseg_67d6_260A = false;
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        //seg006_1413_B0E: 
+                        //likely land based NPC has landed in water.
+                        npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                        npc.IsNPCActive_dseg_67d6_2234 = false;
+                        var tile = UWTileMap.current_tilemap.Tiles[motionparams.x_0 >> 8, motionparams.y_2 >> 8];
+                        //spawn a splash
+                        animo.SpawnAnimoInTile(subclassindex: 6, xpos: 3, ypos: 3, zpos: (short)(tile.floorHeight << 3), tileX: tile.tileX, tileY: tile.tileY);
+                        obj.npc_animation = npc.ANIMATION_DEATH;
+                        npc.GetCritterAnimationGlobalsForCurrObj(obj);
+                        obj.AnimationFrame = (byte)npc.MaxAnimFrame;
+                        obj.Projectile_Speed = 1;
+                        return true;
+                    }
+                }
+                //seg006_1413_BAC
+                if (
+                    ((handler.table01 & 0x800) != 0)
+                    &&
+                    ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x800) == 0)
+                )
+                {
+                    //seg006_1413:0BBA
+                    if (obj.UnkBit_0X15_Bit7 == 0)
+                    {
+                        //seg006_1413_BD3
+                        npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                        UWMotionParamArray.dseg_67d6_260C = false;
+                        UWMotionParamArray.dseg_67d6_260A = false;
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (
+                     ((handler.table01 & 0x20) != 0)
+                     &&
+                      ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x20) == 0)
+                    )
+                    {
+                        if (obj.UnkBit_0X15_Bit7 == 0)
+                        {
+                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                            UWMotionParamArray.dseg_67d6_260C = false;
+                            UWMotionParamArray.dseg_67d6_260A = false;
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        if ((handler.table01 & 0x300) == 0)
+                        {
+                            if ((handler.table01 & 0x400) != 0)
+                            {
+                                var DoorCollision = motion.FindClosedDoorCollision(ref UWMotionParamArray.DoorX_222E, ref UWMotionParamArray.DoorY_222F);
+                                if (DoorCollision == null)
+                                {
+                                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                                    npc.dseg_67d6_2269 = true;
+                                    npc.collisionObject = motion.FindCollisionObject();
+                                }
+                                else
+                                {
+                                    npc.collisionObject = DoorCollision;
+                                    npc.RelatedToColliding_dseg_67d6_226F = true;
+                                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                                    npc.dseg_67d6_2269 = true;
+                                }
+                            }
+                            //seg006_1413_C7E
+                            return (npc.IsNPCActive_dseg_67d6_2234 && npc.RelatedToMotionCollision_dseg_67d6_224E);
+                        }
+                        else
+                        {
+                            npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                            return false;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (UWMotionParamArray.dseg_67d6_2614 == 0)
+                {
+                    UWMotionParamArray.dseg_67d6_2614 = -4;
+                }
+                obj.Projectile_Speed = 1;
+                npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                npc.IsNPCActive_dseg_67d6_2234 = false;
+                return false;
+            }
+        }
+
+        //helpers
+        public short table01
+        {
+            get
+            {
+                return (short)DataLoader.getAt(handlerdata, 0, 16);
+            }
+            set
+            {
+                DataLoader.setAt(handlerdata, 0, 16, value);
+            }
+        }
+
+        public short table23
+        {
+            get
+            {
+                return (short)DataLoader.getAt(handlerdata, 2, 16);
+            }
+        }
+
+        /// <summary>
+        /// Magic projectile + 4
+        /// </summary>
+        public short table45
+        {
+            get
+            {
+                return (short)DataLoader.getAt(handlerdata, 4, 16);
+            }
+        }
+
+    }//end class
+}//end namespace

--- a/src/physics/motion_handlers.cs
+++ b/src/physics/motion_handlers.cs
@@ -22,7 +22,7 @@ namespace Underworld
 
         public byte[] handlerdata;
 
-        public delegate bool MotionHandlerCallback(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams);
+        public delegate bool MotionHandlerCallback(uwObject obj, ref int arg0, UWMotionParamArray motionparams);
 
         public MotionHandlerCallback HandlerFunction;
 
@@ -41,19 +41,19 @@ namespace Underworld
             HandlerFunction = _motionhandlerfunction;
         }
 
-        static bool FlierCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        static bool FlierCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             return true;
         }
 
-        static bool SwimmerCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        static bool SwimmerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             return true;
         }
 
-        static bool PlayerCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        static bool PlayerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
-            if ((handler.table01 & 0x1000)== 0)
+            if ((arg0 & 0x1000)== 0)
             {
                 return false;
             }
@@ -74,19 +74,19 @@ namespace Underworld
             return true;
         }
 
-        static bool ObjectCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        static bool ObjectCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             return false;
         }
 
-        static bool LandBasedCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
+        static bool LandBasedCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
-            if ((handler.table01 & 0x1000) == 0)
+            if ((arg0 & 0x1000) == 0)
             {
                 //seg006_1413_AFB:  
-                if ((handler.table01 & 0x10) != 0)
+                if ((arg0 & 0x10) != 0)
                 {
-                    if ((handler.table01 & 0xF8) != 0x10)
+                    if ((arg0 & 0xF8) != 0x10)
                     {
                         //seg006_1413_B86:
                         if (obj.UnkBit_0X15_Bit7 == 0)
@@ -115,7 +115,7 @@ namespace Underworld
                 }
                 //seg006_1413_BAC
                 if (
-                    ((handler.table01 & 0x800) != 0)
+                    ((arg0 & 0x800) != 0)
                     &&
                     ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x800) == 0)
                 )
@@ -137,7 +137,7 @@ namespace Underworld
                 else
                 {
                     if (
-                     ((handler.table01 & 0x20) != 0)
+                     ((arg0 & 0x20) != 0)
                      &&
                       ((UWMotionParamArray.LikelyNPCTileStates_222C & 0x20) == 0)
                     )
@@ -156,9 +156,9 @@ namespace Underworld
                     }
                     else
                     {
-                        if ((handler.table01 & 0x300) == 0)
+                        if ((arg0 & 0x300) == 0)
                         {
-                            if ((handler.table01 & 0x400) != 0)
+                            if ((arg0 & 0x400) != 0)
                             {
                                 var DoorCollision = motion.FindClosedDoorCollision(ref UWMotionParamArray.DoorX_222E, ref UWMotionParamArray.DoorY_222F);
                                 if (DoorCollision == null)

--- a/src/physics/motion_handlers.cs
+++ b/src/physics/motion_handlers.cs
@@ -43,9 +43,42 @@ namespace Underworld
             HandlerFunction = _motionhandlerfunction;
         }
 
+        /// <summary>
+        /// Flier call back function.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="arg0"></param>
+        /// <param name="motionparams"></param>
+        /// <returns></returns>
         static bool FlierCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
-            return true;
+            npc.IsNPCActive_dseg_67d6_2234 = true; //?
+            if ((arg0 & 0x200) == 0)
+            {
+                if ((arg0 & 0x100)!=0)
+                {
+                    npc.dseg_2636 = 0x80;
+                }
+                if ((arg0 & 0x400) != 0)
+                {
+                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                    npc.dseg_67d6_2269 = true;
+                    npc.collisionObject = motion.FindCollisionObject();
+                }
+                if (npc.RelatedToMotionCollision_dseg_67d6_224E)
+                {
+                    if (npc.IsNPCActive_dseg_67d6_2234)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            else
+            {
+                npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                return false;
+            }
         }
 
         static bool SwimmerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
@@ -84,6 +117,13 @@ namespace Underworld
             }
         }
 
+        /// <summary>
+        /// Players collision callback. Stop some motion.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="arg0"></param>
+        /// <param name="motionparams"></param>
+        /// <returns></returns>
         static bool PlayerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             if ((arg0 & 0x1000)== 0)

--- a/src/physics/motion_handlers.cs
+++ b/src/physics/motion_handlers.cs
@@ -28,7 +28,7 @@ namespace Underworld
 
         static MotionHandler()
         {
-            PlayerMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 }, _motionhandlerfunction: PlayerCallBackFunction);
+            PlayerMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x0, 0x0, 0x11, 0x0, 0x0, 0x0, 0x0 }, _motionhandlerfunction: PlayerCallBackFunction);
             LandNPCMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x0, 0x30, 0x1F, 0x10, 0x10, 0x20, 0x0 }, _motionhandlerfunction: LandBasedCallBackFunction);
             FlierNPCMotionHandler = new(_handlerdata: new byte[] { 0x0, 0x10, 0x0, 0x7, 0x80, 0x0, 0x0, 0x0 }, _motionhandlerfunction: FlierCallBackFunction);
             SwimmerNPCMotionHandler = new(_handlerdata: new byte[] { 0x10, 0, 0x28, 0x17, 0x10, 0x10, 0x20, 0 }, _motionhandlerfunction: SwimmerCallBackFunction);
@@ -53,6 +53,24 @@ namespace Underworld
 
         static bool PlayerCallBackFunction(uwObject obj, MotionHandler handler, UWMotionParamArray motionparams)
         {
+            if ((handler.table01 & 0x1000)== 0)
+            {
+                return false;
+            }
+            if (motion.playerMotionParams.unk_a_pitch != 0)
+            {
+                return false;
+            } 
+            if ((motion.playerMotionParams.momentum_14 * 0xA) >= (motion.PlayerActualForwardSpeed_1_dseg_67d6_22A6 * 3))
+            {
+                return false;
+            }
+            if ((motion.PreviousTileState_dseg_67d6_22B4 & 0xA) !=0)
+            {
+                return false;
+            }
+            motion.playerMotionParams.unk_8_y = 0;
+            motion.playerMotionParams.unk_6_x = 0;
             return true;
         }
 

--- a/src/physics/motion_handlers.cs
+++ b/src/physics/motion_handlers.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Underworld
 {
 
@@ -48,7 +50,38 @@ namespace Underworld
 
         static bool SwimmerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
-            return true;
+            if ((arg0 & 0x300) == 0)
+            {
+                if ((arg0 & 0x400) !=0)
+                {
+                    npc.dseg_2682 = false;
+                    npc.dseg_2684 = false;
+                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                    npc.dseg_67d6_2269 = true;
+                    npc.collisionObject = motion.FindCollisionObject();
+                }
+                if ((arg0 & 0x8) != 0)
+                {
+                    npc.dseg_2682 = false;
+                    npc.dseg_2684 = false;
+                    npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                }
+                if (npc.RelatedToMotionCollision_dseg_67d6_224E)
+                {
+                    if (npc.IsNPCActive_dseg_67d6_2234)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            else
+            {
+                npc.dseg_2682 = false;
+                npc.dseg_2684 = false;
+                npc.RelatedToMotionCollision_dseg_67d6_224E = true;
+                return false;
+            }
         }
 
         static bool PlayerCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
@@ -74,11 +107,26 @@ namespace Underworld
             return true;
         }
 
+        /// <summary>
+        /// This callback handler for regular objects will just return false.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="arg0"></param>
+        /// <param name="motionparams"></param>
+        /// <returns></returns>
         static bool ObjectCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             return false;
         }
 
+
+        /// <summary>
+        /// This will run when land npcs collide.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="arg0"></param>
+        /// <param name="motionparams"></param>
+        /// <returns></returns>
         static bool LandBasedCallBackFunction(uwObject obj, ref int arg0, UWMotionParamArray motionparams)
         {
             if ((arg0 & 0x1000) == 0)

--- a/src/physics/motion_params.cs
+++ b/src/physics/motion_params.cs
@@ -12,48 +12,12 @@ namespace Underworld
         public static byte[] data_3FC = new byte[40];//globals at 0x3FC
         public static byte[] dseg_26b8 = new byte[16];//confirm size
 
-
-        //These likey need to be references to delegate functions... In dosvalue at array +8 is a function call that triggers during collisions
-        public static byte[] DSEG_27B2_SpecialMotionHandling = new byte[8];
-        public static byte[] DSEG_26BA_LandNPCMotionHandler = new byte[] { 0x0, 0x0, 0x30, 0x1F, 0x10, 0x10, 0x20, 0x0 };
-        public static byte[] DSEG_26DE_SwimmingNPCMotionHandler = new byte[] { 0x10, 0, 0x28, 0x17, 0x10, 0x10, 0x20, 0 };
-        public static byte[] DSEG_26C6_FlyingNPCMotionHandler = new byte[] { 0x0, 0x10, 0x0, 0x7, 0x80, 0x0, 0x0, 0x0 };
-        public static byte[] PlayerMotionHandler_dseg_67d6_26AA = new byte[] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
         public static short LikelyNPCTileStates_222C;
 
-        public static byte[] PtrTo26D2_DSEG_26B8_MotionHandler = new byte[8];
-
-        public static short PtrTo267D2_dseg_67d6_26B8_table0
-        {
-            get
-            {
-                return (short)DataLoader.getAt(UWMotionParamArray.PtrTo26D2_DSEG_26B8_MotionHandler, 0, 16);
-            }
-            set
-            {
-                DataLoader.setAt(UWMotionParamArray.PtrTo26D2_DSEG_26B8_MotionHandler, 0, 16, value);
-            }
-        }
-
-        public static short dseg_67d6_26BA_MotionHandler2
-        {
-            get
-            {
-                return (short)DataLoader.getAt(UWMotionParamArray.PtrTo26D2_DSEG_26B8_MotionHandler, 2, 16);
-            }
-        }
+        public static MotionHandler PtrTo26D2_DSEG_26B8_MotionHandler;// = new byte[8];
 
 
-        /// <summary>
-        /// Magic projectile + 4
-        /// </summary>
-        public static short dseg_67d6_26BC_table4
-        {
-            get
-            {
-                return (short)DataLoader.getAt(UWMotionParamArray.PtrTo26D2_DSEG_26B8_MotionHandler, 4, 16);
-            }
-        }
+
 
 
         //globals        

--- a/src/physics/motion_params.cs
+++ b/src/physics/motion_params.cs
@@ -12,6 +12,8 @@ namespace Underworld
         public static byte[] data_3FC = new byte[40];//globals at 0x3FC
         public static byte[] dseg_26b8 = new byte[16];//confirm size
 
+
+        //These likey need to be references to delegate functions... In dosvalue at array +8 is a function call that triggers during collisions
         public static byte[] DSEG_27B2_SpecialMotionHandling = new byte[8];
         public static byte[] DSEG_26BA_LandNPCMotionHandler = new byte[] { 0x0, 0x0, 0x30, 0x1F, 0x10, 0x10, 0x20, 0x0 };
         public static byte[] DSEG_26DE_SwimmingNPCMotionHandler = new byte[] { 0x10, 0, 0x28, 0x17, 0x10, 0x10, 0x20, 0 };
@@ -212,7 +214,7 @@ namespace Underworld
         }
 
 
-        public static int dseg_67d6_41D//height related in collision
+        public static int dseg_67d6_41D//height related in collision.likely upper height of collision
         {//0x21
             get
             {
@@ -1220,25 +1222,25 @@ namespace Underworld
         {
             get
             {//to confirm is this a byte or a word?
-                return (int)DataLoader.getAt(dseg_2562, 0xF, 16);
+                return (int)DataLoader.getAt(dseg_2562, 0xF, 8);
             }
             set
             {
-                DataLoader.setAt(dseg_2562, 0xF, 16, value);
+                DataLoader.setAt(dseg_2562, 0xF, 8, value);
             }
         }
 
-        // public int Unk10
-        // {
-        //     get
-        //     {
-        //         return (int)DataLoader.getAt(dseg_2562, 0x10, 8);
-        //     }
-        //     set
-        //     {
-        //         DataLoader.setAt(dseg_2562, 0x10, 8, value);
-        //     }
-        // }
+        public int Unk10
+        {
+            get
+            {
+                return (int)DataLoader.getAt(dseg_2562, 0x10, 8);
+            }
+            set
+            {
+                DataLoader.setAt(dseg_2562, 0x10, 8, value);
+            }
+        }
 
         public int Unk11_offset
         {

--- a/src/physics/motion_params.cs
+++ b/src/physics/motion_params.cs
@@ -414,11 +414,11 @@ namespace Underworld
                 DataLoader.setAt(data, 0x10, 16, value);
             }
         }
-        public byte speed_12
+        public sbyte speed_12
         {
             get
             {
-                return (byte)DataLoader.getAt(data, 0x12, 8);
+                return (sbyte)DataLoader.getAt(data, 0x12, 8);
             }
             set
             {
@@ -682,10 +682,6 @@ namespace Underworld
             }
             set
             {
-                if (value <=5)
-                {
-                    Debug.Print("here");
-                }
                 DataLoader.setAt(PtrToMotionCalc, 2, 16, value);
             }
         }

--- a/src/physics/motion_params.cs
+++ b/src/physics/motion_params.cs
@@ -17,9 +17,6 @@ namespace Underworld
         public static MotionHandler PtrTo26D2_DSEG_26B8_MotionHandler;// = new byte[8];
 
 
-
-
-
         //globals        
 
 

--- a/src/physics/motion_player.cs
+++ b/src/physics/motion_player.cs
@@ -97,7 +97,7 @@ namespace Underworld
         public static void PlayerMotion(short ClockIncrement)
         {
             UWMotionParamArray.instance = motion.playerMotionParams;//in case we step on a jump trap...
-
+            
             //These values are used in camera bobbing/shaking
             CameraRollModifier_dseg_67d6_33D4 = 0;
             CameraPitchModifier_dseg_67d6_33D2 = 0;
@@ -397,7 +397,7 @@ namespace Underworld
             }//end uw2 specific code.
 
             //Seg008_a61
-            playerMotionParams.speed_12 = (byte)ClockIncrement;//too low a value breaks some motion. too high a value makes turning too fast.
+            playerMotionParams.speed_12 = (sbyte)ClockIncrement;//too low a value breaks some motion. too high a value makes turning too fast.
 
             if (_RES != GAME_UW2)
             {

--- a/src/physics/motion_player.cs
+++ b/src/physics/motion_player.cs
@@ -113,7 +113,7 @@ namespace Underworld
             CalculateMotion(
                 projectile: playerdat.playerObject,
                 MotionParams: playerMotionParams,
-                SpecialMotionHandler: UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA);
+                SpecialMotionHandler: MotionHandler.PlayerMotionHandler);
 
             ApplyPlayerMotion(playerdat.playerObject);
             // if (initial != PlayerMotionYaw_dseg_67d6_8296)
@@ -446,13 +446,13 @@ namespace Underworld
 
             //seg008_1B09_AAA:
             playerMotionParams.heading_1E = PlayerMotionYaw_dseg_67d6_8296;
-            setAt(UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA, 0, 16, 0x0);
+            setAt(MotionHandler.PlayerMotionHandler.handlerdata, 0, 16, 0x0);  //setAt(UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA, 0, 16, 0x0);
 
             if ((playerdat.MagicalMotionAbilities & 0x14) != 0)
             {
                 //seg008_1B09_ABD:
                 //player is flying or levitating
-                setAt(UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA, 0, 16, 0x1000);
+                setAt(MotionHandler.PlayerMotionHandler.handlerdata, 0, 16, 0x1000); //UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA
                 playerMotionParams.unk_17 = 0x80;
             }
 

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -57,7 +57,7 @@ namespace Underworld
             }
 
             MissileHeading = 1 + (((X1 - uimanager.Window3DHeadingAdjust) * 5) / 13);
-            //note missile pitch is initialised with a value from DSEG_33D6 but that value always appears to be 0.
+            //note missile pitch is initialised with a value from DSEG_33D6 (camera pitch) TODO add that value in.
             MissilePitch = (Y1 - uimanager.Window3DPitchAdjust) / 6;
 
             Debug.Print($"Pitch {MissilePitch} Heading {MissileHeading} at mousepos {X1},{Y1} ({(uimanager.ViewPortMouseXPos / 4)},{(uimanager.ViewPortMouseYPos / 4)})");

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -112,6 +112,10 @@ namespace Underworld
                     {
                         //todo handle swimming player height adjustment
                         Debug.Print($"Swimminglauncher. Projectile needs to be adjusted! {Launcher.a_name}");
+                        if (playerdat.SwimCounter > 0x50)
+                        {
+                            projectile.zpos = (short)(((MissilePitch<<1) + playerdat.playerObject.zpos + ( commonObjDat.height(playerdat.playerObject.item_id) - (playerdat.SwimCounter >> 3) )) & 0x7F);
+                        }
                     }
                 }
 
@@ -161,7 +165,7 @@ namespace Underworld
                     }
                     else
                     {
-                        if (_RES!=GAME_UW2)
+                        if (_RES != GAME_UW2)
                         {
                             UWsoundeffects.PlaySoundEffectAtObject(0xA, projectile, 0);//throw sounds.
                         }
@@ -412,7 +416,7 @@ namespace Underworld
                         {
                             if (MotionCalcArray.z4 - argC_distance <= UWMotionParamArray.Z_dseg_67d6_2582)
                             {
-                                result = true;                                
+                                result = true;
                             }
                             else
                             {
@@ -456,11 +460,11 @@ namespace Underworld
             MissileLauncherHeadingBase = 1;
             var projectile = PrepareProjectileObject(critter);
             MissileFlagA = false;
-            if (projectile!=null)
+            if (projectile != null)
             {
                 //make a launch sound
                 UWsoundeffects.PlaySoundEffectAtObject(effectNo: 0xA, obj: projectile, volDelta: 0x14);
-            }        
+            }
         }
     }//end class
 }//end namespace

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -458,8 +458,8 @@ namespace Underworld
             MissileFlagA = false;
             if (projectile!=null)
             {
-                //TODO make a launch sound
-                //MakeASound();
+                //make a launch sound
+                UWsoundeffects.PlaySoundEffectAtObject(effectNo: 0xA, obj: projectile, volDelta: 0x14);
             }        
         }
     }//end class

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -57,8 +57,9 @@ namespace Underworld
             }
 
             MissileHeading = 1 + (((X1 - uimanager.Window3DHeadingAdjust) * 5) / 13);
-            //note missile pitch is initialised with a value from DSEG_33D6 (camera pitch) TODO add that value in.
-            MissilePitch = (Y1 - uimanager.Window3DPitchAdjust) / 6;
+
+            MissilePitch = PlayerCameraPitch_dseg_67d6_33D6 / 0x300;//initialise from camera pitch
+            MissilePitch += (Y1 - uimanager.Window3DPitchAdjust) / 6;
 
             Debug.Print($"Pitch {MissilePitch} Heading {MissileHeading} at mousepos {X1},{Y1} ({(uimanager.ViewPortMouseXPos / 4)},{(uimanager.ViewPortMouseYPos / 4)})");
             if (Y1 < uimanager.Window3DDropThreshold)

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -78,6 +78,10 @@ namespace Underworld
         /// <returns></returns>
         public static uwObject PrepareProjectileObject(uwObject Launcher)
         {
+            if (Launcher.IsStatic)
+            {
+                Debug.Print($"Static launcher of a projectile spell! Implement me ! {Launcher.a_name}");
+            }
             var slot = ObjectCreator.PrepareNewObject(RangedAmmoItemID, ObjectFreeLists.ObjectListType.MobileList);
             if (slot != -1)
             {
@@ -110,6 +114,7 @@ namespace Underworld
                     if (Launcher == playerdat.playerObject)
                     {
                         //todo handle swimming player height adjustment
+                        Debug.Print($"Swimminglauncher. Projectile needs to be adjusted! {Launcher.a_name}");
                     }
                 }
 

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -159,9 +159,16 @@ namespace Underworld
                     projectile.next = tile.indexObjectList;
                     tile.indexObjectList = projectile.index;
 
-                    if (MissileFlagB && MissileFlagA)
+                    if ((_RES == GAME_UW2) && (!MissileFlagB && !MissileFlagA))
                     {
-                        //TODO some logic around sound effects.
+                        UWsoundeffects.PlaySoundEffectAtObject(0x1C, projectile, 0);//throw sounds
+                    }
+                    else
+                    {
+                        if (_RES!=GAME_UW2)
+                        {
+                            UWsoundeffects.PlaySoundEffectAtObject(0xA, projectile, 0);//throw sounds.
+                        }
                     }
 
                     return projectile;

--- a/src/physics/motion_projectile.cs
+++ b/src/physics/motion_projectile.cs
@@ -79,10 +79,6 @@ namespace Underworld
         /// <returns></returns>
         public static uwObject PrepareProjectileObject(uwObject Launcher)
         {
-            if (Launcher.IsStatic)
-            {
-                Debug.Print($"Static launcher of a projectile spell! Implement me ! {Launcher.a_name}");
-            }
             var slot = ObjectCreator.PrepareNewObject(RangedAmmoItemID, ObjectFreeLists.ObjectListType.MobileList);
             if (slot != -1)
             {
@@ -93,7 +89,7 @@ namespace Underworld
 
                 if (MissileLauncherHeadingBase != 0)
                 {
-                    MissileLauncherHeadingBase = Launcher.npc_heading;//todo account for the scenario where the launcher is a static
+                    MissileLauncherHeadingBase = Launcher.npc_heading;
                 }
                 MissileLauncherHeadingBase = MissileLauncherHeadingBase + (Launcher.heading << 5);
                 MissileLauncherHeadingBase = (MissileHeading + MissileLauncherHeadingBase + 0x100) & 0xFF;

--- a/src/utility/ObjectCreator.cs
+++ b/src/utility/ObjectCreator.cs
@@ -713,7 +713,7 @@ namespace Underworld
             }
             obj.npc_xhome = (short)xhome;
             obj.npc_yhome = (short)yhome;
-            obj.NextFrame_0XA_Bit0123 = 0;//this may be a next frame to update setting.
+            obj.NextFrame_0XA_Bit0123 = (short)(main.ThisFrameDelta + 1);//next frame where the object will move/process updates.
             obj.Projectile_Speed = 2;
             obj.UnkBit_0X13_Bit0to6 = 0;
             obj.invis = 0;

--- a/src/utility/teleportation.cs
+++ b/src/utility/teleportation.cs
@@ -183,7 +183,7 @@ namespace Underworld
                 playerdat.PlacePlayerInTile(-1, -1, -1, -1);
             }
 
-            Loader.setAt(UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA, 0, 16, 0);
+            Loader.setAt(MotionHandler.PlayerMotionHandler.handlerdata, 0, 16, 0);//Loader.setAt(UWMotionParamArray.PlayerMotionHandler_dseg_67d6_26AA, 0, 16, 0);
             motion.playerMotionParams.momentum_14 = 0;
             motion.playerMotionParams.gravity_10_Z = 0;
             motion.playerMotionParams.unk_e_Y = 0;


### PR DESCRIPTION
Addition of a number of bug fixes and missing features from Motion code.
Highlights
- Fixed the bridge throwing bug, objects clamping to the height of a bridge when throwing them over it
- Fixed the multi-body bridge bug. Player will clip through to the bottom of the level when colliding with more than 1 object on a bridge
- Fixed magic projectiles bouncing off of walls.
- Added the "collison handlers" for various NPC and the player.
- Launching projectiles is now adjusted by camera pitch