### PR TITLE
Fix/eat plants with use

### DIFF
--- a/src/interaction/use.cs
+++ b/src/interaction/use.cs
@@ -162,6 +162,13 @@ namespace Underworld
             {
                 result = true;//supress messaging.
             }
+            if (!result && !WorldObject
+                && Food.IsFood(ObjectUsed)
+                && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
+                && Food.SpecialFoodCases(ObjectUsed, true))
+            {
+                result = true;
+            }
             if ((!result) && (!UsedFromCollision))
             {
                 uimanager.AddToMessageScroll(GameStrings.GetString(1, GameStrings.str_you_cannot_use_that_));
@@ -407,7 +414,7 @@ namespace Underworld
                             switch (ObjectUsed.classindex)
                             {
                                 case 4://dream plant
-                                    return Food.SpecialFoodCases(ObjectUsed, WorldObject);
+                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
                                 case >= 8 and <= 0xF:
                                     return smallblackrockgem.Use(ObjectUsed, WorldObject);
                             }

--- a/src/interaction/use.cs
+++ b/src/interaction/use.cs
@@ -162,9 +162,10 @@ namespace Underworld
             {
                 result = true;//supress messaging.
             }
-            if (!result && Food.IsFood(ObjectUsed)
+            if (!result && !WorldObject
+                && Food.IsFood(ObjectUsed)
                 && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
-                && Food.SpecialFoodCases(ObjectUsed, !WorldObject))
+                && Food.SpecialFoodCases(ObjectUsed, true))
             {
                 result = true;
             }
@@ -285,7 +286,9 @@ namespace Underworld
                                     return key_of_infinity.Use(ObjectUsed, WorldObject);
                                 case 0xE://plant (0xCE)
                                 case 0xF://plant (0xCF)
-                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
+                                    if (WorldObject)
+                                        return false;
+                                    return Food.SpecialFoodCases(ObjectUsed, true);
                             }
                         }
                         else
@@ -294,7 +297,9 @@ namespace Underworld
                             {
                                 case 0xE://thorny flower (0xCE)
                                 case 0xF://plant (0xCF)
-                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
+                                    if (WorldObject)
+                                        return false;
+                                    return Food.SpecialFoodCases(ObjectUsed, true);
                                 case > 0 and <= 7://a range of potions.
                                     return potion.Use(ObjectUsed, WorldObject);
                             }
@@ -419,7 +424,9 @@ namespace Underworld
                             switch (ObjectUsed.classindex)
                             {
                                 case 4://dream plant
-                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
+                                    if (WorldObject)
+                                        return false;
+                                    return Food.SpecialFoodCases(ObjectUsed, true);
                                 case >= 8 and <= 0xF:
                                     return smallblackrockgem.Use(ObjectUsed, WorldObject);
                             }

--- a/src/interaction/use.cs
+++ b/src/interaction/use.cs
@@ -162,7 +162,11 @@ namespace Underworld
             {
                 result = true;//supress messaging.
             }
-            if (!result && !WorldObject
+            if (!result && WorldObject && Food.IsFood(ObjectUsed))
+            {
+                result = true;
+            }
+            else if (!result && !WorldObject
                 && Food.IsFood(ObjectUsed)
                 && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
                 && Food.SpecialFoodCases(ObjectUsed, true))
@@ -287,7 +291,7 @@ namespace Underworld
                                 case 0xE://plant (0xCE)
                                 case 0xF://plant (0xCF)
                                     if (WorldObject)
-                                        return false;
+                                        return true;
                                     return Food.SpecialFoodCases(ObjectUsed, true);
                             }
                         }
@@ -298,7 +302,7 @@ namespace Underworld
                                 case 0xE://thorny flower (0xCE)
                                 case 0xF://plant (0xCF)
                                     if (WorldObject)
-                                        return false;
+                                        return true;
                                     return Food.SpecialFoodCases(ObjectUsed, true);
                                 case > 0 and <= 7://a range of potions.
                                     return potion.Use(ObjectUsed, WorldObject);
