### PR TITLE
Align inventory mouse controls with DOS UW1/UW2

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -751,15 +751,15 @@ public partial class main : Node3D
 						case Key.F1: //open options menu
 							uimanager.InteractionModeToggle(0); break;
 						case Key.F2: //talk
-							uimanager.InteractionModeToggle((uimanager.InteractionModes)1); break;
+							uimanager.InteractionModeButtonPressed((uimanager.InteractionModes)1); break;
 						case Key.F3://pickup
-							uimanager.InteractionModeToggle((uimanager.InteractionModes)2); break;
+							uimanager.InteractionModeButtonPressed((uimanager.InteractionModes)2); break;
 						case Key.F4://look
-							uimanager.InteractionModeToggle((uimanager.InteractionModes)3); break;
+							uimanager.InteractionModeButtonPressed((uimanager.InteractionModes)3); break;
 						case Key.F5://attack
-							uimanager.InteractionModeToggle((uimanager.InteractionModes)4); break;
+							uimanager.InteractionModeButtonPressed((uimanager.InteractionModes)4); break;
 						case Key.F6://use
-							uimanager.InteractionModeToggle((uimanager.InteractionModes)5); break;
+							uimanager.InteractionModeButtonPressed((uimanager.InteractionModes)5); break;
 						case Key.F7://toggle panel
 							if (keyinput.AltPressed)
 							{

--- a/src/ui/uimanager_interaction.cs
+++ b/src/ui/uimanager_interaction.cs
@@ -33,6 +33,7 @@ namespace Underworld
 
         public enum InteractionModes
         {
+            ModeNone = -1,
             ModeOptions = 0,
             ModeTalk = 1,
             ModePickup = 2,
@@ -271,11 +272,49 @@ namespace Underworld
         }
 
         /// <summary>
+        /// DOS "no mode": no interaction button selected. Inventory uses L=Use, R=Look.
+        /// </summary>
+        public static void EnterInteractionModeNone()
+        {
+            PreviousInteractionMode = InteractionMode;
+            InteractionMode = InteractionModes.ModeNone;
+            SetAllInteractionButtonsOff();
+            if (playerdat.play_drawn == 1)
+            {
+                ToggleWeaponAnimationState(false);
+            }
+        }
+
+        static void SetAllInteractionButtonsOff()
+        {
+            if (UWClass._RES == UWClass.GAME_UW2)
+            {
+                for (int i = 0; i <= instance.InteractionButtonsUW2.GetUpperBound(0); i++)
+                {
+                    instance.InteractionButtonsUW2[i].Texture = instance.UW2InteractionBtnsOff[i];
+                }
+            }
+            else
+            {
+                for (int i = 0; i <= instance.InteractionButtonsUW1.GetUpperBound(0); i++)
+                {
+                    instance.InteractionButtonsUW1[i].Texture = grLfti.LoadImageAt(i * 2, false);
+                }
+            }
+        }
+
+        /// <summary>
         /// Sets the on button for the interaction buttons to the specified index.
         /// </summary>
         /// <param name="index"></param>
         private static void ToggleInteractionButtonDisplay(InteractionModes index)
         {
+            if (index == InteractionModes.ModeNone)
+            {
+                EnterInteractionModeNone();
+                return;
+            }
+
             if (UWClass._RES == UWClass.GAME_UW2)
             {
                 for (int i = 0; i <= instance.InteractionButtonsUW2.GetUpperBound(0); i++)
@@ -369,6 +408,26 @@ namespace Underworld
         }
 
 
+        /// <summary>
+        /// User clicked a mode button / pressed F2-F6. Re-clicking the active mode
+        /// (except Options) enters no-mode. Attack also sheaths if drawn.
+        /// </summary>
+        public static void InteractionModeButtonPressed(InteractionModes index)
+        {
+            if (index == InteractionMode
+                && index != InteractionModes.ModeOptions
+                && index != InteractionModes.ModeNone)
+            {
+                if (index == InteractionModes.ModeAttack && playerdat.play_drawn == 1)
+                {
+                    ToggleWeaponAnimationState(false);
+                }
+                EnterInteractionModeNone();
+                return;
+            }
+            InteractionModeToggle(index);
+        }
+
         private void _on_interactionoptions_button(InputEvent @event, long extra_arg_0)
         {
             if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
@@ -389,7 +448,7 @@ namespace Underworld
                     {
                         return;
                     }
-                    InteractionModeToggle((InteractionModes)extra_arg_0);
+                    InteractionModeButtonPressed((InteractionModes)extra_arg_0);
                 }
             }
         }

--- a/src/ui/uimanager_inventory.cs
+++ b/src/ui/uimanager_inventory.cs
@@ -105,6 +105,27 @@ namespace Underworld
             {
                 return;
             }
