### PR TITLE
fix(save): serialise UW1's live animation-overlay blocks

### DIFF
--- a/src/player/playerdat.cs
+++ b/src/player/playerdat.cs
@@ -554,9 +554,15 @@ namespace Underworld
                 }
 
                 //Update rendering
-                Godot.RenderingServer.GlobalShaderParameterSet("renderceilings", playerdat.RenderCeilings);
-                Godot.RenderingServer.GlobalShaderParameterSet("renderwalls", playerdat.RenderWalls);
-                Godot.RenderingServer.GlobalShaderParameterSet("renderfloors", playerdat.RenderFloors);
+                // Chargen sets DetailLevel headlessly (InitEmptyPlayer), and touching
+                // a Godot singleton with no engine running segfaults the process
+                // instead of throwing, so gate on the scene root existing.
+                if (main.instance != null)
+                {
+                    Godot.RenderingServer.GlobalShaderParameterSet("renderceilings", playerdat.RenderCeilings);
+                    Godot.RenderingServer.GlobalShaderParameterSet("renderwalls", playerdat.RenderWalls);
+                    Godot.RenderingServer.GlobalShaderParameterSet("renderfloors", playerdat.RenderFloors);
+                }
             }
         }
 

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -181,9 +181,16 @@ namespace Underworld
             // single call covers both games.
             DetailLevel = 3;
 