@@ -425,7 +429,7 @@ namespace Underworld
                             {
                                 case 4://dream plant
                                     if (WorldObject)
-                                        return false;
+                                        return true;
                                     return Food.SpecialFoodCases(ObjectUsed, true);
                                 case >= 8 and <= 0xF:
                                     return smallblackrockgem.Use(ObjectUsed, WorldObject);

--- a/src/interaction/use.cs
+++ b/src/interaction/use.cs
@@ -162,10 +162,9 @@ namespace Underworld
             {
                 result = true;//supress messaging.
             }
-            if (!result && !WorldObject
-                && Food.IsFood(ObjectUsed)
+            if (!result && Food.IsFood(ObjectUsed)
                 && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
-                && Food.SpecialFoodCases(ObjectUsed, true))
+                && Food.SpecialFoodCases(ObjectUsed, !WorldObject))
             {
                 result = true;
             }
@@ -284,12 +283,18 @@ namespace Underworld
                             {
                                 case 7://key of infinity
                                     return key_of_infinity.Use(ObjectUsed, WorldObject);
+                                case 0xE://plant (0xCE)
+                                case 0xF://plant (0xCF)
+                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
                             }
                         }
                         else
                         {
                             switch (ObjectUsed.classindex)
                             {
+                                case 0xE://thorny flower (0xCE)
+                                case 0xF://plant (0xCF)
+                                    return Food.SpecialFoodCases(ObjectUsed, !WorldObject);
                                 case > 0 and <= 7://a range of potions.
                                     return potion.Use(ObjectUsed, WorldObject);
                             }

--- a/src/interaction/use.cs
+++ b/src/interaction/use.cs
@@ -162,17 +162,17 @@ namespace Underworld
             {
                 result = true;//supress messaging.
             }
-            if (!result && WorldObject && Food.IsFood(ObjectUsed))
-            {
-                result = true;
-            }
-            else if (!result && !WorldObject
-                && Food.IsFood(ObjectUsed)
-                && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
-                && Food.SpecialFoodCases(ObjectUsed, true))
-            {
-                result = true;
-            }
+            // if (!result && WorldObject && Food.IsFood(ObjectUsed))
+            // {
+            //     result = true;
+            // }
+            // else if (!result && !WorldObject
+            //     && Food.IsFood(ObjectUsed)
+            //     && (ObjectUsed.majorclass != 2 || ObjectUsed.minorclass != 3)
+            //     && Food.SpecialFoodCases(ObjectUsed, true))
+            // {
+            //     result = true;
+            // }
             if ((!result) && (!UsedFromCollision))
             {
                 uimanager.AddToMessageScroll(GameStrings.GetString(1, GameStrings.str_you_cannot_use_that_));

--- a/src/objects/food.cs
+++ b/src/objects/food.cs
@@ -7,6 +7,8 @@ namespace Underworld
     {
         public static bool Use(uwObject obj, bool WorldObject)
         {
+            if (WorldObject)
+                return true;
             Debug.Print($"a wood weighs {commonObjDat.mass(0xCC)} a torch weighs {commonObjDat.mass(0x91)}");
             if (_RES == GAME_UW2)
             {

--- a/src/objects/food.cs
+++ b/src/objects/food.cs
@@ -7,9 +7,15 @@ namespace Underworld
     {
         public static bool Use(uwObject obj, bool WorldObject)
         {
-            if (WorldObject)
-                return true;
-            Debug.Print($"a wood weighs {commonObjDat.mass(0xCC)} a torch weighs {commonObjDat.mass(0x91)}");
+            //Ordinarily food cannot be used from the world except when dropped on the player head.
+            //when dropping food on the player head the object will be a WorldObject. 
+            //This checks that the object being used is the object in the player hand. 
+            // Fixes issue where dropping food was not working because original check was for world object only
+            if ((WorldObject) && (obj.index != playerdat.ObjectInHand))  
+            {
+                return true; // suppress any do not use message.
+            }
+
             if (_RES == GAME_UW2)
             {
                 switch (obj.classindex)

--- a/src/ui/uimanager_views.cs
+++ b/src/ui/uimanager_views.cs
@@ -268,9 +268,9 @@ namespace Underworld
                     {
                         LookAtTile(pixel.R8, tileX, tileY);//there needs to be a distance check to see if the player sees something or nothing. I think it should be based on the shading.
                     }
-                    else
+                    else if (InteractionMode == InteractionModes.ModeUse)
                     {
-                        //do nothing.
+                        uimanager.AddToMessageScroll(GameStrings.GetString(1, GameStrings.str_you_cannot_use_that_));
                     }
                 }
             }


### PR DESCRIPTION
Plants were edible if dragging to paperdoll mouth, but not by using directly.  Also, DOS displays you cannot use that message when clicking on floor, ceiling, etc, but nothing when trying to eat food from the ground.  Aligning all this with DOS behavior.

There is a plant very near to UW1 spawn to test.