+            switch (inventoryPressSlotName)
+            {
+                case "RightShoulder":
+                case "LeftShoulder":
+                case "RightHand":
+                case "LeftHand":
+                    if (obj.index != OpenedContainerIndex && OpenedContainerIndex != -1)
+                    {
+                        var match = objectsearch.FindMatchInObjectChain(
+                            ListHeadIndex: obj.index,
+                            itemIndex: OpenedContainerIndex,
+                            objList: playerdat.InventoryObjects,
+                            SkipNext: true);
+                        if (match != null)
+                        {
+                            Debug.Print("attempt to pickup container while it or sub-object is opened");
+                            return;
+                        }
+                    }
+                    break;
+            }
             if (obj.index == OpenedContainerIndex)
             {
                 return; // don't drag the container currently being viewed

--- a/src/ui/uimanager_inventory.cs
+++ b/src/ui/uimanager_inventory.cs
@@ -105,6 +105,16 @@ namespace Underworld
             {
                 return;
             }
+            if (InConversation && obj.majorclass == 2 && obj.minorclass == 0 && obj.classindex != 0xF)
+            {
+                AddToMessageScroll(
+                    stringToAdd: GameStrings.GetString(
+                        1,
+                        GameStrings.str_you_cannot_barter_a_container__instead_remove_the_contents_you_want_to_trade_),
+                    option: 2,
+                    mode: MessageDisplay.MessageDisplayMode.TemporaryMessage);
+                return;
+            }
             switch (inventoryPressSlotName)
             {
                 case "RightShoulder":
@@ -423,12 +433,6 @@ namespace Underworld
                 container.Close(
                     index: objAtSlot.index,
                     objList: playerdat.InventoryObjects);
-                return;
-            }
-
-            if (InConversation)
-            {
-                InteractWithObjectInSlotConversation(objAtSlot, isLeftClick);
                 return;
             }
 

--- a/src/ui/uimanager_inventory.cs
+++ b/src/ui/uimanager_inventory.cs
@@ -17,17 +17,204 @@ namespace Underworld
         /// </summary>
         public static int OpenedContainerIndex = -1;
 
+        // Inventory pointer / drag state (DOS paperdoll drag-and-drop).
+        static bool inventoryPointerDown;
+        static bool inventoryDragActive;
+        static MouseButton inventoryPointerButton;
+        static string inventoryPressSlotName;
+        static Vector2 inventoryPressPos;
+        static int inventoryPressObjIndex;
+        static int inventoryPressSlotId;
+        const float InventoryDragThresholdPx = 5f;
+
+        /// <summary>
+        /// UW1: left or right drag. UW2: right drag only (left drag does nothing).
+        /// </summary>
+        static bool CanInventoryDrag(MouseButton button)
+        {
+            if (button == MouseButton.Right)
+            {
+                return true;
+            }
+            if (button == MouseButton.Left)
+            {
+                return UWClass._RES != UWClass.GAME_UW2;
+            }
+            return false;
+        }
+
+        static void ClearInventoryPointerState()
+        {
+            inventoryPointerDown = false;
+            inventoryDragActive = false;
+            inventoryPressSlotName = null;
+            inventoryPressObjIndex = -1;
+            inventoryPressSlotId = -1;
+        }
+
+        static void BeginInventoryPointerDown(string slotname, MouseButton button, Vector2 position)
+        {
+            inventoryPointerDown = true;
+            inventoryDragActive = false;
+            inventoryPointerButton = button;
+            inventoryPressSlotName = slotname;
+            inventoryPressPos = position;
+            inventoryPressObjIndex = GetObjAtSlot(slotname);
+            inventoryPressSlotId = CurrentSlot;
+        }
+
+        /// <summary>
+        /// After moving past the drag threshold, mark the gesture as a drag.
+        /// Pickup only happens when the button is allowed to drag (UW1 L/R, UW2 R).
+        /// UW2 left-drag is therefore a no-op (not a click).
+        /// </summary>
+        static void TryStartInventoryDrag(Vector2 position)
+        {
+            if (!inventoryPointerDown || inventoryDragActive)
+            {
+                return;
+            }
+            if (inventoryPressPos.DistanceTo(position) < InventoryDragThresholdPx)
+            {
+                return;
+            }
+
+            inventoryDragActive = true;
+
+            if (!CanInventoryDrag(inventoryPointerButton))
+            {
+                return;
+            }
+
+            // Already holding something (e.g. from world Get): just mark drag for place-on-release.
+            if (playerdat.ObjectInHand != -1)
+            {
+                return;
+            }
+            if (inventoryPressObjIndex <= 0)
+            {
+                return;
+            }
+            if (inventoryPressSlotName == "OpenedContainer")
+            {
+                return;
+            }
+
+            var obj = playerdat.InventoryObjects[inventoryPressObjIndex];
+            if (obj == null)
+            {
+                return;
+            }
+            if (obj.index == OpenedContainerIndex)
+            {
+                return; // don't drag the container currently being viewed
+            }
+
+            CurrentSlot = inventoryPressSlotId;
+            PickupObjectFromSlot(obj);
+        }
+
+        static void PlaceHeldItemAtSlot(string slotname)
+        {
+            GetObjAtSlot(slotname); // sets CurrentSlot
+            if (CurrentSlot == 0 && playerdat.ObjectInHand != 1 && TryEatInteraction())
+            {
+                return;
+            }
+
+            if (slotname == "OpenedContainer")
+            {
+                MoveObjectInHandOutOfOpenedContainer(playerdat.ObjectInHand);
+                return;
+            }
+
+            var objIndex = GetObjAtSlot(slotname);
+            if (objIndex > 0)
+            {
+                UseObjectsTogether(playerdat.ObjectInHand, objIndex);
+            }
+            else
+            {
+                PickupToEmptySlot(playerdat.ObjectInHand);
+            }
+        }
+
+        static void DropHeldItemIntoWorld()
+        {
+            if (playerdat.ObjectInHand == -1)
+            {
+                return;
+            }
+            // Drop vs throw uses these positions in motion.InitPlayerProjectileValues().
+            // Mirror ClickOnViewPort so release height/heading match the cursor.
+            var mouse = instance.GetViewport().GetMousePosition();
+            ViewPortMouseXPos = mouse.X;
+            ViewPortMouseYPos = mouse.Y;
+
+            var objToThrow = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
+            var itemid = objToThrow.item_id;
+            if (pickup.DropObjectByPlayer(objToThrow, true))
+            {
+                playerdat.ObjectInHand = -1;
+                instance.mousecursor.SetCursorToCursor();
+                pickup.DropSpecialCases(itemid);
+            }
+        }
+
+        /// <summary>
+        /// Slot under the cursor for drag-drop. Release events often arrive on the
+        /// press control, so placement must not trust that control's bind name.
+        /// </summary>
+        static string FindInventorySlotUnderMouse()
+        {
+            if (instance == null)
+            {
+                return null;
+            }
+            var mouse = instance.GetViewport().GetMousePosition();
+
+            // Overlapping input hitboxes first, then visible art.
+            if (ControlContainsMouse(instance.ArmourInput, mouse)) return "Armour";
+            if (ControlContainsMouse(instance.LeggingsInput, mouse)) return "Leggings";
+            if (ControlContainsMouse(instance.GlovesInput1, mouse)
+                || ControlContainsMouse(instance.GlovesInput2, mouse)) return "Gloves";
+            if (ControlContainsMouse(instance.RightRingInput, mouse)) return "RightRing";
+            if (ControlContainsMouse(instance.LeftRingInput, mouse)) return "LeftRing";
+
+            if (ControlContainsMouse(instance.Helm, mouse)) return "Helm";
+            if (ControlContainsMouse(instance.Boots, mouse)) return "Boots";
+            if (ControlContainsMouse(instance.RightShoulder, mouse)) return "RightShoulder";
+            if (ControlContainsMouse(instance.LeftShoulder, mouse)) return "LeftShoulder";
+            if (ControlContainsMouse(instance.RightHand, mouse)) return "RightHand";
+            if (ControlContainsMouse(instance.LeftHand, mouse)) return "LeftHand";
+            if (ControlContainsMouse(instance.OpenedContainer, mouse)) return "OpenedContainer";
+
+            if (instance.Backpack != null)
+            {
+                for (int i = 0; i < instance.Backpack.Length; i++)
+                {
+                    if (ControlContainsMouse(instance.Backpack[i], mouse))
+                    {
+                        return $"Back{i}";
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        static bool ControlContainsMouse(Control control, Vector2 mouse)
+        {
+            return control != null
+                && control.IsVisibleInTree()
+                && control.GetGlobalRect().HasPoint(mouse);
+        }
+
         private static void InteractWithEmptySlot()
         {
-            //there is no object in the slot.
-            switch (InteractionMode)
+            if (playerdat.ObjectInHand != -1)
             {
-                case InteractionModes.ModePickup:
-                case InteractionModes.ModeTalk:
-                    {
-                        PickupToEmptySlot(playerdat.ObjectInHand);
-                        break;
-                    }
+                PickupToEmptySlot(playerdat.ObjectInHand);
             }
         }
 
@@ -190,246 +377,134 @@ namespace Underworld
 
 
         /// <summary>
-        /// 
+        /// Empty-handed inventory click (no drag). Matches DOS: action on release.
+        /// Use = L/R Use; Look UW1 = L Use/R Look, UW2 = L/R Look;
+        /// other modes = L Use, R Look.
+        /// Does not change interaction mode.
         /// </summary>
-        /// <param name="slotname"></param>
-        /// <param name="objAtSlot"></param>
-        /// <param name="isLeftClick"></param>
         private static void InteractWithObjectInSlot(string slotname, uwObject objAtSlot, bool isLeftClick)
         {
             if ((MessageDisplay.WaitingForTypedInput) || (MessageDisplay.WaitingForYesOrNo))
-            {//stop while typing in progress
+            {
                 return;
             }
-            if (InteractionMode == InteractionModes.ModeAttack)
+            // Block inventory only during an active combat swing (weapon drawn, not Ready).
+            // Sheathed / no-mode must still allow Use/Look clicks.
+            if (InteractionMode == InteractionModes.ModeAttack
+                && playerdat.play_drawn == 1
+                && combat.stage != combat.CombatStages.Ready)
             {
-                if (combat.stage != combat.CombatStages.Ready)
-                {
-                    return;
-                }
+                return;
             }
 
-            if (CurrentSlot == 0) //HELM
+            if (slotname == "OpenedContainer")
             {
-                //try the eat interation.
-                if (playerdat.ObjectInHand != 1)
-                {
-                    if (TryEatInteraction())
-                    {
-                        return; //food has been consumed. exit function.
-                    }
-                }
+                container.Close(
+                    index: objAtSlot.index,
+                    objList: playerdat.InventoryObjects);
+                return;
             }
 
+            if (InConversation)
+            {
+                InteractWithObjectInSlotConversation(objAtSlot, isLeftClick);
+                return;
+            }
+
+            if (ShouldUseInventoryObjectOnClick(isLeftClick))
+            {
+                UseInventoryObject(objAtSlot);
+            }
+            else
+            {
+                look.LookAt(objAtSlot.index, playerdat.InventoryObjects, false);
+            }
+        }
+
+        /// <summary>
+        /// Empty-handed inventory click: whether this button Uses (vs Looks).
+        /// </summary>
+        static bool ShouldUseInventoryObjectOnClick(bool isLeftClick)
+        {
             switch (InteractionMode)
             {
-                case InteractionModes.ModeAttack:
                 case InteractionModes.ModeUse:
-                    if (slotname != "OpenedContainer")
-                    {
-                        if (isLeftClick)
-                        {
-                            if (useon.CurrentItemBeingUsed != null)
-                            {
-                                useon.UseOn(
-                                    ObjectUsed: objAtSlot,
-                                    srcObject: useon.CurrentItemBeingUsed,
-                                    WorldObject: true);
-                            }
-                            else
-                            {
-                                use.Use(
-                                    ObjectUsed: objAtSlot,
-                                    UsingObjectOrCharacter: playerdat.playerObject,
-                                    objList: playerdat.InventoryObjects,
-                                    WorldObject: false);
-                            }
-                        }
-                        else
-                        {
-                            //do pickup
-                            //try and pickup
-                            InteractionModeToggle(InteractionModes.ModePickup);
-                            PickupObjectFromSlot(objAtSlot);
-                        }
-                    }
-                    else
-                    {
-                        //close up opened container.
-                        container.Close(
-                            index: objAtSlot.index,
-                            objList: playerdat.InventoryObjects);
-                    }
-                    break;
+                    return true;
                 case InteractionModes.ModeLook:
-                    if (slotname != "OpenedContainer")
-                    {
-                        if (isLeftClick)
-                        {
-                            look.LookAt(objAtSlot.index, playerdat.InventoryObjects, false);
-                        }
-                        else
-                        {
-                            InteractionModeToggle(InteractionModes.ModeUse);
-                            if (useon.CurrentItemBeingUsed != null)
-                            {
-                                useon.UseOn(
-                                    ObjectUsed: objAtSlot,
-                                    srcObject: useon.CurrentItemBeingUsed,
-                                    WorldObject: true);
-                            }
-                            else
-                            {
-                                use.Use(
-                                    objAtSlot,
-                                    playerdat.playerObject,
-                                    objList: playerdat.InventoryObjects,
-                                    WorldObject: false);
-                            }
-
-                        }
-
-                    }
-                    else
-                    {
-                        //close up opened container.
-                        container.Close(
-                            index: objAtSlot.index,
-                            objList: playerdat.InventoryObjects);
-                    }
-                    break;
-
-                case InteractionModes.ModeTalk://same as pickup except no use
-                case InteractionModes.ModePickup:
-                    if (slotname == "OpenedContainer")
-                    {
-                        if ((playerdat.ObjectInHand != -1) && (!isLeftClick))
-                        {
-                            MoveObjectInHandOutOfOpenedContainer(playerdat.ObjectInHand);
-                        }
-                        else
-                        {
-                            //close up opened container when no obj in hand or when leftclicking
-                            container.Close(
-                                index: objAtSlot.index,
-                                objList: playerdat.InventoryObjects);
-                        }
-                    }
-                    else
-                    {
-                        if (playerdat.ObjectInHand != -1)
-                        {
-                            //do a use interaction on the object already there. 
-                            UseObjectsTogether(playerdat.ObjectInHand, objAtSlot.index);
-                        }
-                        else
-                        {
-                            if (!uimanager.InConversation)
-                            {
-                                if (isLeftClick)
-                                {
-                                    //try and pickup
-                                    switch (slotname)
-                                    {
-                                        case "RightShoulder":
-                                        case "LeftShoulder":
-                                        case "RightHand":
-                                        case "LeftHand":
-                                            if (objAtSlot.index != OpenedContainerIndex)
-                                            {
-                                                if ((OpenedContainerIndex == -1))
-                                                {
-                                                    PickupObjectFromSlot(objAtSlot);
-                                                }
-                                                else
-                                                {
-                                                    //check if the opened container is not in the object chain of the object list
-                                                    var match = objectsearch.FindMatchInObjectChain(ListHeadIndex: objAtSlot.index, itemIndex: OpenedContainerIndex, objList: playerdat.InventoryObjects, SkipNext: true);
-                                                    if (match == null)
-                                                    {
-                                                        PickupObjectFromSlot(objAtSlot);
-                                                    }
-                                                    else
-                                                    {
-                                                        Debug.Print("attempt to pickup container while it or sub-object is opened");
-                                                    }
-                                                }
-                                            }
-                                            break;
-                                        default:
-                                            if (objAtSlot.index != OpenedContainerIndex)
-                                            {
-                                                PickupObjectFromSlot(objAtSlot);
-                                            }
-                                            break;
-                                    }
-
-                                }
-                                else
-                                {
-                                    //use the object at that slot
-                                    use.Use(
-                                        ObjectUsed: objAtSlot,
-                                        UsingObjectOrCharacter: playerdat.playerObject,
-                                        objList: playerdat.InventoryObjects,
-                                        WorldObject: false);
-                                }
-                            }
-                            else
-                            {//click on a slot in a conversation
-                                if (isLeftClick)
-                                {
-                                    //left click pickup in conversation
-                                    //var obj = playerdat.InventoryObjects[objAtSlot];
-                                    if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0))
-                                    {
-                                        AddToMessageScroll(
-                                            stringToAdd: GameStrings.GetString(1, GameStrings.str_you_cannot_barter_a_container__instead_remove_the_contents_you_want_to_trade_),
-                                            option: 2,
-                                            mode: MessageDisplay.MessageDisplayMode.TemporaryMessage
-                                            );
-                                    }
-                                    else
-                                    {
-                                        //try and pickup if not a container
-                                        PickupObjectFromSlot(objAtSlot);
-                                    }
-                                }
-                                else
-                                {//check if container.
-                                    //var obj = playerdat.InventoryObjects[objAtSlot];
-                                    if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0) && (objAtSlot.classindex != 0xF))
-                                    {//containers, browse into
-                                        use.Use(
-                                            objAtSlot,
-                                            playerdat.playerObject,
-                                            objList: playerdat.InventoryObjects,
-                                            WorldObject: false);
-                                    }
-                                    else
-                                    {
-                                        if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0) && (objAtSlot.classindex == 0xF))
-                                        {//runebag. ignore.
-
-                                        }
-                                        else
-                                        {//all other objects look at
-                                            look.PrintLookDescription(
-                                                obj: objAtSlot,
-                                                objList: playerdat.InventoryObjects,
-                                                OutputConvo: true,
-                                                lorecheckresult: look.LoreCheck(objAtSlot));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    break;
-                case InteractionModes.ModeOptions:
-                    break;//donothing.
+                    // UW2 Look mode: both buttons Look. UW1: left Use, right Look.
+                    return (UWClass._RES != UWClass.GAME_UW2) && isLeftClick;
                 default:
-                    Debug.Print("Unimplemented inventory use verb-object combination"); break;
+                    // None / Talk / Get / Combat / Options: left Use, right Look.
+                    return isLeftClick;
+            }
+        }
+
+        static void UseInventoryObject(uwObject objAtSlot)
+        {
+            if (useon.CurrentItemBeingUsed != null)
+            {
+                useon.UseOn(
+                    ObjectUsed: objAtSlot,
+                    srcObject: useon.CurrentItemBeingUsed,
+                    WorldObject: false);
+            }
+            else
+            {
+                use.Use(
+                    ObjectUsed: objAtSlot,
+                    UsingObjectOrCharacter: playerdat.playerObject,
+                    objList: playerdat.InventoryObjects,
+                    WorldObject: false);
+            }
+        }
+
+        /// <summary>
+        /// Conversation inventory clicks keep trade-oriented behaviour (pickup / open / look).
+        /// </summary>
+        static void InteractWithObjectInSlotConversation(uwObject objAtSlot, bool isLeftClick)
+        {
+            if (playerdat.ObjectInHand != -1)
+            {
+                UseObjectsTogether(playerdat.ObjectInHand, objAtSlot.index);
+                return;
+            }
+
+            if (isLeftClick)
+            {
+                if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0))
+                {
+                    AddToMessageScroll(
+                        stringToAdd: GameStrings.GetString(1, GameStrings.str_you_cannot_barter_a_container__instead_remove_the_contents_you_want_to_trade_),
+                        option: 2,
+                        mode: MessageDisplay.MessageDisplayMode.TemporaryMessage);
+                }
+                else
+                {
+                    PickupObjectFromSlot(objAtSlot);
+                }
+            }
+            else
+            {
+                if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0) && (objAtSlot.classindex != 0xF))
+                {
+                    use.Use(
+                        objAtSlot,
+                        playerdat.playerObject,
+                        objList: playerdat.InventoryObjects,
+                        WorldObject: false);
+                }
+                else if ((objAtSlot.majorclass == 2) && (objAtSlot.minorclass == 0) && (objAtSlot.classindex == 0xF))
+                {
+                    // runebag: ignore
+                }
+                else
+                {
+                    look.PrintLookDescription(
+                        obj: objAtSlot,
+                        objList: playerdat.InventoryObjects,
+                        OutputConvo: true,
+                        lorecheckresult: look.LoreCheck(objAtSlot));
+                }
             }
         }
 

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -491,10 +491,59 @@ namespace Underworld
 
 		public override void _Input(InputEvent @event)
 		{
+			if (InConversation
+				&& @event is InputEventMouseButton temporaryMessageClick
+				&& (temporaryMessageClick.ButtonIndex == MouseButton.Left
+					|| temporaryMessageClick.ButtonIndex == MouseButton.Right)
+				&& HandleTemporaryMessageClick(temporaryMessageClick))
+			{
+				GetViewport().SetInputAsHandled();
+				return;
+			}
+
 			// Continue inventory drag detection when the cursor leaves the pressed slot control.
 			if (inventoryPointerDown && @event is InputEventMouseMotion mouseMotion)
 			{
 				TryStartInventoryDrag(mouseMotion.GlobalPosition);
+			}
+			if (tradePointerDown && @event is InputEventMouseMotion tradeMotion)
+			{
+				TryStartTradeDrag(tradeMotion.GlobalPosition);
+			}
+
+			if (@event is InputEventMouseButton mouseButton
+				&& !mouseButton.Pressed)
+			{
+				if (inventoryPointerDown
+					&& mouseButton.ButtonIndex == inventoryPointerButton)
+				{
+					TryStartInventoryDrag(mouseButton.GlobalPosition);
+					if (inventoryDragActive
+						&& playerdat.ObjectInHand != -1
+						&& TryPlaceHeldItemInTradeSlot(mouseButton.GlobalPosition))
+					{
+						ClearInventoryPointerState();
+						GetViewport().SetInputAsHandled();
+						return;
+					}
+				}
+
+				if (tradePointerDown
+					&& mouseButton.ButtonIndex == tradePointerButton)
+				{
+					TryStartTradeDrag(mouseButton.GlobalPosition);
+					if (tradeDragActive && playerdat.ObjectInHand != -1)
+					{
+						var destSlot = FindInventorySlotUnderMouse();
+						if (destSlot != null)
+						{
+							ClearTradeDragState();
+							PlaceHeldItemAtSlot(destSlot);
+							GetViewport().SetInputAsHandled();
+							return;
+						}
+					}
+				}
 			}
 
 			if (@event is InputEventKey keyinput)
@@ -555,10 +604,25 @@ namespace Underworld
 					{
 						PlaceHeldItemAtSlot(destSlot);
 					}
-					else if (IsMouseInViewPort())
+					else if (!InConversation && IsMouseInViewPort())
 					{
 						DropHeldItemIntoWorld();
 					}
+				}
+			}
+
+			if (tradePointerDown
+				&& @event is InputEventMouseButton tradeMouseButton
+				&& !tradeMouseButton.Pressed
+				&& tradeMouseButton.ButtonIndex == tradePointerButton)
+			{
+				TryStartTradeDrag(tradeMouseButton.GlobalPosition);
+				var wasTradeDrag = tradeDragActive;
+				ClearTradeDragState();
+				if (wasTradeDrag && playerdat.ObjectInHand != -1
+					&& !InConversation && IsMouseInViewPort())
+				{
+					DropHeldItemIntoWorld();
 				}
 			}
 		}

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -491,6 +491,12 @@ namespace Underworld
 
 		public override void _Input(InputEvent @event)
 		{
+			// Continue inventory drag detection when the cursor leaves the pressed slot control.
+			if (inventoryPointerDown && @event is InputEventMouseMotion mouseMotion)
+			{
+				TryStartInventoryDrag(mouseMotion.GlobalPosition);
+			}
+
 			if (@event is InputEventKey keyinput)
 			{
 				if (keyinput.Pressed)
@@ -526,6 +532,32 @@ namespace Underworld
 									break;
 								}
 						}