-            RenderingServer.GlobalShaderParameterSet("renderceilings", playerdat.RenderCeilings);
-            RenderingServer.GlobalShaderParameterSet("renderwalls", playerdat.RenderWalls);
-            RenderingServer.GlobalShaderParameterSet("renderfloors", playerdat.RenderFloors);
+            // InitEmptyPlayer is pure chargen state and is exercised headlessly by
+            // the save-game tests. Touching any Godot singleton with no engine
+            // running segfaults the process rather than throwing, so gate the
+            // shader globals on the scene root existing.
+            if (main.instance != null)
+            {
+                RenderingServer.GlobalShaderParameterSet("renderceilings", playerdat.RenderCeilings);
+                RenderingServer.GlobalShaderParameterSet("renderwalls", playerdat.RenderWalls);
+                RenderingServer.GlobalShaderParameterSet("renderfloors", playerdat.RenderFloors);
+            }
 
             if (_RES != GAME_UW2)
             {

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -37,6 +37,9 @@ namespace Underworld
         private const int UW2BlockSize = 0x8000;
         // UW1 per-level block size
         private const int UW1BlockSize = UWTileMap.TileMapDataSize; // 0x7C08
+        // UW1 per-level animation-overlay block size. 64 slots × 6 bytes, matching
+        // the targetDataLen LevArkLoader.LoadOverlayBlock asks for.
+        private const int UW1OverlayBlockSize = 64 * 6;
 
         /// <summary>
         /// Serialize one level block (UWBlock) to the raw bytes that should be
@@ -50,6 +53,38 @@ namespace Underworld
             if (block?.Data != null)
             {
                 int copyLen = Math.Min(block.Data.Length, targetSize);
+                Buffer.BlockCopy(block.Data, 0, result, 0, copyLen);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Serialize one UW1 animation-overlay block to the fixed 384 bytes the
+        /// container stores. UW1 only: UW2 keeps overlays inside the level block
+        /// itself, and the demo keeps them in LEVEL13.ANX rather than in the ARK.
+        /// </summary>
+        public static byte[] SerializeOverlayBlock(UWBlock block)
+        {
+            byte[] result = new byte[UW1OverlayBlockSize];
+            if (block?.Data != null)
+            {
+                // A short buffer just means the remaining overlay slots are absent, so
+                // zero-padding is correct. An over-long one cannot be represented in 64
+                // six-byte slots and means something upstream grew the buffer, so say so
+                // rather than truncating in silence. Writing a well-formed block still
+                // beats throwing: LEV.ARK is written after DESC, PLAYER.DAT and
+                // BGLOBALS.DAT, so aborting here would leave a half-updated save slot.
+                // Console.Error, not GD.PushWarning: this runs in the headless save
+                // tests, and touching Godot with no engine segfaults rather than
+                // throwing. Not Debug.Print or Trace.WriteLine either, since those
+                // compile out without DEBUG/TRACE and the warning would vanish from
+                // release builds, which is where a silent truncation matters most.
+                if (block.Data.Length > UW1OverlayBlockSize)
+                {
+                    Console.Error.WriteLine(
+                        $"LevArkWriter: UW1 overlay block is {block.Data.Length} bytes, expected {UW1OverlayBlockSize}; truncating.");
+                }
+                int copyLen = Math.Min(block.Data.Length, UW1OverlayBlockSize);
                 Buffer.BlockCopy(block.Data, 0, result, 0, copyLen);
             }
             return result;
@@ -259,7 +294,10 @@ namespace Underworld
             // Replace visited tilemap blocks with live dungeon data.
             if (UWTileMap.dungeons != null)
             {
-                for (int lvl = 0; lvl < UWTileMap.NO_OF_LEVELS; lvl++)
+                // Same bound as the overlay loop below: dungeons is a public static
+                // array, so do not assume its length agrees with NO_OF_LEVELS.
+                int tileLevels = Math.Min(UWTileMap.NO_OF_LEVELS, UWTileMap.dungeons.Length);
+                for (int lvl = 0; lvl < tileLevels; lvl++)
                 {
                     if (UWTileMap.dungeons[lvl] != null)
                     {
@@ -268,6 +306,35 @@ namespace Underworld
                         {
                             blockData[lvl] = SerializeLevelBlock(live);
                         }
+                    }
+                }
+            }
+
+            // Replace overlay blocks (9..17) with the live animation-overlay data
+            // for any visited level.
+            //
+            // Without this the two halves of an in-flight animation disagree. A
+            // moving door writes its object record into the tilemap block (door.cs
+            // sets item 0x1CF) and its overlay record into ovl_ark_block (animo.cs
+            // stores the object link, tile and duration). Serialising only the
+            // tilemap leaves a moving-door object with no matching overlay, which
+            // is an internally inconsistent LEV.ARK and is what a save taken
+            // mid-animation produced. See hankmorgan/UnderworldGodot#43.
+            //
+            // UW1 proper only. UW2 has no separate overlay block, and the demo
+            // reads overlays from LEVEL13.ANX rather than from the ARK, so in
+            // neither case does block 9+lvl hold overlay data to replace.
+            if (UWClass._RES == UWClass.GAME_UW1 && UWTileMap.dungeons != null)
+            {
+                // dungeons is a public static array, so bound by its actual length as
+                // well as by NO_OF_LEVELS rather than trusting the two to agree.
+                int overlayLevels = Math.Min(UWTileMap.NO_OF_LEVELS, UWTileMap.dungeons.Length);
+                for (int lvl = 0; lvl < overlayLevels; lvl++)
+                {
+                    UWBlock liveOverlay = UWTileMap.dungeons[lvl]?.ovl_ark_block;
+                    if (liveOverlay?.Data != null)
+                    {
+                        blockData[9 + lvl] = SerializeOverlayBlock(liveOverlay);
                     }
                 }
             }

--- a/src/ui/uimanager_stats.cs
+++ b/src/ui/uimanager_stats.cs
@@ -76,7 +76,11 @@ namespace Underworld
 		/// </summary>
 		public static void RefreshStatsDisplay()
 		{
-			instance.Charname.Text = $"[center][color={AttributesFontColor}]{playerdat.CharName.ToUpper()}[/color][/center]";
+			// playerdat setters (max_hp, max_mana, play_level) call this, so it
+			// runs from pure game-state paths that have no scene tree, eg the
+			// headless save-game unit tests. instance is only assigned in _Ready.
+			if (instance == null) { return; }
+			instance.Charname.Text =$"[center][color={AttributesFontColor}]{playerdat.CharName.ToUpper()}[/color][/center]";
 			instance.CharClass.Text = $"[color={AttributesFontColor}]{playerdat.CharClassName.ToUpper()}[/color]";
 			instance.CharLevel.Text = $"[right][color={AttributesFontColor}]{playerdat.play_level}{GameStrings.GetOrdinal(playerdat.play_level).ToUpper()}[/color][/right]";
 			instance.STR.Text = $"[right][color={AttributesFontColor}]{playerdat.STR}[/color][/right]";

--- a/src/ui/uimanager_views.cs
+++ b/src/ui/uimanager_views.cs
@@ -426,6 +426,8 @@ namespace Underworld
 
         public static void RefreshWeightDisplay()
         {
+            // Called from playerdat inventory paths that also run headlessly.
+            if (uimanager.instance == null) { return; }
             uimanager.instance.WeightCapacity.Text = (playerdat.WeightCapacity / 0xA).ToString();
             Debug.Print($"player weight capacity is now {playerdat.WeightCapacity}");
         }

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -89,7 +89,7 @@ public class AutomapNotesRoundTripTests : System.IDisposable
         Underworld.LevArkLoader.lev_ark_file_data = rewritten;
         try
         {
-            var reloaded = new Underworld.automapnote(0, Underworld.UWClass.GAME_UW1);
+            var reloaded = new Underworld.automapnote(0);
             Assert.Single(reloaded.notes);
             Assert.Equal("INTEGRATION TEST NOTE", reloaded.notes[0].notetext);
             Assert.Equal(10, reloaded.notes[0].posX);

--- a/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/LevArkRoundTripTests.cs
@@ -358,4 +358,144 @@ public class LevArkRoundTripTests : IDisposable
         Assert.True(otherDiffs == 0,
             $"PlacePlayerInTile leaked byte changes outside slot 1 and target tile ({StartX},{StartY}): {otherDiffs} diffs, first at 0x{firstOtherDiff:X4}");
     }
+
+    // Regression guard for hankmorgan/UnderworldGodot#43.
+    //
+    // UW1 keeps animation overlays in their own ARK blocks (9..17), separate from
+    // the tilemap blocks (0..8). A moving door writes its object record into the
+    // tilemap and its overlay record into the overlay block, so serialising only
+    // the tilemap produces a save whose two halves disagree: a moving-door object
+    // with no matching overlay. The writer used to pass blocks 9..17 straight
+    // through from the source ARK, so any live overlay state was silently lost.
+    [Fact]
+    public void Uw1_LiveOverlayBlock_SurvivesFullSerializeAndReextract()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        Assert.True(LevArkLoader.LoadLevArkFileData(folder: "DATA"));
+
+        // Dispose() restores BasePath, _RES, lev_ark_file_data and dungeons, but not
+        // current_tilemap, so this test has to put that one back itself or it leaks
+        // into the rest of the serialised [Collection("UWClassState")] group. The try
+        // must start here, before any mutation: a throw from the constructor, the
+        // assertions or Serialize would otherwise skip the finally entirely.
+        UWTileMap origCurrent = UWTileMap.current_tilemap;
+        byte[] originalFile = LevArkLoader.lev_ark_file_data;
+        try
+        {
+            // The UWTileMap constructor loads the overlay block, as on level load.
+            UWTileMap.dungeons = new UWTileMap[UWTileMap.NO_OF_LEVELS];
+            UWTileMap.dungeons[0] = new UWTileMap(0);
+            UWTileMap.current_tilemap = UWTileMap.dungeons[0];
+
+            UWBlock liveOverlay = UWTileMap.dungeons[0].ovl_ark_block;
+            Assert.NotNull(liveOverlay);
+            Assert.NotNull(liveOverlay.Data);
+
+            // Keep the pristine tilemap bytes so we can prove below that writing the
+            // overlay block left the neighbouring level block untouched.
+            UWBlock tileBefore = LevArkLoader.LoadLevArkBlock(0);
+            Assert.NotNull(tileBefore?.Data);
+            byte[] tileExpected = (byte[])tileBefore.Data.Clone();
+
+            // Write a recognisable 6-byte overlay record into slot 0, standing in for
+            // the record animo.CreateAnimoLink writes when a door starts moving.
+            var expected = new byte[] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
+            for (int i = 0; i < expected.Length; i++) liveOverlay.Data[i] = expected[i];
+
+            byte[] rewritten = LevArkWriter.Serialize();
+            Assert.NotNull(rewritten);
+
+            LevArkLoader.lev_ark_file_data = rewritten;
+
+            UWBlock reloaded = LevArkLoader.LoadOverlayBlock(0);
+            Assert.NotNull(reloaded);
+            Assert.NotNull(reloaded.Data);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.True(expected[i] == reloaded.Data[i],
+                    $"Overlay byte {i} lost: expected 0x{expected[i]:X2}, got 0x{reloaded.Data[i]:X2}");
+            }
+
+            // The tilemap must still round-trip byte for byte. Checking only its
+            // length would pass even if the contents had shifted or been corrupted.
+            UWBlock tileAfter = LevArkLoader.LoadLevArkBlock(0);
+            Assert.NotNull(tileAfter?.Data);
+            int compareLen = Math.Min(tileExpected.Length, tileAfter.Data.Length);
+            Assert.True(compareLen >= UWTileMap.TileMapDataSize,
+                $"tilemap block 0 truncated to {tileAfter.Data.Length}");
+            for (int i = 0; i < compareLen; i++)
+            {
+                Assert.True(tileExpected[i] == tileAfter.Data[i],
+                    $"tilemap byte 0x{i:X4} changed: expected 0x{tileExpected[i]:X2}, got 0x{tileAfter.Data[i]:X2}");
+            }
+        }
+        finally
+        {
+            LevArkLoader.lev_ark_file_data = originalFile;
+            UWTileMap.current_tilemap = origCurrent;
+        }
+    }
+
+    // The overlay block is a fixed 384 bytes (64 slots x 6). Writing any other
+    // length would move every following block in the container.
+    [Fact]
+    public void Uw1_SerializeOverlayBlock_IsExactly384Bytes()
+    {
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+
+        Assert.Equal(384, LevArkWriter.SerializeOverlayBlock(null).Length);
+
+        var oversized = new UWBlock { Data = new byte[1000] };
+        Assert.Equal(384, LevArkWriter.SerializeOverlayBlock(oversized).Length);
+
+        var undersized = new UWBlock { Data = new byte[10] };
+        byte[] padded = LevArkWriter.SerializeOverlayBlock(undersized);
+        Assert.Equal(384, padded.Length);
+    }
+
+    // Ties the 384 constant to the real archive rather than to itself. Asserting
+    // the helper returns its own hard-coded size would keep passing even if the
+    // format assumption were wrong, so read the container's own offset table and
+    // confirm every UW1 overlay block really is that long.
+    [Fact]
+    public void Uw1_OverlayBlocksInRealArk_AreEach384Bytes()
+    {
+        string ark = Path.Combine(TestData.UW2GogRoot, "UW1", "DATA", "LEV.ARK");
+        Assert.True(File.Exists(ark), $"missing UW1 fixture: {ark}");
+        byte[] raw = File.ReadAllBytes(ark);
+
+        int blockCount = (int)Underworld.Loader.getAt(raw, 0, 16);
+        Assert.Equal(135, blockCount);
+
+        int OffsetOf(int i) => (int)Underworld.Loader.getAt(raw, 2 + i * 4, 32);
+
+        // Length is the gap to the next block that starts later in the file.
+        int LengthOf(int i)
+        {
+            int start = OffsetOf(i);
+            Assert.True(start > 0, $"block {i} unexpectedly absent");
+            int next = raw.Length;
+            for (int j = 0; j < blockCount; j++)
+            {
+                int o = OffsetOf(j);
+                if (o > start && o < next) next = o;
+            }
+            return next - start;
+        }
+
+        for (int lvl = 0; lvl < 9; lvl++)
+        {
+            Assert.True(384 == LengthOf(9 + lvl),
+                $"overlay block {9 + lvl} is {LengthOf(9 + lvl)} bytes, not 384");
+        }
+
+        // Sanity-check the sibling assumption too, so a layout change is loud.
+        for (int lvl = 0; lvl < 9; lvl++)
+        {
+            Assert.True(UWTileMap.TileMapDataSize == LengthOf(lvl),
+                $"tilemap block {lvl} is {LengthOf(lvl)} bytes, not {UWTileMap.TileMapDataSize}");
+        }
+    }
 }


### PR DESCRIPTION
> **Stacked on #61.** This branch is cut from `fix/headless-ui-null-guards`, so until #61 merges this PR shows two commits and the diff includes that one. Only `389bf6c` belongs to this PR. It is stacked because the save tests cannot run headlessly without #61's guards.

`LevArkWriter` dropped UW1's live animation-overlay state. `AssembleUW1Ark` replaced tilemaps, automap and notes from live state but never blocks 9..17, so the source archive's overlays were written instead.

That splits an in-flight animation in half. Starting a moving door calls `animo.CreateAnimoLink`, which stores the object link, tile and duration in `ovl_ark_block`, and only then sets the door object to item `0x1CF`. The object record lives in the tilemap block, which we serialise; the overlay record did not.

## DOS keeps the live record, so this is a divergence and not a policy difference

Measured on the sample save pair attached to #33, comparing each writer against pristine `DATA` rather than against each other, since the pairs are separate play sessions:

| overlay block 9 | versus pristine `DATA` |
| --- | --- |
| DOS-created moving-door save | differs in 4 bytes: `link=1014, duration=4, tile=(33,8)` |
| port-created moving-door save | **byte-identical to pristine** |

## The cost is visible

Loading the port's `LEV.ARK` in real DOS `UW.EXE` renders the doorway as a **closed door**, where the DOS save shows it open mid-swing. The animation is simply lost.

## And the fix is faithful

Re-serialising that DOS save through this writer produces a container **byte-identical to the original**, all 294960 bytes. For this state that is a stronger statement than "it loads".

## Scope and container safety

Verified against the real archive rather than assumed: `DATA/LEV.ARK` declares 135 blocks, and parsing its offset table gives 384 bytes for each of blocks 9..17 and `0x7C08` for each of 0..8. Writing a fixed 384 cannot move a following block, and the writer rebuilds every output offset from the substituted lengths anyway.

UW1 proper only. UW2 has no separate overlay block, and the demo reads overlays from `LEVEL13.ANX` rather than from the ARK.

Both replacement loops are bounded by `Math.Min(NO_OF_LEVELS, dungeons.Length)`, since `dungeons` is a public static array whose length need not agree with `NO_OF_LEVELS`.

`SerializeOverlayBlock` truncates oversized buffers and zero-pads short ones rather than throwing, because `LEV.ARK` is written after `DESC`, `PLAYER.DAT` and `BGLOBALS.DAT` and aborting mid-save would leave a half-updated slot. Oversized input writes a warning to stderr, since it means an upstream invariant broke.

## Tests

42 pass. `Uw1_LiveOverlayBlock_SurvivesFullSerializeAndReextract` is confirmed load-bearing, failing with `Overlay byte 0 lost: expected 0xA0, got 0x80` when only the replacement loop is disabled. It also compares the neighbouring tilemap block byte for byte to prove the container did not shift. `Uw1_OverlayBlocksInRealArk_AreEach384Bytes` parses the shipped archive, so the size constant is tied to the format rather than to itself.

## What this is not

**It does not fix #43.** An earlier version of this description presented the dropped overlay as a strong candidate cause for that hang. That was an untested claim, and bisecting in real DOS has since refuted it: `PLAYER.DAT` is the culprit, because the port writes an inventory chain head of 1 while emitting no inventory records and DOS follows it past the end of the file. Narrowed to a single byte, with the runs on #43. The port's `LEV.ARK` loads there even without the overlay record.

So please take this on its own merits: live state was being dropped, and mid-animation saves were internally inconsistent.