### PR TITLE
Conversation system fixes

### DIFF
--- a/src/conversation/conversation_functions/babl_fmenu.cs
+++ b/src/conversation/conversation_functions/babl_fmenu.cs
@@ -18,8 +18,8 @@ namespace Underworld
             uimanager.instance.scroll.Clear();
             yield return new WaitForSeconds(0.2f);
             
-            int Start = at(stackptr - 1);
-            int flagIndex = at(stackptr - 2);
+            int Start = at(stack + stackptr - 1);
+            int flagIndex = at(stack + stackptr - 2);
             usingBablF = true;
             ClearConversationOptions();
             string finaltext = "";

--- a/src/conversation/conversation_functions/babl_hack.cs
+++ b/src/conversation/conversation_functions/babl_hack.cs
@@ -7,7 +7,7 @@ namespace Underworld
     {
         public static void babl_hack(uwObject talker)
         {
-            var mode = at(at(stackptr - 1));
+            var mode = at(at(stack + stackptr - 1));
             
             Debug.Print($"babl hack mode {mode}");
             switch (mode)
@@ -64,9 +64,9 @@ namespace Underworld
         /// </summary>
         static void SetUpArenaFight()
         {
-            var IsPowerFullprobability_var4 = GetConvoStackValueAtPtr(stackptr-4);
-            var Arena_var6 = GetConvoStackValueAtPtr(stackptr-3);
-            var di_noOfFighters =GetConvoStackValueAtPtr(stackptr-2);
+            var IsPowerFullprobability_var4 = GetConvoStackValueAtPtr(stack + stackptr-4);
+            var Arena_var6 = GetConvoStackValueAtPtr(stack + stackptr-3);
+            var di_noOfFighters =GetConvoStackValueAtPtr(stack + stackptr-2);
             var xOffset_var8 = 1;
             var yOffset_varA = 1;
             var var10 = 0;

--- a/src/conversation/conversation_functions/babl_menu.cs
+++ b/src/conversation/conversation_functions/babl_menu.cs
@@ -11,7 +11,7 @@ namespace Underworld
         {
             uimanager.instance.scroll.Clear();
             int[] args = new int[1];
-            args[0] = at(stackptr - 1);//ptr to value
+            args[0] = at(stack + stackptr - 1);//ptr to value
 
             int Start = args[0];
             yield return new WaitForSeconds(0.2f);

--- a/src/conversation/conversation_functions/check_inv_quality.cs
+++ b/src/conversation/conversation_functions/check_inv_quality.cs
@@ -4,7 +4,7 @@ namespace Underworld
     {
         static void check_inv_quality()
         {
-            var index= at(at(stackptr-1));
+            var index= at(at(stack + stackptr-1));
             if (index!=0)
             {
                 var obj = UWTileMap.current_tilemap.LevelObjects[index];

--- a/src/conversation/conversation_functions/compare.cs
+++ b/src/conversation/conversation_functions/compare.cs
@@ -7,8 +7,8 @@ namespace Underworld
         public static void compare()
         {
             int[] args = new int[2];
-            args[0] = at(stackptr - 1);
-            args[1] = at(stackptr - 2);
+            args[0] = at(stack + stackptr - 1);
+            args[1] = at(stack + stackptr - 2);
 
             var string1 = getString(at(args[0]));
             var string2 = getString(at(args[1]));

--- a/src/conversation/conversation_functions/contains.cs
+++ b/src/conversation/conversation_functions/contains.cs
@@ -7,8 +7,8 @@ namespace Underworld
         public static void contains()
         {
             int[] args = new int[2];
-            args[0] = at(stackptr - 1);
-            args[1] = at(stackptr - 2);
+            args[0] = at(stack + stackptr - 1);
+            args[1] = at(stack + stackptr - 2);
 
             var string1 = getString(at(args[0]));
             var string2 = getString(at(args[1]));

--- a/src/conversation/conversation_functions/count_inv.cs
+++ b/src/conversation/conversation_functions/count_inv.cs
@@ -5,7 +5,7 @@ namespace Underworld
     {   
         public static void count_inv()
         {
-            var itemindex = at(at(stackptr-1));
+            var itemindex = at(at(stack + stackptr-1));
 
             var obj = UWTileMap.current_tilemap.LevelObjects[itemindex];
             if (obj!=null)

--- a/src/conversation/conversation_functions/do_demand.cs
+++ b/src/conversation/conversation_functions/do_demand.cs
@@ -27,8 +27,8 @@ namespace Underworld
         /// <returns></returns>
         static IEnumerator do_demandUW1(uwObject talker)
         {
-            var ifYouInsist = GetConvoStackValueAtPtr(stackptr - 2); //npc gives in
-            var noYouWont = GetConvoStackValueAtPtr(stackptr - 1); //refuses
+            var ifYouInsist = GetConvoStackValueAtPtr(stack + stackptr - 2); //npc gives in
+            var noYouWont = GetConvoStackValueAtPtr(stack + stackptr - 1); //refuses
             var attitudeOffset = FindVariableAddress("npc_attitude");
             var attitude = at(attitudeOffset);
 
@@ -65,9 +65,9 @@ namespace Underworld
         /// <returns></returns>
         static IEnumerator do_demandUW2(uwObject talker)
         {
-            var ifYouInsist = GetConvoStackValueAtPtr(stackptr - 2); //npc gives in
-            var noYouWont = GetConvoStackValueAtPtr(stackptr - 1); //refuses
-            var whatItems = GetConvoStackValueAtPtr(stackptr - 3); //there are no items selected
+            var ifYouInsist = GetConvoStackValueAtPtr(stack + stackptr - 2); //npc gives in
+            var noYouWont = GetConvoStackValueAtPtr(stack + stackptr - 1); //refuses
+            var whatItems = GetConvoStackValueAtPtr(stack + stackptr - 3); //there are no items selected
 
             var attitudeOffset = FindVariableAddress("npc_attitude");
             var attitude = at(attitudeOffset);

--- a/src/conversation/conversation_functions/do_inv_create.cs
+++ b/src/conversation/conversation_functions/do_inv_create.cs
@@ -4,7 +4,7 @@ namespace Underworld
     {   
         public static void do_inv_create(uwObject talker)
         {
-            var arg0 = at(at(stackptr-1));
+            var arg0 = at(at(stack + stackptr-1));
             var slot = ObjectCreator.PrepareNewObject(arg0);
             if (slot!=0)
             {

--- a/src/conversation/conversation_functions/do_inv_delete.cs
+++ b/src/conversation/conversation_functions/do_inv_delete.cs
@@ -6,7 +6,7 @@ namespace Underworld
     {   
         public static void do_inv_delete(uwObject talker)
         {
-            var arg0 = at(at(stackptr-1));
+            var arg0 = at(at(stack + stackptr-1));
             Debug.Print($"do_inv_delete {arg0}");
             
             var next = talker.link;

--- a/src/conversation/conversation_functions/do_offer.cs
+++ b/src/conversation/conversation_functions/do_offer.cs
@@ -6,12 +6,12 @@ namespace Underworld
         public static IEnumerator do_offer()
         {
             //Get strings ids from the stack
-            var YeahWeTrade = GetConvoStackValueAtPtr(stackptr - 5);//Guess            
-            var INoLike = GetConvoStackValueAtPtr(stackptr - 4);//Trade is not enough
-            var YouThinkMeStupid = GetConvoStackValueAtPtr(stackptr - 3);//really bad offer made
-            var ImTiredOfThis = GetConvoStackValueAtPtr(stackptr - 2); //trade patience ran out
+            var YeahWeTrade = GetConvoStackValueAtPtr(stack + stackptr - 5);//Guess            
+            var INoLike = GetConvoStackValueAtPtr(stack + stackptr - 4);//Trade is not enough
+            var YouThinkMeStupid = GetConvoStackValueAtPtr(stack + stackptr - 3);//really bad offer made
+            var ImTiredOfThis = GetConvoStackValueAtPtr(stack + stackptr - 2); //trade patience ran out
 
-            var YouMakeNoSense = GetConvoStackValueAtPtr(stackptr - 1);//no items offered
+            var YouMakeNoSense = GetConvoStackValueAtPtr(stack + stackptr - 1);//no items offered
 
 
             if (TradePatience < 0)

--- a/src/conversation/conversation_functions/find_barter.cs
+++ b/src/conversation/conversation_functions/find_barter.cs
@@ -4,7 +4,7 @@ namespace Underworld
     {
         public static void find_barter()
         {
-            var toFind = at(at(stackptr - 1));
+            var toFind = at(at(stack + stackptr - 1));
             var itemcount = GetPlayerSelectedTradeItems(out int[] itemIds, out int[] itemIndices);
             if (toFind < 1000)
             {//find exact match

--- a/src/conversation/conversation_functions/find_barter_total.cs
+++ b/src/conversation/conversation_functions/find_barter_total.cs
@@ -10,10 +10,10 @@ namespace Underworld
         /// </summary>
         public static void find_barter_total()
         {
-            var item_id = at(at(stackptr - 4));
-            var PtrNoOfMatches = at(stackptr - 3);
-            var PtrResultArray = at(stackptr - 2);
-            var PtrTotalQty = at(stackptr - 1);
+            var item_id = at(at(stack + stackptr - 4));
+            var PtrNoOfMatches = at(stack + stackptr - 3);
+            var PtrResultArray = at(stack + stackptr - 2);
+            var PtrTotalQty = at(stack + stackptr - 1);
 
             Debug.Print($"find_barter_total({item_id})");
             var itemcount = GetPlayerSelectedTradeItems(out int[] itemIds, out int[] itemIndices);

--- a/src/conversation/conversation_functions/find_inv.cs
+++ b/src/conversation/conversation_functions/find_inv.cs
@@ -6,8 +6,8 @@ namespace Underworld
     {
         public static void find_inv(uwObject talker)
         {
-            var Character_arg0 = at(at(stackptr - 1));
-            var ItemID_arg1 = at(at(stackptr - 2));
+            var Character_arg0 = at(at(stack + stackptr - 1));
+            var ItemID_arg1 = at(at(stack + stackptr - 2));
             Debug.Print($"Find_Inv({Character_arg0},{ItemID_arg1});");
 
             //arg0 when 0 search npc, else search player

--- a/src/conversation/conversation_functions/get_quest.cs
+++ b/src/conversation/conversation_functions/get_quest.cs
@@ -5,7 +5,7 @@ namespace Underworld
     {
         public static void get_quest()
         {        
-            var questno = GetConvoStackValueAtPtr(stackptr - 1); 
+            var questno = GetConvoStackValueAtPtr(stack + stackptr - 1); 
             result_register = GetQuest(questno);
             Debug.Print($"Getting quest {questno} which is {result_register}");
             return;

--- a/src/conversation/conversation_functions/give_ptr_npc.cs
+++ b/src/conversation/conversation_functions/give_ptr_npc.cs
@@ -6,8 +6,8 @@ namespace Underworld
     {
         public static void give_ptr_npc(uwObject talker)
         {
-            var qty = at(at(stackptr-1));
-            var ObjectIndex = at(at(stackptr-2));
+            var qty = at(at(stack + stackptr-1));
+            var ObjectIndex = at(at(stack + stackptr-2));
             Debug.Print($"{qty} of {ObjectIndex}");
             //try and find in trade area first.
             var itemcount = GetPlayerSelectedTradeItems(out int[] itemIds, out int[] itemIndices);

--- a/src/conversation/conversation_functions/give_to_npc.cs
+++ b/src/conversation/conversation_functions/give_to_npc.cs
@@ -4,8 +4,8 @@ namespace Underworld
     {
         public static void give_to_npc(uwObject talker)
         {
-            var CountItems_arg1 = GetConvoStackValueAtPtr(stackptr - 2);//how many items to get
-            var ItemIndicesToGive_Array = at(stackptr - 1); // array of item ids to get.  GetConvoStackValueAtPtr(stackptr-1);
+            var CountItems_arg1 = GetConvoStackValueAtPtr(stack + stackptr - 2);//how many items to get
+            var ItemIndicesToGive_Array = at(stack + stackptr - 1); // array of item ids to get.  GetConvoStackValueAtPtr(stack + stackptr-1);
 
             //Get the player inventory
             var itemcount = GetPlayerSelectedTradeItems(out int[] itemIds, out int[] itemIndices);

--- a/src/conversation/conversation_functions/gronk_door.cs
+++ b/src/conversation/conversation_functions/gronk_door.cs
@@ -9,9 +9,9 @@ namespace Underworld
         /// </summary>
         public static void gronk_door()
         {
-            var tileX = GetConvoStackValueAtPtr(stackptr - 3);
-            var tileY = GetConvoStackValueAtPtr(stackptr - 2);
-            var mode = GetConvoStackValueAtPtr(stackptr - 1);
+            var tileX = GetConvoStackValueAtPtr(stack + stackptr - 3);
+            var tileY = GetConvoStackValueAtPtr(stack + stackptr - 2);
+            var mode = GetConvoStackValueAtPtr(stack + stackptr - 1);
 
             Debug.Print($"Gronkdoor {tileX}, {tileY}, {mode}");
             var tile = UWTileMap.current_tilemap.Tiles[tileX, tileY];

--- a/src/conversation/conversation_functions/identify_inv.cs
+++ b/src/conversation/conversation_functions/identify_inv.cs
@@ -7,8 +7,8 @@ namespace Underworld
         /// </summary>
         public static void identify_inv()
         {
-            var index = at(at(stackptr-4));
-            var lorecheck = at(at(stackptr-1));
+            var index = at(at(stack + stackptr-4));
+            var lorecheck = at(at(stack + stackptr-1));
             var value = GetTrueItemValue(
                     ApplyLikeDislike: true, 
                     appraise_accuracy: NPCAppraisalAccuracy, 
@@ -22,7 +22,7 @@ namespace Underworld
                 IncludeYouSee: false);
             var stringIDNo = GameStrings.AddString(currentConversation.StringBlock, idString);
 
-            Set(at(stackptr-2), stringIDNo );
+            Set(at(stack + stackptr-2), stringIDNo );
             result_register = value;
         }
     }

--- a/src/conversation/conversation_functions/imported_functions.cs
+++ b/src/conversation/conversation_functions/imported_functions.cs
@@ -282,7 +282,7 @@ namespace Underworld
             }
             //set the value at the stackptr to the result
             Debug.Print($"Set result {result_register} at {stackptr}");
-            Set(stackptr, result_register);
+            Set(stack + stackptr, result_register);
 
             if (TradeResult == 1)
             {

--- a/src/conversation/conversation_functions/imported_functions.cs
+++ b/src/conversation/conversation_functions/imported_functions.cs
@@ -281,7 +281,7 @@ namespace Underworld
                     }
             }
             //set the value at the stackptr to the result
-            Debug.Print($"Set result {result_register} at {stackptr}");
+            Debug.Print($"Set result {result_register} at {stack + stackptr}");
             Set(stack + stackptr, result_register);
 
             if (TradeResult == 1)

--- a/src/conversation/conversation_functions/length.cs
+++ b/src/conversation/conversation_functions/length.cs
@@ -4,7 +4,7 @@ namespace Underworld
     {
         public static void length()
         {
-            var stringaddress =  GetConvoStackValueAtPtr(stackptr - 1);           
+            var stringaddress =  GetConvoStackValueAtPtr(stack + stackptr - 1);           
             result_register = getString(stringaddress).Length;
         }
     }//end class

--- a/src/conversation/conversation_functions/place_object.cs
+++ b/src/conversation/conversation_functions/place_object.cs
@@ -4,9 +4,9 @@ namespace Underworld
     {
         public static void place_object(uwObject talker)
         {
-            var index = at(at(stackptr - 3));
-            var tilex = at(at(stackptr - 2));
-            var tiley = at(at(stackptr - 1));
+            var index = at(at(stack + stackptr - 3));
+            var tilex = at(at(stack + stackptr - 2));
+            var tiley = at(at(stack + stackptr - 1));
             var tile = UWTileMap.current_tilemap.Tiles[tilex, tiley];
 
             //remove from the npcs inventory

--- a/src/conversation/conversation_functions/print.cs
+++ b/src/conversation/conversation_functions/print.cs
@@ -9,7 +9,7 @@ namespace Underworld
         {
             yield return new WaitForSeconds(0.3f);
             //Debug.Print(getString(arg1));
-            var arg1  = GetConvoStackValueAtPtr(stackptr - 1);  
+            var arg1  = GetConvoStackValueAtPtr(stack + stackptr - 1);  
             uimanager.AddToConvoScroll(
                 stringToAdd: getString(arg1,true),
                 colour: PRINT_SAY

--- a/src/conversation/conversation_functions/random.cs
+++ b/src/conversation/conversation_functions/random.cs
@@ -7,7 +7,7 @@ namespace Underworld
         /// </summary>
         public static void Random()
         {
-            var max = GetConvoStackValueAtPtr(stackptr - 1);  
+            var max = GetConvoStackValueAtPtr(stack + stackptr - 1);  
             result_register = Rng.r.Next(max) + 1;
             return;
         }

--- a/src/conversation/conversation_functions/set_attitude.cs
+++ b/src/conversation/conversation_functions/set_attitude.cs
@@ -8,8 +8,8 @@ namespace Underworld
         /// </summary>
         public static void set_attitude()
         {
-            var newAttitude_di = GetConvoStackValueAtPtr(stackptr - 1);
-            var whoami = GetConvoStackValueAtPtr(stackptr - 2);
+            var newAttitude_di = GetConvoStackValueAtPtr(stack + stackptr - 1);
+            var whoami = GetConvoStackValueAtPtr(stack + stackptr - 2);
             CallBacks.RunCodeOnNPCS_WhoAmI(npc.set_attitude_by_array, whoami, new int[] { newAttitude_di }, false);
 
             //Note there is buggy usage of this function in vanilla UW2 on the Prison Tower level 2. Goblin Guard conversation. 

--- a/src/conversation/conversation_functions/set_inv_quality.cs
+++ b/src/conversation/conversation_functions/set_inv_quality.cs
@@ -4,8 +4,8 @@ namespace Underworld
     {
         public static void set_inv_quality()
         {
-            var index = GetConvoStackValueAtPtr(stackptr - 2);
-            var newQuality = GetConvoStackValueAtPtr(stackptr - 1);
+            var index = GetConvoStackValueAtPtr(stack + stackptr - 2);
+            var newQuality = GetConvoStackValueAtPtr(stack + stackptr - 1);
             var obj = UWTileMap.current_tilemap.LevelObjects[index];
             obj.quality = (short)newQuality;
         }

--- a/src/conversation/conversation_functions/set_likes_dislikes.cs
+++ b/src/conversation/conversation_functions/set_likes_dislikes.cs
@@ -9,7 +9,7 @@ namespace Underworld
         /// </summary>
         public static void set_likes_dislikes()
         {
-            Likes = at(stackptr-2);         
+            Likes = at(stack + stackptr-2);         
 
             var arrayindex = Likes;
             var entry = at(arrayindex);
@@ -28,7 +28,7 @@ namespace Underworld
             }
 
 
-            Dislikes = at(stackptr-1);
+            Dislikes = at(stack + stackptr-1);
 
             arrayindex = Dislikes;
             entry = at(arrayindex);

--- a/src/conversation/conversation_functions/set_quest.cs
+++ b/src/conversation/conversation_functions/set_quest.cs
@@ -4,8 +4,8 @@ namespace Underworld
     {
         public static void set_quest()
         {
-            var questno = GetConvoStackValueAtPtr(stackptr - 2);   
-            var newvalue = GetConvoStackValueAtPtr(stackptr - 1);   
+            var questno = GetConvoStackValueAtPtr(stack + stackptr - 2);   
+            var newvalue = GetConvoStackValueAtPtr(stack + stackptr - 1);   
             playerdat.SetQuest(questno, newvalue);
         }
     }//end class

--- a/src/conversation/conversation_functions/set_race_attitude.cs
+++ b/src/conversation/conversation_functions/set_race_attitude.cs
@@ -9,13 +9,13 @@ namespace Underworld
         /// </summary>
         public static void set_race_attitude(uwObject talker)
         {
-            var range = at(at(stackptr-1));
+            var range = at(at(stack + stackptr-1));
             if (range<=0)
             {
                 range = 1;
             }
-            var newAttitute = at(at(stackptr-2));
-            var race = at(at(stackptr-3));
+            var newAttitute = at(at(stack + stackptr-2));
+            var race = at(at(stack + stackptr-3));
             Debug.Print($"set_race_attitude to {newAttitute} in range {range} for race {race}");
             for (var tileX = talker.tileX - range; tileX <= talker.tileX + range; tileX++)
             {

--- a/src/conversation/conversation_functions/set_sequence.cs
+++ b/src/conversation/conversation_functions/set_sequence.cs
@@ -7,9 +7,9 @@ namespace Underworld
         /// </summary>
         public static void set_sequence()
         {
-            var var2 = GetConvoStackValueAtPtr(stackptr-1);
-            var di = GetConvoStackValueAtPtr(stackptr-2);
-            var whoami = GetConvoStackValueAtPtr(stackptr-3);
+            var var2 = GetConvoStackValueAtPtr(stack + stackptr-1);
+            var di = GetConvoStackValueAtPtr(stack + stackptr-2);
+            var whoami = GetConvoStackValueAtPtr(stack + stackptr-3);
             var functionparam = (di<<3) | (var2 & 0x7);
 
             CallBacks.RunCodeOnNPCS_WhoAmI(set_sequence, whoami, new int[]{functionparam},false);

--- a/src/conversation/conversation_functions/sex.cs
+++ b/src/conversation/conversation_functions/sex.cs
@@ -10,7 +10,7 @@ namespace Underworld
         public static void Sex()
         {
             var gender = playerdat.gender - 2; //-2 if male, -1 if female
-            result_register = GetConvoStackValueAtPtr(stackptr + gender);
+            result_register = GetConvoStackValueAtPtr(stack + stackptr + gender);
             Debug.Print(getString(result_register));
             return;
         }

--- a/src/conversation/conversation_functions/show_inv.cs
+++ b/src/conversation/conversation_functions/show_inv.cs
@@ -4,8 +4,8 @@ namespace Underworld
     {
         public static void show_inv()
         {
-            var ResultIndices = at(stackptr - 1);
-            var ResultItemIds = at(stackptr - 2);            
+            var ResultIndices = at(stack + stackptr - 1);
+            var ResultItemIds = at(stack + stackptr - 2);            
             var itemcount = GetPlayerSelectedTradeItems(out int[] itemIds, out int[] itemIndices);
             for (int s = 0; s<uimanager.NoOfTradeSlots; s++)
             {

--- a/src/conversation/conversation_functions/switch_pic.cs
+++ b/src/conversation/conversation_functions/switch_pic.cs
@@ -4,7 +4,7 @@ namespace Underworld
     {
         public static void switch_pic()
         {
-            var WhoAmI = at(at(stackptr - 1));
+            var WhoAmI = at(at(stack + stackptr - 1));
             uimanager.instance.NPCPortrait.Texture = NPCPortrait(WhoAmI, 0);
             var newname =GameStrings.GetString(7, WhoAmI + 16);
             if (newname!="")

--- a/src/conversation/conversation_functions/take_from_npc.cs
+++ b/src/conversation/conversation_functions/take_from_npc.cs
@@ -6,7 +6,7 @@ namespace Underworld
     {
         public static void take_from_npc(uwObject talker)
         {
-            var arg1 = GetConvoStackValueAtPtr(stackptr-1);
+            var arg1 = GetConvoStackValueAtPtr(stack + stackptr-1);
             Debug.Print($"take_from_npc({arg1})");
 
 

--- a/src/conversation/conversation_functions/take_from_npc_inv.cs
+++ b/src/conversation/conversation_functions/take_from_npc_inv.cs
@@ -7,7 +7,7 @@ namespace Underworld
         /// </summary>
         public static void take_from_npc_inv(uwObject talker)
         {
-            var di = GetConvoStackValueAtPtr(stackptr - 1);
+            var di = GetConvoStackValueAtPtr(stack + stackptr - 1);
             var si = 0;
             var next = talker.link;
             while (si<di)

--- a/src/conversation/conversation_functions/take_id_from_npc.cs
+++ b/src/conversation/conversation_functions/take_id_from_npc.cs
@@ -6,7 +6,7 @@ namespace Underworld
     {
         public static void take_id_from_npc(uwObject talker)
         {
-            var id = GetConvoStackValueAtPtr(stackptr-1);
+            var id = GetConvoStackValueAtPtr(stack + stackptr-1);
             Debug.Print($"Take ID {id}");
             var ObjectToGive = UWTileMap.current_tilemap.LevelObjects[id];
             if (playerdat.ObjectInHand  == -1)

--- a/src/conversation/conversation_functions/teleport_player.cs
+++ b/src/conversation/conversation_functions/teleport_player.cs
@@ -7,9 +7,9 @@ namespace Underworld
         public static void teleport_player()
         {
             DoTeleport = true;
-            TeleportToLevel = GetConvoStackValueAtPtr(stackptr-1);
-            TeleportTileY = GetConvoStackValueAtPtr(stackptr-2);
-            TeleportTileX = GetConvoStackValueAtPtr(stackptr-3);
+            TeleportToLevel = GetConvoStackValueAtPtr(stack + stackptr-1);
+            TeleportTileY = GetConvoStackValueAtPtr(stack + stackptr-2);
+            TeleportTileX = GetConvoStackValueAtPtr(stack + stackptr-3);
             Debug.Print($"Teleport Player to {TeleportToLevel},{TeleportTileX},{TeleportTileY}");          
         }
     }//end class

--- a/src/conversation/conversation_functions/teleport_talker.cs
+++ b/src/conversation/conversation_functions/teleport_talker.cs
@@ -6,8 +6,8 @@ namespace Underworld
     {
         public static void teleport_talker(uwObject talker)
         {
-            TeleportTileY = GetConvoStackValueAtPtr(stackptr-1);
-            TeleportTileX = GetConvoStackValueAtPtr(stackptr-2);
+            TeleportTileY = GetConvoStackValueAtPtr(stack + stackptr-1);
+            TeleportTileX = GetConvoStackValueAtPtr(stack + stackptr-2);
             Debug.Print($"Teleport Talker to {TeleportTileX},{TeleportTileY}");          
             npc.moveNPCToTile(talker, TeleportTileX, TeleportTileY);
         }

--- a/src/conversation/conversation_functions/transform_talker.cs
+++ b/src/conversation/conversation_functions/transform_talker.cs
@@ -7,10 +7,10 @@ namespace Underworld
         public static void transform_talker(uwObject talker)
         {
             Debug.Print("transform talker");
-            var ArgA = GetConvoStackValueAtPtr(stackptr - 1);
-            var newIsPowerful = GetConvoStackValueAtPtr(stackptr - 2);
-            var newWhoAMI = GetConvoStackValueAtPtr(stackptr - 3);
-            var newItemID = GetConvoStackValueAtPtr(stackptr - 4);
+            var ArgA = GetConvoStackValueAtPtr(stack + stackptr - 1);
+            var newIsPowerful = GetConvoStackValueAtPtr(stack + stackptr - 2);
+            var newWhoAMI = GetConvoStackValueAtPtr(stack + stackptr - 3);
+            var newItemID = GetConvoStackValueAtPtr(stack + stackptr - 4);
 
             var tile = UWTileMap.current_tilemap.Tiles[talker.npc_xhome, talker.npc_yhome];
 

--- a/src/conversation/conversation_functions/x_clock.cs
+++ b/src/conversation/conversation_functions/x_clock.cs
@@ -6,8 +6,8 @@ namespace Underworld
     {
         public static void x_clock()
         {
-            var xvalue = at(at(stackptr-1));
-            var xnumber = at(at(stackptr-2));            
+            var xvalue = at(at(stack + stackptr-1));
+            var xnumber = at(at(stack + stackptr-2));            
            
             if (xvalue>0x100)
             {                

--- a/src/conversation/conversation_functions/x_exp.cs
+++ b/src/conversation/conversation_functions/x_exp.cs
@@ -6,7 +6,7 @@ namespace Underworld
     {
         public static void x_exp()
         {
-            var newEXP = at(at(stackptr-1));
+            var newEXP = at(at(stack + stackptr-1));
             Debug.Print($"Untested x_exp({newEXP})");
             playerdat.ChangeExperience(newEXP);
             result_register = playerdat.Exp>>4;

--- a/src/conversation/conversation_functions/x_obj_pos.cs
+++ b/src/conversation/conversation_functions/x_obj_pos.cs
@@ -10,11 +10,11 @@ namespace Underworld
         public static void x_obj_pos()
         {
             Debug.Print("Untested x_obj_pos");
-            var X_var4 = at(stackptr - 3);
-            var Y_var8 = at(stackptr - 2);
-            var Z_var10 = at(stackptr - 1);
-            var objindex = at(at(stackptr - 5));
-            var mode = at(at(stackptr - 4));
+            var X_var4 = at(stack + stackptr - 3);
+            var Y_var8 = at(stack + stackptr - 2);
+            var Z_var10 = at(stack + stackptr - 1);
+            var objindex = at(at(stack + stackptr - 5));
+            var mode = at(at(stack + stackptr - 4));
 
             var obj = UWTileMap.current_tilemap.LevelObjects[objindex];
 

--- a/src/conversation/conversation_functions/x_obj_stuff.cs
+++ b/src/conversation/conversation_functions/x_obj_stuff.cs
@@ -7,15 +7,15 @@ namespace Underworld
         /// </summary>
         public static void x_obj_stuff()
         {
-            var identifyObject = at(at(stackptr-7));
-            var owner = at(at(stackptr-6));
-            var flags = at(at(stackptr-5));
-            var link = at(at(stackptr-4));
-            var flag1 = at(at(stackptr-3));
-            var flag0 = at(at(stackptr-2));
-            var quality = at(at(stackptr-1));
-            var objindex = at(at(stackptr-9));
-            var mode = at(at(stackptr-8));
+            var identifyObject = at(at(stack + stackptr-7));
+            var owner = at(at(stack + stackptr-6));
+            var flags = at(at(stack + stackptr-5));
+            var link = at(at(stack + stackptr-4));
+            var flag1 = at(at(stack + stackptr-3));
+            var flag0 = at(at(stack + stackptr-2));
+            var quality = at(at(stack + stackptr-1));
+            var objindex = at(at(stack + stackptr-9));
+            var mode = at(at(stack + stackptr-8));
 
             var obj = UWTileMap.current_tilemap.LevelObjects[objindex];
             if (obj!=null)
@@ -27,39 +27,39 @@ namespace Underworld
                     {
                         if (look.CanBeIdentified(obj))
                         {
-                            Set(at(stackptr-7), obj.heading); //update variable.
+                            Set(at(stack + stackptr-7), obj.heading); //update variable.
                         }
                     }
                     if (owner != -1)
                     {
-                        Set(at(stackptr-6), obj.owner);
+                        Set(at(stack + stackptr-6), obj.owner);
                     }
                     if (flags != -1)
                     {
-                        Set(at(stackptr-5), obj.flags_full);
+                        Set(at(stack + stackptr-5), obj.flags_full);
                     }
                     if (link!=-1)
                     {
                         if (_RES==GAME_UW2)
                         {
-                            Set(at(stackptr-4),obj.link);
+                            Set(at(stack + stackptr-4),obj.link);
                         }
                         else
                         {
-                            Set(at(stackptr-4),obj.link & 0x1FF);
+                            Set(at(stack + stackptr-4),obj.link & 0x1FF);
                         }                       
                     }
                     if (flag1!=-1)
                     {
-                        Set(at(stackptr-3), obj.flags1);
+                        Set(at(stack + stackptr-3), obj.flags1);
                     }
                     if (flag0!=-1)
                     {
-                        Set(at(stackptr-2), obj.flags0);
+                        Set(at(stack + stackptr-2), obj.flags0);
                     }
                     if (quality!=-1)
                     {
-                        Set(at(stackptr-1), obj.quality);
+                        Set(at(stack + stackptr-1), obj.quality);
                     }
                 }
                 else

--- a/src/conversation/conversation_functions/x_skills.cs
+++ b/src/conversation/conversation_functions/x_skills.cs
@@ -8,8 +8,8 @@ namespace Underworld
         {
             if (_RES!=GAME_UW2)
             {
-                var NewValue = at(at(stackptr-1));
-                var SkillNo = at(at(stackptr-2));
+                var NewValue = at(at(stack + stackptr-1));
+                var SkillNo = at(at(stack + stackptr-2));
                 Debug.Print($"x_skills {NewValue} {SkillNo}");
                 if (NewValue==10000)
                 {
@@ -29,8 +29,8 @@ namespace Underworld
             {
                 //uw2 version differs as it takes into account skillpoints
                 Debug.Print("UW2 Version of X_Skills");
-                var NewValue = at(at(stackptr-1));
-                var SkillNo = at(at(stackptr-2));
+                var NewValue = at(at(stack + stackptr-1));
+                var SkillNo = at(at(stack + stackptr-2));
                 Debug.Print($"x_skills {NewValue} {SkillNo}");
                 if (NewValue > 10000)
                 {

--- a/src/conversation/conversation_functions/x_traps.cs
+++ b/src/conversation/conversation_functions/x_traps.cs
@@ -6,10 +6,10 @@ namespace Underworld
     {
         public static void x_traps()
         {
-            Debug.Print($"X_traps {GetConvoStackValueAtPtr(stackptr-1)},{GetConvoStackValueAtPtr(stackptr-2)}");
+            Debug.Print($"X_traps {GetConvoStackValueAtPtr(stack + stackptr-1)},{GetConvoStackValueAtPtr(stack + stackptr-2)}");
 
-            var di_arg1 = GetConvoStackValueAtPtr(stackptr-2);
-            var si_arg0 = GetConvoStackValueAtPtr(stackptr-1);
+            var di_arg1 = GetConvoStackValueAtPtr(stack + stackptr-2);
+            var si_arg0 = GetConvoStackValueAtPtr(stack + stackptr-1);
 
             if ((si_arg0 >=0) && (di_arg1<0x3FF))
             {

--- a/src/conversation/conversationinitialisation.cs
+++ b/src/conversation/conversationinitialisation.cs
@@ -67,6 +67,7 @@ namespace Underworld
                     }
 
                     InitialiseConversationMemory();
+                    stack = currentConversation.NoOfMemorySlots;
 
                     ImportVariables(talker);
 

--- a/src/conversation/conversationio.cs
+++ b/src/conversation/conversationio.cs
@@ -24,14 +24,14 @@ namespace Underworld
             }
             else
             {
-                if (stringno>=512)
+                if (stringno >= 512)
                 {//get string by direct full reference
                     return GameStrings.GetString(stringno);
                 }
                 else
                 {
                     return GameStrings.GetString(currentConversation.StringBlock, stringno);
-                }                
+                }
             }
         }
 
@@ -53,9 +53,9 @@ namespace Underworld
             //I: value is an integer value
             //<num>: decimal value
             //<extension>: format: C<number>: use array index <number-1> offset from the initial source value.
-            
+
             //Remove \\1 and \\0 which wraps the reprinting of player typed input in conversations.
-            input=input.Replace("\\1","").Replace("\\0","");
+            input = input.Replace("\\1", "").Replace("\\0", "");
 
             if (!input.Contains("@"))
             {
@@ -65,7 +65,7 @@ namespace Underworld
 
             Debug.Print($"Doing string replacement on line {input}");
             MatchCollection matches = Regex.Matches(input, RegExForFindingReplacements);
-            
+
             for (int sm = 0; sm < matches.Count; sm++)
             {
                 string ReplacementString = matches[sm].Value;
@@ -108,13 +108,13 @@ namespace Underworld
                                         {
                                             if (SIOffset)
                                             {
-                                                OffsetValue = at(basep+ val) -1;
+                                                OffsetValue = at(stack + basep + val) - 1;
                                             }
                                             else
                                             {
                                                 OffsetValue = val;
                                             }
-                                            
+
                                         }
                                         else
                                         {
@@ -142,7 +142,7 @@ namespace Underworld
                         case "@GS": //Global string.
                             {
                                 //FoundString = GameStrings.GetString(0x125, at(ReplacementValue)); //getString(at(ReplacementValue));
-                                FoundString = getString(at(ReplacementValue+OffsetValue));
+                                FoundString = getString(at(ReplacementValue + OffsetValue));
                                 break;
                             }
                         case "@GI": //Global integer
@@ -155,35 +155,35 @@ namespace Underworld
                             {
                                 if (OffsetValue != 0)
                                 {
-                                    int actualptr = at(basep + OffsetValue);
+                                    int actualptr = at(stack + basep + OffsetValue);
                                     FoundString = getString(at(basep + actualptr));
                                 }
                                 else
                                 {
-                                    FoundString = getString(at(basep + ReplacementValue));
+                                    FoundString = getString(at(stack + basep + ReplacementValue));
                                 }
                                 break;
                             }
                         case "@SI": //Stack integer
                             {
-                                FoundString = at(basep + ReplacementValue + ArrayOffset).ToString();
+                                FoundString = at(stack + basep + ReplacementValue + ArrayOffset).ToString();
                                 break;
                             }
 
                         case "@PS": //Pointer string
                             {
-                                FoundString = getString(at(at(basep + ReplacementValue)));
+                                FoundString = getString(at(at(stack + basep + ReplacementValue)));
                                 break;
                             }
                         case "@PI": //Pointer integer
                             {
                                 if (ReplacementValue < 0)
                                 {
-                                    FoundString = at(at(basep + ReplacementValue)).ToString();//was basp+replacement-1. If I have to change again this may need deeper investigation of ConvoVM memory management
+                                    FoundString = at(at(stack + basep + ReplacementValue)).ToString();//was basp+replacement-1. If I have to change again this may need deeper investigation of ConvoVM memory management
                                 }
                                 else
                                 {
-                                    FoundString = at(at(basep + ReplacementValue)).ToString();
+                                    FoundString = at(at(stack + basep + ReplacementValue)).ToString();
                                 }
                                 break;
                             }

--- a/src/conversation/conversationstack.cs
+++ b/src/conversation/conversationstack.cs
@@ -13,9 +13,15 @@ namespace Underworld
         public static short[] StackValues;
 
         /// <summary>
-        /// The stack pointer
+        /// The stack pointer, relative to the stack index
         /// </summary>
         public static int stackptr = 0;
+
+
+        /// <summary>
+        /// The stack, reletive to the conversationmemory + no of memory slots
+        /// </summary>
+        public static int stack = 0;
 
         /// <summary>
         /// The top value in the stack.
@@ -38,7 +44,7 @@ namespace Underworld
         /// </summary>
         public static short Pop()
         {  
-            var popvalue = StackValues[stackptr];
+            var popvalue = StackValues[stack + stackptr];
             //Debug.Print($"Pop {popvalue} from {stackptr}");
             stackptr--;            
             return popvalue;
@@ -52,7 +58,7 @@ namespace Underworld
         public static void Push(short newValue)
         {
             stackptr++;
-            StackValues[stackptr] = newValue;
+            StackValues[stack + stackptr] = newValue;
             //Debug.Print($"Push {newValue} to {stackptr}");
         }
 

--- a/src/conversation/conversationvm.cs
+++ b/src/conversation/conversationvm.cs
@@ -29,8 +29,19 @@ namespace Underworld
 		/// <summary>
 		/// The base pointer
 		/// </summary>
-		public static int basep = 0;
+		public static int basep
+		{
+			get
+			{
+				return _bp;
+			}
+			set
+			{
+				_bp = value;
+			}
+		}
 
+		static int _bp=0;
 
 		//To handle teleportation requests for the player
 		static bool DoTeleport = false;
@@ -40,11 +51,16 @@ namespace Underworld
 
 		public static IEnumerator RunConversationVM(uwObject talker)
 		{
-			bool testing = false;
+			bool testing = true;
 			bool finished = false;
+			stackptr = 0;
 
 			while (!finished)
 			{
+				if (testing && ((instrp == 1768) || (instrp==1493)))
+				{
+					Debug.Print("HREE");
+				}
 				switch (currentConversation.instuctions[instrp])
 				{
 					case cnv_NOP:
@@ -85,7 +101,7 @@ namespace Underworld
 
 					case cnv_OPDIV:
 						{
-							if (at(stackptr) == 0)
+							if (at(stack + stackptr) == 0)
 							{
 								Debug.Print($"Divide by Zero Error at OPDIV {instrp}");
 								Push(0x7FFF);
@@ -363,7 +379,7 @@ namespace Underworld
 
 					case cnv_PUSHI_EFF:
 						{
-							if (testing) { Debug.Print($"{instrp}:PUSHI_EFF {basep + currentConversation.instuctions[instrp + 1]}"); }
+							if (testing) { Debug.Print($"{instrp}:PUSHI_EFF {currentConversation.NoOfMemorySlots + basep + currentConversation.instuctions[instrp + 1]}"); }
 							Push(currentConversation.NoOfMemorySlots + basep + currentConversation.instuctions[instrp + 1]);
 							instrp++;
 							break;
@@ -391,25 +407,26 @@ namespace Underworld
 						{
 							//Debug.Print("Instruction:" + instrp +" Pushing Base Ptr :" + basep + " => " + stackptr);	
 							if (testing) { Debug.Print($"{instrp}:PUSHBP {basep}"); }
-							Push(basep);
+							stackptr++;
+							Set(stack + stackptr, basep);
 							break;
 						}
 
 
 					case cnv_POPBP:
 						{
-							if (stackptr < 0)
-							{
-								Debug.Print($"{instrp} StackPtr is {stackptr}. Possible UW1 bug in some conversations. Exiting conversation!");
-								finished = true;
-							}
-							else
-							{
+							// if (stackptr < 0)
+							// {
+							// 	Debug.Print($"{instrp} StackPtr is {stackptr}. Possible UW1 bug in some conversations. Exiting conversation!");
+							// 	finished = true;
+							// }
+							// else
+							// {
 								//Debug.Print("Instruction:" + instrp +" Popping Base Ptr :" + basep + " => " + stackptr);	
 								int arg1 = Pop();
 								if (testing) { Debug.Print($"{instrp}:POPBP {arg1}"); }
 								basep = arg1;
-							}
+							//}
 							break;
 						}
 
@@ -426,21 +443,22 @@ namespace Underworld
 						{
 							//Debug.Print("Instruction:" + instrp +" Setting Stack Ptr to BaseP :" + basep + " => " + stackptr);
 							if (testing) { Debug.Print($"{instrp}:BPTOSP {basep}"); }
-							set_stackp(basep);
+							stackptr = basep;
+							//set_stackp(basep);
 							break;
 						}
 
 
 					case cnv_ADDSP:
 						{
-							int arg1 = at(stackptr);
+							int arg1 = at(stack + stackptr);
 
 							if (testing) { Debug.Print($"{instrp}:ADDSP {arg1}"); }
 							/// fill reserved stack space with dummy values
 							//for (int i = 0; i <= arg1; i++)
 							//	Push(0);
 
-							set_stackp(stackptr + arg1 - 1);
+							stackptr = stackptr + arg1 - 1;
 
 							break;
 						}
@@ -448,26 +466,34 @@ namespace Underworld
 
 					case cnv_FETCHM:
 						{
-							var address = Pop();
-							var arg1 = at(address);
-							// var varname = GetVariableNameAtAddress(address);
-							// if (varname!="")
-							// {
-							// 	Debug.Print ($"Fetching {varname} with value {arg1}");
-							// }
-							if (testing) { Debug.Print($"{instrp}:FETCHM {arg1}"); }
-							Push(arg1);
+							var address = at(stack + stackptr);
+							var value = at(address);
+							if (testing) { Debug.Print($"{instrp}:FETCHM {address} with value {value}"); }
+							Set(stack + stackptr, value);
+							// var address = Pop();
+							// var arg1 = at(address);
+							// // var varname = GetVariableNameAtAddress(address);
+							// // if (varname!="")
+							// // {
+							// // 	Debug.Print ($"Fetching {varname} with value {arg1}");
+							// // }
+							// if (testing) { Debug.Print($"{instrp}:FETCHM {arg1}"); }
+							// Push(arg1);
 							break;
 						}
 
 
 					case cnv_STO:
 						{
-							int value = Pop();
-							int index = Pop();
-							if (testing) { Debug.Print($"{instrp}:STO {index} {value}"); }
-							Set(index, value);
-
+							var value = at(stack + stackptr);
+							var address = at(stack + stackptr - 1);
+							Set(address, value);
+							if (testing) { Debug.Print($"{instrp}:STO {value} at {address}"); }
+							stackptr -= 2;
+							// int value = Pop();
+							// int index = Pop();
+							// if (testing) { Debug.Print($"{instrp}:STO {index} {value}"); }
+							// Set(index, value);
 							break;
 						}
 
@@ -475,12 +501,12 @@ namespace Underworld
 					case cnv_OFFSET:
 						{
 							//int arg1 = Pop();
-							int arg1 = at(stackptr);
-							int arg2 = at(stackptr - 1);//Pop();
+							int arg1 = at(stack + stackptr);
+							int arg2 = at(stack + stackptr - 1);//Pop();
 							stackptr--;
 							if (testing) { Debug.Print($"{instrp}:Offset {arg1} {arg2}"); }
 							arg1 += arg2 - 1;  //why -1
-							Set(stackptr, arg1);
+							Set(stack + stackptr, arg1);
 							//Push(arg1);
 							break;
 						}
@@ -675,7 +701,7 @@ namespace Underworld
 		private static void InitialiseConversationMemory()
 		{
 			StackValues = new short[4096];
-			stackptr = 200;  //vanilla behaviour this should be at offset NoOfImportedVariables of the conversation memory
+			stackptr = 0;  //vanilla behaviour this should be at offset NoOfImportedVariables of the conversation memory
 			result_register = 0;
 			instrp = 0;
 			call_level = 1;

--- a/src/conversation/conversationvm.cs
+++ b/src/conversation/conversationvm.cs
@@ -57,10 +57,10 @@ namespace Underworld
 
 			while (!finished)
 			{
-				if (testing && ((instrp == 1768) || (instrp==1493)))
-				{
-					Debug.Print("HREE");
-				}
+				// if (testing && ((instrp == 1768) || (instrp==1493)))
+				// {
+				// 	Debug.Print("Uncomment here to test specific instructions.");
+				// }
 				switch (currentConversation.instuctions[instrp])
 				{
 					case cnv_NOP:


### PR DESCRIPTION
Fixes conversationvm so that issues with retrieving function param values at addresses lower than the base pointer (baseptr -2 etc) is resolved. Main change is that baseptr and stackptr now start at the end of the imported variables and that stackptr values are relative to the stack and not the overall memory space of the vm.