+					}
+				}
+			}
+		}
+
+		public override void _UnhandledInput(InputEvent @event)
+		{
+			// Release outside inventory slot controls (e.g. over the 3D view).
+			if (inventoryPointerDown
+				&& @event is InputEventMouseButton mouseButton
+				&& !mouseButton.Pressed
+				&& mouseButton.ButtonIndex == inventoryPointerButton)
+			{
+				TryStartInventoryDrag(mouseButton.GlobalPosition);
+				ClearInventoryPointerState();
+
+				if (playerdat.ObjectInHand != -1)
+				{
+					var destSlot = FindInventorySlotUnderMouse();
+					if (destSlot != null)
+					{
+						PlaceHeldItemAtSlot(destSlot);
+					}
+					else if (IsMouseInViewPort())
+					{
+						DropHeldItemIntoWorld();
 					}
 				}
 			}

--- a/src/ui/uimanager_messagescroll.cs
+++ b/src/ui/uimanager_messagescroll.cs
@@ -1,4 +1,6 @@
+using System.Collections;
 using Godot;
+using Peaky.Coroutines;
 
 namespace Underworld
 {
@@ -88,6 +90,9 @@ namespace Underworld
 		public MessageDisplay convo = new();
 
 		public static bool MessageScrollIsTemporary = false;
+		public static int TemporaryMessageId = 0;
+		static MessageScrollLine[] temporaryMessageBackup;
+		static bool temporaryMessageClickDown = false;
 
 		public static bool CursorOverMessageScroll = false; //Used to determine where cursor is when clicking conversation options
 
@@ -179,6 +184,8 @@ namespace Underworld
 					{
 						//back up lines
 						var backup = BackupLines(instance.scroll.Lines, 5);
+						temporaryMessageBackup = backup;
+						var temporaryMessageId = ++TemporaryMessageId;
 						MessageScrollIsTemporary = true;
 						instance.scroll.Clear();
 						_ = Peaky.Coroutines.Coroutine.Run(
@@ -187,7 +194,7 @@ namespace Underworld
 							);
 
 						_ = Peaky.Coroutines.Coroutine.Run(
-							instance.scroll.RestoreLinesAfterWait(backup, 2f),
+							RestoreTemporaryMessageAfterWait(backup, 2f, temporaryMessageId),
 							main.instance
 							);
 						break;
@@ -211,6 +218,74 @@ namespace Underworld
 					uimanager.StartDragonAnimation(1);
 				}
 			}
+		}
+
+		public static bool HandleTemporaryMessageClick(InputEventMouseButton mouseButton)
+		{
+			if (!MessageScrollIsTemporary && !temporaryMessageClickDown)
+			{
+				return false;
+			}
+
+			if (mouseButton.Pressed)
+			{
+				if (MessageScrollIsTemporary)
+				{
+					CancelTemporaryMessage();
+				}
+				temporaryMessageClickDown = true;
+			}
+			else if (temporaryMessageClickDown)
+			{
+				temporaryMessageClickDown = false;
+			}
+			return true;
+		}
+
+		public static void CancelTemporaryMessage()
+		{
+			if (!MessageScrollIsTemporary)
+			{
+				return;
+			}
+
+			TemporaryMessageId++;
+			RestoreMessageScrollLines(temporaryMessageBackup);
+			temporaryMessageBackup = null;
+			MessageScrollIsTemporary = false;
+		}
+
+		static void RestoreMessageScrollLines(MessageScrollLine[] linesToRestore)
+		{
+			if (linesToRestore == null)
+			{
+				return;
+			}
+
+			for (int i = 0; i <= instance.scroll.Lines.GetUpperBound(0); i++)
+			{
+				instance.scroll.Lines[i] = new MessageScrollLine(
+					linesToRestore[i].OptionNo,
+					linesToRestore[i].LineText);
+			}
+			instance.scroll.UpdateMessageDisplay();
+		}
+
+		static IEnumerator RestoreTemporaryMessageAfterWait(
+			MessageScrollLine[] linesToRestore,
+			float waittime,
+			int temporaryMessageId)
+		{
+			yield return new WaitForSeconds(waittime);
+
+			if (!MessageScrollIsTemporary || temporaryMessageId != TemporaryMessageId)
+			{
+				yield break;
+			}
+
+			RestoreMessageScrollLines(linesToRestore);
+			temporaryMessageBackup = null;
+			MessageScrollIsTemporary = false;
 		}
 
 		public static MessageScrollLine[] BackupLines(MessageScrollLine[] toBackup, int size)

