### PR TITLE
chore: bring audio NuGet dependencies up to date (ADLMidi.NET 1.2.0, Munt.NET 0.2.2)

### DIFF
--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Munt.NET" Version="0.2.1" />
-    <ProjectReference Include="..\AdlMidi.NET\src\ADLMidi.NET\ADLMidi.NET.csproj" />
+    <PackageReference Include="ADLMidi.NET" Version="1.2.0" />
     <PackageReference Include="MeltySynth" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -11,7 +11,7 @@
     <None Remove="tools/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Munt.NET" Version="0.2.1" />
+    <PackageReference Include="Munt.NET" Version="0.2.2" />
     <PackageReference Include="ADLMidi.NET" Version="1.2.0" />
     <PackageReference Include="MeltySynth" Version="2.4.1" />
   </ItemGroup>

--- a/Underworld.sln
+++ b/Underworld.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Underworld", "Underworld.csproj", "{24A08942-84C0-4463-9309-FE0737F94F59}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ADLMidi.NET", "..\AdlMidi.NET\src\ADLMidi.NET\ADLMidi.NET.csproj", "{2D39821A-C241-4154-8996-AF2F989B196F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
## Summary

Two related audio-stack updates, both via NuGet:

### ADLMidi.NET: 0.x ProjectReference → 1.2.0 PackageReference

csinkers published [ADLMidi.NET 1.2.0](https://www.nuget.org/packages/ADLMidi.NET) on 2026-05-18, which now contains everything the port was consuming from the local fork:

- macOS arm64 native dylib ([csinkers/AdlMidi.NET#1](https://github.com/csinkers/AdlMidi.NET/pull/1))
- Real-time MIDI API used by `AdlMidiEngine` ([csinkers/AdlMidi.NET#2](https://github.com/csinkers/AdlMidi.NET/pull/2))
- `OplChip` bare-chip wrapper used by `SfxStreamPlayer` ([csinkers/AdlMidi.NET#3](https://github.com/csinkers/AdlMidi.NET/pull/3))

Switching from the local `<ProjectReference>` to a `<PackageReference>`:

- Removes the requirement to clone `AdlMidi.NET` alongside this repo at a specific relative path. Drops the workaround introduced in 6cdac99.
- Pins to a published, immutable version (`1.2.0`) instead of whatever HEAD a contributor's fork happens to be on.
- Aligns with how `Munt.NET` and `MeltySynth` are already consumed in the same csproj.
- Places `libadlmidi.dylib` at `runtimes/osx-arm64/native/` and registers it in `Underworld.deps.json` as an `osx-arm64` native asset. The prior `ProjectReference` setup left the dylib flat at the `bin/Debug` root, which works on some host configurations but not all on macOS.

### Munt.NET: 0.2.1 → 0.2.2

Picks up the `XmiPlayer.IsPlaying` end-of-track fix ([abedegno/Munt.NET#1](https://github.com/abedegno/Munt.NET/issues/1)) that I raised in [#28](https://github.com/hankmorgan/UnderworldGodot/issues/28). Non-looping XMI tracks now correctly report `IsPlaying=false` once their final event has been rendered, so `MusicStreamPlayer` consumers driving end-of-track sequencing can poll `IsPlaying` directly rather than tracking elapsed time as a workaround.

No code changes needed in the port: `ISynthEngine` / `MusicStreamPlayer` surfaces are unchanged.

## Test plan

- [x] `dotnet build` clean (0 errors) with both new package references.
- [x] `libadlmidi.dylib` ends up at `runtimes/osx-arm64/native/`, registered in `Underworld.deps.json` as an `osx-arm64` native asset.
- [x] Game launches on macOS arm64 under Godot 4.6.1 mono with .NET 10 host. SFX play in-game (i.e. `OplChip.Create(48000)` succeeds).
- [ ] Verify on Windows + Linux. The ADLMidi.NET package ships native binaries for `win-x64`, `win-x86`, and `linux-x64` (same layout as macOS), so I'd expect parity, but I don't have a way to test locally.