--- a/src/ui/uimanager_paperdoll.cs
+++ b/src/ui/uimanager_paperdoll.cs
@@ -522,68 +522,118 @@ namespace Underworld
 		/// <param name="extra_arg_0"></param>
 		private void _paperdoll_gui_input(InputEvent @event, string extra_arg_0)
         {
-            if (@event is InputEventMouseButton eventMouseButton 
-                && eventMouseButton.Pressed 
-                &&  (((eventMouseButton.ButtonIndex == MouseButton.Left) || (eventMouseButton.ButtonIndex == MouseButton.Right)))
-            )
+            if (playerdat.ParalyseTimer > 0 || playerdat.DreamingInVoid || MessageScrollIsTemporary)
             {
-                if (playerdat.ParalyseTimer>0)
-                {
-                    return; //block input while paralysed
-                }
-                if (playerdat.DreamingInVoid)
-                {
-                    return;// to prevent inventory use while in the void.
-                }
-                bool isLeftClick = (eventMouseButton.ButtonIndex == MouseButton.Left);
-                if (MessageScrollIsTemporary)
-                {//avoids bug involved in clicking on an object while a temp message is displayed
-                    return;
-                }
-                //LEFT CLICK ACTIONS
-                Debug.Print($"->{extra_arg_0}");
-                var objIndexAtSlot = GetObjAtSlot(extra_arg_0);
+                return;
+            }
 
-                //Do action appropiate to the interaction mode verb. use 
+            if (@event is InputEventMouseMotion mouseMotion)
+            {
+                if (inventoryPointerDown)
+                {
+                    TryStartInventoryDrag(mouseMotion.GlobalPosition);
+                }
+                return;
+            }
+
+            if (@event is not InputEventMouseButton eventMouseButton)
+            {
+                return;
+            }
+            if ((eventMouseButton.ButtonIndex != MouseButton.Left)
+                && (eventMouseButton.ButtonIndex != MouseButton.Right))
+            {
+                return;
+            }
+
+            bool isLeftClick = eventMouseButton.ButtonIndex == MouseButton.Left;
+            Debug.Print($"->{extra_arg_0}");
+
+            if (eventMouseButton.Pressed)
+            {
+                // Drag/click tracking. Use-on / spell modes act on release only.
+                if (UsageMode == 0)
+                {
+                    BeginInventoryPointerDown(extra_arg_0, eventMouseButton.ButtonIndex, eventMouseButton.GlobalPosition);
+                }
+                return;
+            }
+
+            // Mouse release
+            if (UsageMode != 0)
+            {
+                var objIndexAtSlot = GetObjAtSlot(extra_arg_0);
                 if (objIndexAtSlot > 0)
-                { //there is an object in that slot.
-                    uwObject obj = playerdat.InventoryObjects[objIndexAtSlot];
-                    switch(UsageMode)
+                {
+                    switch (UsageMode)
                     {
-                        case 0: //default
-                            InteractWithObjectInSlot(
-                                slotname: extra_arg_0,
-                                objAtSlot: obj,
-                                isLeftClick: isLeftClick);
-                            break;
                         case 1://object select to use on another. eg doorkey
                             useon.UseOn(
-                                ObjectUsed: playerdat.InventoryObjects[objIndexAtSlot], 
-                                srcObject: useon.CurrentItemBeingUsed, 
+                                ObjectUsed: playerdat.InventoryObjects[objIndexAtSlot],
+                                srcObject: useon.CurrentItemBeingUsed,
                                 WorldObject: false);
                             break;
                         case 2://spell casting
                             if (SpellCasting.currentSpell.SpellMajorClass != 5)
-                                {//as long as it's not a project(?) try and cast on the object
-                                    SpellCasting.CastCurrentSpellOnRayCastTarget(
-                                        index: objIndexAtSlot, 
-                                        objList: playerdat.InventoryObjects, 
-                                        WorldObject:false);
-                                }
+                            {
+                                SpellCasting.CastCurrentSpellOnRayCastTarget(
+                                    index: objIndexAtSlot,
+                                    objList: playerdat.InventoryObjects,
+                                    WorldObject: false);
+                            }
                             break;
                     }
                 }
-                else
-                {
-                    switch(UsageMode)
-                    {
-                        case 0:
-                            InteractWithEmptySlot(); break;
-                    }
-                 
-                }
                 CurrentSlot = -1;
+                ClearInventoryPointerState();
+                return;
             }
+
+            // Only complete the gesture for the button that started it.
+            if (inventoryPointerDown && eventMouseButton.ButtonIndex != inventoryPointerButton)
+            {
+                return;
+            }
+
+            bool wasDrag = inventoryDragActive;
+            // Start drag on release if movement already exceeded threshold but
+            // motion events were sparse (e.g. fast flick).
+            if (inventoryPointerDown && !wasDrag)
+            {
+                TryStartInventoryDrag(eventMouseButton.GlobalPosition);
+                wasDrag = inventoryDragActive;
+            }
+            ClearInventoryPointerState();
+
+            if (playerdat.ObjectInHand != -1)
+            {
+                // Place at the slot under the cursor (not the press control bind).
+                var destSlot = FindInventorySlotUnderMouse();
+                if (destSlot != null)
+                {
+                    PlaceHeldItemAtSlot(destSlot);
+                }
+                else if (IsMouseInViewPort())
+                {
+                    DropHeldItemIntoWorld();
+                }
+                // else leave item in hand
+            }
+            else if (!wasDrag)
+            {
+                // Click without drag: mode-dependent Use/Look on this control.
+                var objIndexAtSlot = GetObjAtSlot(extra_arg_0);
+                if (objIndexAtSlot > 0)
+                {
+                    InteractWithObjectInSlot(
+                        slotname: extra_arg_0,
+                        objAtSlot: playerdat.InventoryObjects[objIndexAtSlot],
+                        isLeftClick: isLeftClick);
+                }
+            }
+
+            CurrentSlot = -1;
+            GetViewport().SetInputAsHandled();
         }
 
         /// <summary>

--- a/src/ui/uimanager_paperdoll.cs
+++ b/src/ui/uimanager_paperdoll.cs
@@ -613,7 +613,7 @@ namespace Underworld
                 {
                     PlaceHeldItemAtSlot(destSlot);
                 }
-                else if (IsMouseInViewPort())
+                else if (!InConversation && IsMouseInViewPort())
                 {
                     DropHeldItemIntoWorld();
                 }
@@ -633,6 +633,10 @@ namespace Underworld
             }
 
             CurrentSlot = -1;
+            if (TradeDragActive)
+            {
+                ClearTradeDragState();
+            }
             GetViewport().SetInputAsHandled();
         }
 

--- a/src/ui/uimanager_trade.cs
+++ b/src/ui/uimanager_trade.cs
@@ -47,6 +47,115 @@ namespace Underworld
         static int[] NPCItemIDs = new int[6];
         static bool[] NPCItemSelected = new bool[6];
 
+        static bool tradePointerDown;
+        static bool tradeDragActive;
+        static long tradePressSlot;
+        static bool tradePressIsPlayerSide;
+        static MouseButton tradePointerButton;
+        static Vector2 tradePressPos;
+        const float TradeDragThresholdPx = 5f;
+
+        static void BeginTradePointerDown(long slotNo, bool isPlayerSide, MouseButton button, Vector2 position)
+        {
+            tradePointerDown = true;
+            tradeDragActive = false;
+            tradePressSlot = slotNo;
+            tradePressIsPlayerSide = isPlayerSide;
+            tradePointerButton = button;
+            tradePressPos = position;
+        }
+
+        static void ClearTradePointerState()
+        {
+            tradePointerDown = false;
+            tradeDragActive = false;
+        }
+
+        /// <summary>
+        /// Starts dragging an item out of the player's trade area.
+        /// </summary>
+        static void TryStartTradeDrag(Vector2 position)
+        {
+            if (!tradePointerDown || tradeDragActive
+                || !tradePressIsPlayerSide
+                || !CanInventoryDrag(tradePointerButton)
+                || tradePressPos.DistanceTo(position) < TradeDragThresholdPx)
+            {
+                return;
+            }
+
+            tradeDragActive = true;
+            if (playerdat.ObjectInHand != -1 || PlayerItemIDs[tradePressSlot] == -1)
+            {
+                return;
+            }
+
+            playerdat.ObjectInHand = PlayerItemIDs[tradePressSlot];
+            var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
+            instance.mousecursor.SetCursorToObject(obj.item_id);
+            SetPlayerTradeSlot((int)tradePressSlot, -1, false);
+        }
+
+        public static bool TradeDragActive => tradeDragActive;
+
+        public static void ClearTradeDragState()
+        {
+            ClearTradePointerState();
+        }
+
+        static int FindPlayerTradeSlotUnderMouse(Vector2 mouse)
+        {
+            for (int i = 0; i < NoOfTradeSlots; i++)
+            {
+                if (ControlContainsMouse(playerTrade[i], mouse)
+                    || ControlContainsMouse(playerTradeSelected[i], mouse))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        static void PlaceHeldItemAtTradeSlot(int slotNo)
+        {
+            if (playerdat.ObjectInHand == -1)
+            {
+                return;
+            }
+
+            if (PlayerItemIDs[slotNo] == -1)
+            {
+                SetPlayerTradeSlot(slotNo, playerdat.ObjectInHand, true);
+                playerdat.ObjectInHand = -1;
+                instance.mousecursor.SetCursorToCursor();
+            }
+            else
+            {
+                var swap = playerdat.ObjectInHand;
+                playerdat.ObjectInHand = PlayerItemIDs[slotNo];
+                var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
+                instance.mousecursor.SetCursorToObject(obj.item_id);
+                SetPlayerTradeSlot(slotNo, swap, true);
+            }
+        }
+
+        public static bool TryPlaceHeldItemInTradeSlot(Vector2 mouse)
+        {
+            if (!InConversation || playerdat.ObjectInHand == -1)
+            {
+                return false;
+            }
+
+            var slotNo = FindPlayerTradeSlotUnderMouse(mouse);
+            if (slotNo == -1)
+            {
+                return false;
+            }
+
+            PlaceHeldItemAtTradeSlot(slotNo);
+            return true;
+        }
+
 
         public static int NoOfTradeSlots
         {
@@ -244,7 +353,6 @@ namespace Underworld
         void HandleTradeSlotClick(InputEvent @event, long slotNo, bool isPlayerSide)
         {
             if (@event is not InputEventMouseButton eventMouseButton
-                || eventMouseButton.Pressed
                 || ((eventMouseButton.ButtonIndex != MouseButton.Left)
                     && (eventMouseButton.ButtonIndex != MouseButton.Right)))
             {
@@ -252,34 +360,69 @@ namespace Underworld
             }
 
             int[] itemIds = isPlayerSide ? PlayerItemIDs : NPCItemIDs;
+            if (eventMouseButton.Pressed)
+            {
+                if (isPlayerSide
+                    && playerdat.ObjectInHand == -1
+                    && CanInventoryDrag(eventMouseButton.ButtonIndex)
+                    && itemIds[slotNo] != -1)
+                {
+                    BeginTradePointerDown(
+                        slotNo,
+                        isPlayerSide,
+                        eventMouseButton.ButtonIndex,
+                        eventMouseButton.GlobalPosition);
+                }
+                return;
+            }
+
+            if (tradePointerDown
+                && (eventMouseButton.ButtonIndex != tradePointerButton
+                    || slotNo != tradePressSlot
+                    || isPlayerSide != tradePressIsPlayerSide))
+            {
+                return;
+            }
+
+            if (tradeDragActive)
+            {
+                if (isPlayerSide)
+                {
+                    var destinationSlot = FindPlayerTradeSlotUnderMouse(eventMouseButton.GlobalPosition);
+                    if (destinationSlot != -1)
+                    {
+                        PlaceHeldItemAtTradeSlot(destinationSlot);
+                    }
+                }
+                ClearTradePointerState();
+                return;
+            }
+
+            if (isPlayerSide && playerdat.ObjectInHand != -1 && inventoryDragActive)
+            {
+                PlaceHeldItemAtTradeSlot((int)slotNo);
+                ClearInventoryPointerState();
+                return;
+            }
+
             if (eventMouseButton.ButtonIndex == MouseButton.Right)
             {
+                ClearTradePointerState();
                 LookAtTradeSlot(itemIds, slotNo, useLoreCheck: isPlayerSide);
                 return;
             }
 
             // Left release
-            if (isPlayerSide && playerdat.ObjectInHand != -1)
+            if (isPlayerSide && playerdat.ObjectInHand != -1
+                && (eventMouseButton.ButtonIndex == MouseButton.Left || inventoryDragActive))
             {
-                // Place / swap held item into the player trade slot.
-                if (itemIds[slotNo] == -1)
-                {
-                    SetPlayerTradeSlot((int)slotNo, playerdat.ObjectInHand, true);
-                    playerdat.ObjectInHand = -1;
-                    mousecursor.SetCursorToCursor();
-                }
-                else
-                {
-                    var swap = playerdat.ObjectInHand;
-                    playerdat.ObjectInHand = itemIds[slotNo];
-                    var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
-                    mousecursor.SetCursorToObject(obj.item_id);
-                    SetPlayerTradeSlot((int)slotNo, swap, true);
-                }
+                PlaceHeldItemAtTradeSlot((int)slotNo);
+                ClearInventoryPointerState();
                 return;
             }
 
             ToggleTradeSlotSelection(slotNo, isPlayerSide);
+            ClearTradePointerState();
         }
 
         static void LookAtTradeSlot(int[] itemIds, long slotNo, bool useLoreCheck)

--- a/src/ui/uimanager_trade.cs
+++ b/src/ui/uimanager_trade.cs
@@ -219,24 +219,112 @@ namespace Underworld
         }
         private void _on_player_trade_selected(InputEvent @event, long extra_arg_0)
         {
-            if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
-            {                
-                //toggle selected
-                if (PlayerItemSelected[extra_arg_0])
+            HandleTradeSlotClick(@event, extra_arg_0, isPlayerSide: true);
+        }
+
+        private void _on_npc_trade_selected(InputEvent @event, long extra_arg_0)
+        {
+            HandleTradeSlotClick(@event, extra_arg_0, isPlayerSide: false);
+        }
+
+        private void _on_player_trade_input(InputEvent @event, long extra_arg_0)
+        {
+            HandleTradeSlotClick(@event, extra_arg_0, isPlayerSide: true);
+        }
+
+        private void _on_npc_trade_input(InputEvent @event, long extra_arg_0)
+        {
+            HandleTradeSlotClick(@event, extra_arg_0, isPlayerSide: false);
+        }
+
+        /// <summary>
+        /// Trade slots: left release = select (or place held item on player side),
+        /// right release = look.
+        /// </summary>
+        void HandleTradeSlotClick(InputEvent @event, long slotNo, bool isPlayerSide)
+        {
+            if (@event is not InputEventMouseButton eventMouseButton
+                || eventMouseButton.Pressed
+                || ((eventMouseButton.ButtonIndex != MouseButton.Left)
+                    && (eventMouseButton.ButtonIndex != MouseButton.Right)))
+            {
+                return;
+            }
+
+            int[] itemIds = isPlayerSide ? PlayerItemIDs : NPCItemIDs;
+            if (eventMouseButton.ButtonIndex == MouseButton.Right)
+            {
+                LookAtTradeSlot(itemIds, slotNo, useLoreCheck: isPlayerSide);
+                return;
+            }
+
+            // Left release
+            if (isPlayerSide && playerdat.ObjectInHand != -1)
+            {
+                // Place / swap held item into the player trade slot.
+                if (itemIds[slotNo] == -1)
                 {
-                    PlayerTradeOff(extra_arg_0);
+                    SetPlayerTradeSlot((int)slotNo, playerdat.ObjectInHand, true);
+                    playerdat.ObjectInHand = -1;
+                    mousecursor.SetCursorToCursor();
                 }
                 else
                 {
-                    if (PlayerItemIDs[extra_arg_0]!=-1)
-                    {//check if occupied.
-                        PlayerTradeOn(extra_arg_0);
-                    }
-                    else
-                    {
-                        PlayerTradeOff(extra_arg_0);
-                    }
+                    var swap = playerdat.ObjectInHand;
+                    playerdat.ObjectInHand = itemIds[slotNo];
+                    var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
+                    mousecursor.SetCursorToObject(obj.item_id);
+                    SetPlayerTradeSlot((int)slotNo, swap, true);
                 }
+                return;
+            }
+
+            ToggleTradeSlotSelection(slotNo, isPlayerSide);
+        }
+
+        static void LookAtTradeSlot(int[] itemIds, long slotNo, bool useLoreCheck)
+        {
+            if (itemIds[slotNo] == -1)
+            {
+                return;
+            }
+            var obj = UWTileMap.current_tilemap.LevelObjects[itemIds[slotNo]];
+            if (obj == null)
+            {
+                return;
+            }
+            look.PrintLookDescription(
+                obj: obj,
+                objList: UWTileMap.current_tilemap.LevelObjects,
+                OutputConvo: true,
+                lorecheckresult: useLoreCheck ? look.LoreCheck(obj) : 0);
+        }
+
+        void ToggleTradeSlotSelection(long slotNo, bool isPlayerSide)
+        {
+            if (isPlayerSide)
+            {
+                if (PlayerItemIDs[slotNo] == -1)
+                {
+                    PlayerTradeOff(slotNo);
+                    return;
+                }
+                if (PlayerItemSelected[slotNo])
+                    PlayerTradeOff(slotNo);
+                else
+                    PlayerTradeOn(slotNo);
+            }
+            else
+            {
+                if (NPCItemIDs[slotNo] == -1)
+                {
+                    NpcTradeOff(slotNo);
+                    return;
+                }
+                if (NPCItemSelected[slotNo])
+                    NpcTradeOff(slotNo);
+                else
+                    NPCTradeOn(slotNo);
             }
         }
 
@@ -253,30 +341,6 @@ namespace Underworld
             PlayerItemSelected[slotNo] = false;
         }
 
-
-        private void _on_npc_trade_selected(InputEvent @event, long extra_arg_0)
-        {
-            if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
-            {                
-                //toggle selected
-                if (NPCItemSelected[extra_arg_0])
-                {
-                    NpcTradeOff(extra_arg_0);
-                }
-                else
-                {
-                    if (NPCItemIDs[extra_arg_0]!=-1)
-                    {//check if occupied.
-                        NPCTradeOn(extra_arg_0);
-                    }
-                    else
-                    {
-                        NpcTradeOff(extra_arg_0);
-                    }
-                }
-            }
-        }
-
         public static void NpcTradeOff(long slotNo)
         {
             npcTradeSelected[slotNo].Texture = null;
@@ -288,80 +352,6 @@ namespace Underworld
         {
             npcTradeSelected[slotNo].Texture = SelectionCross;
             NPCItemSelected[slotNo] = true;
-        }
-
-        private void _on_player_trade_input(InputEvent @event, long extra_arg_0)
-        {
-            if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed)
-            {  
-                if (eventMouseButton.ButtonIndex == MouseButton.Left)
-                {//left click item manipulation
-                    if (PlayerItemIDs[extra_arg_0]== -1)
-                    {//no item currently in slot.
-                        if (playerdat.ObjectInHand!=-1)
-                        {//drop available item in slot
-                            SetPlayerTradeSlot((int)extra_arg_0,playerdat.ObjectInHand,true);
-                            playerdat.ObjectInHand = -1;
-                            mousecursor.SetCursorToCursor();
-                        }
-                    }
-                    else
-                    {
-                        if (playerdat.ObjectInHand == -1)
-                        {//take item from slot into a free hand
-                            playerdat.ObjectInHand = PlayerItemIDs[extra_arg_0];
-                            var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
-                            mousecursor.SetCursorToObject(obj.item_id);
-                            SetPlayerTradeSlot((int)extra_arg_0, -1, false);                            
-                        }
-                        else
-                        {
-                            //swap objects
-                            var swap = playerdat.ObjectInHand;
-                            playerdat.ObjectInHand = PlayerItemIDs[extra_arg_0];
-                            var obj = UWTileMap.current_tilemap.LevelObjects[playerdat.ObjectInHand];
-                            mousecursor.SetCursorToObject(obj.item_id);
-                            SetPlayerTradeSlot((int)extra_arg_0, swap, true);
-                        }
-                    }
-                }
-                else
-                {//right click look at
-                    if (PlayerItemIDs[extra_arg_0]!=-1)
-                    {
-                        var obj = UWTileMap.current_tilemap.LevelObjects[PlayerItemIDs[extra_arg_0]];
-                        if (obj!=null)
-                        {
-                            look.PrintLookDescription(
-                                obj: obj,
-                                objList:UWTileMap.current_tilemap.LevelObjects,
-                                OutputConvo: true,
-                                lorecheckresult: look.LoreCheck(obj));
-                        }  
-                    }
-                }                
-            }
-        }
-
-
-        private void _on_npc_trade_input(InputEvent @event, long extra_arg_0)
-        {
-            if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
-            {  
-                //AddToMessageScroll($"NPC {extra_arg_0}");
-                if (NPCItemIDs[extra_arg_0]!=-1)
-                {
-                    var obj = UWTileMap.current_tilemap.LevelObjects[NPCItemIDs[extra_arg_0]];
-                    if (obj!=null)
-                    {
-                        look.PrintLookDescription(
-                            obj: obj, 
-                            objList: UWTileMap.current_tilemap.LevelObjects,
-                            OutputConvo: true,
-                            lorecheckresult: 0);
-                    }                    
-                }
-            }
         }
     }//end class
 }//end namespace


### PR DESCRIPTION
Hey Hank, I just wanted to say that I love this project you're working on.  UW1 is my favorite game of all time, and your hard work (over the past decade it looks like!) has enabled me to fulfill a lifelong dream I've had ever since I was a child.  Ever since seeing VR kiosks in the mall, I've dreamed about walking around the Stygian Abyss in VR.  And now, thanks to forking your project, I've actually been able to do it.  I CANNOT THANK YOU ENOUGH!!!!  I was literally in tears the first time I got the map to load.

Originally, I just wanted to make a VR map viewer and walk around, but things have been going so well that I've decided to try and make the game fully playable.  I don't know if you'd ever be interested in the VR stuff I've been doing, but the very least I can do is help with bugfixes and improvements to the main project.

The inventory UI being different from the DOS games was bugging me, so I took a stab at tweaking it.  It's not perfect, but it matches DOS behavior much more (including UW1 vs UW2 differences).  I know this may be a lot to review in a single push request, but without doing all of it together, it made the game kind of broken.

Let me know if you're interested in me helping out with stuff like this.  I am happy to contribute back.  If you would prefer to keep this as more of your personal passion project, I completely understand.

THANK YOU SO MUCH!!!
-Matt

--

Inventory actions now follow vanilla timing and verbs more closely: clicks resolve on mouse release, and drag-and-drop moves items instead of mode-dependent press handling.

Click verbs (empty-handed):
- Use: both buttons Use
- Talk/Get/Combat/None: left Use, right Look
- Look UW1: left Use, right Look; Look UW2: both Look
- Right-click no longer switches interaction mode

Drag-and-drop:
- UW1: left or right drag picks up after a short move, places on release
- UW2: right drag only; left drag is a no-op (not treated as a click)
- Place uses the slot under the cursor; release over the 3D view drops or throws using current viewport mouse position
- Food can be dragged to the helm to eat

Interaction mode:
- Re-clicking the active mode (buttons or F2-F6) enters no-mode
- Attack re-click sheaths the weapon and clears the mode
- Programmatic mode changes (e.g. starting a conversation) keep Talk mode instead of clearing it

Trade window:
- Left release selects (or places a held item on the player side)
- Right release looks at the item