### PR TITLE
fix(save): write UW1's inventory count and head so DOS accepts port saves

### DIFF
--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -251,38 +251,41 @@ the field, and `InitEmptyPlayer` sets `DetailLevel = 3` for UW1.
 UW2 storage offset is TBD; the accessor short-circuits to 3 for
 UW2 to avoid touching unknown bytes.
 
-### 5. pdat[0xD3] = ShadeCutOff (shade-table index)
+### 5. pdat[0xD3] is the inventory record count, not ShadeCutOff
 
-DOS UW.EXE chargen writes a non-zero value at `pdat[0xD3]` and the
-Journey-Onward path validates it. Port chargen left this byte at `0`;
-on DOS load, that 0 sent UW.EXE into a non-returning loop in the
-load sequence (player UI never appeared, game hung after the "You
-enter the Abyss" splash).
+DOS UW.EXE chargen writes a non-zero value at `pdat[0xD3]`. Port chargen left it at
+`0`, and on DOS load that sent UW.EXE into a non-returning loop after the "You reenter
+the Abyss" splash. The port then wrote a constant `3`, which stopped that particular
+hang.
 
-**Semantics** (per @hankmorgan, PR #33 review, confirmed by
-disassembly): the byte is the **shade-table index** — the global
-named `ShadeCutOff_dseg_67d6_8622` in the UW2 disassembly, written
-by `ovr142_0` (`OpenAndApplyShadesDat_ovr142_0` in UW2; same
-function in UW1 at `UW1_asm.asm:385926-386218`). Indexes into
-`shades.dat`: `0=Darkness, 1=Burning Match, 2=Candlelight,
-3=Light, 4=Magic Lantern, 5=Night Vision, 6=Daylight, 7=Sunlight`.
-SHADES.DAT is exactly 96 bytes (8 entries × 12 bytes); valid
-range is `0..7`. UW2 stores it at `pdat[0x37F]`. Both format-doc
-projects had it labelled incorrectly as "no of items+1".
+**Earlier reading, now believed wrong.** This section used to identify the byte as
+`ShadeCutOff`, a shade-table index, per @hankmorgan on the PR #33 review. DOS reads the
+shade index from somewhere else: the high nibble of player data `+0x63`.
 
-The function does NOT bound-check the input — passing `8` reads
-12 bytes off EOF; DOS tolerates because subsequent gameplay
-overwrites the shading params before they're rendered. An
-earlier diagnostic write of `0x08` therefore "worked" by
-accident. The correct chargen value is `3` (Light); see
-`InitEmptyPlayer`.
+```
+mov  bx, PlayerDataPTR_dseg_5c99_7270
+mov  al, [bx+63h]
+mov  ah, 0
+and  ax, 0F0h
+sar  ax, 4
+push ax
+call j_OpenAndApplyShadesDat_ovr142_0
+```
 
-The port already tracks an analogous `playerdat.lightlevel`
-accessor at `pdat[0x64]` bits 4-7 (different storage). Long-term:
-keep these in sync at light-source change events. Short-term:
-`InitEmptyPlayer` (UW1) writes `pdat[0xD3] = 0x03` (Light) at
-chargen; replacing the literal with a derived-from-lightlevel
-expression is a follow-up.
+**Current reading.** `0xD3..0xD4` is a 16-bit count of inventory records, stored as
+records plus one. Three DOS-created saves with empty inventories all hold `1` there and
+are 312 bytes, ending at `InventoryPtr`. Varying only that byte in a port save holding
+six records, loaded in real DOS: `3` hangs, `6` gives `Error code A003`, `7` loads with
+the inventory intact.
+
+This is inference from behaviour and from sample files. The instruction that reads
+`0xD3` has not been found in the disassembly, and the format notes in
+`Guide to the Ultima Underworlds.md` hedge the field width as "int16 (I think)". The
+high byte is zero in every sample available, so the width is not established by the
+samples either.
+
+`PlayerDatWriter` derives the value on save, so the chargen constant no longer reaches
+the file.
 
 ### 6. Avatar self-link `pdat[0xDB-0xDC] = 0x0040` (link = 1)
 

--- a/src/player/playerdatainit.cs
+++ b/src/player/playerdatainit.cs
@@ -194,21 +194,12 @@ namespace Underworld
 
             if (_RES != GAME_UW2)
             {
-                // pdat[0xD3] = ShadeCutOff (shade-table index, per @hankmorgan
-                // on PR #33: the global is named ShadeCutOff_dseg_67d6_8622
-                // in the UW2 disasm, set by OpenAndApplyShadesDat_ovr142_0;
-                // the UW1 equivalent is ovr142_0 at UW1_asm.asm:385926-386218).
-                // Indexes shades.dat: 0=Darkness, 1=Burning Match,
-                // 2=Candlelight, 3=Light, 4=Magic Lantern, 5=Night Vision,
-                // 6=Daylight, 7=Sunlight. SHADES.DAT is exactly 96 bytes
-                // (8 entries × 12 bytes); valid range 0..7. DOS chargen
-                // default is 3 (Light). The function does NOT bound-check
-                // the input — passing 8 reads off EOF; DOS tolerates
-                // because subsequent gameplay overwrites the shading params
-                // before they're rendered. Without ANY value here (port
-                // default 0 = Darkness; functions but DOS Journey-Onward
-                // hangs in some load paths) DOS won't load. 3 is the
-                // semantically correct chargen value.
+                // 0xD3..0xD4 is the inventory record count, records plus one, which
+                // PlayerDatWriter derives on save. This chargen value therefore no
+                // longer reaches the file; it is left as 3 so in-memory behaviour is
+                // unchanged. It was previously identified as ShadeCutOff, but DOS reads
+                // the shade index from the high nibble of player data +0x63. See
+                // docs/save-architecture.md section 5.
                 SetAt(0xD3, 0x03);
             }
 

--- a/src/savegame/PlayerDatWriter.cs
+++ b/src/savegame/PlayerDatWriter.cs
@@ -39,6 +39,12 @@ namespace Underworld
         private const int Uw1BpOffsetBase = 0x10E;
         private const int Uw1BpCount = 8;
 
+        // DOS reads the number of inventory records from this 16-bit field, as
+        // "records + 1". Every DOS-created UW1 save carries N+1 here; the port
+        // wrote a constant 3, which is what made DOS walk a chain longer than it
+        // had read. See issue #44.
+        private const int Uw1InventoryCountOffset = 0xD3;
+
         public static byte[] Serialize()
         {
             if (Loader._RES == Loader.GAME_UW2)
@@ -94,16 +100,14 @@ namespace Underworld
             }
 
             int newLast = order.Count;
-            // DOS UW.EXE hangs at "You reenter the Abyss..." when PLAYER.DAT
-            // ends exactly at InventoryPtr (0x138) with no inventory slots
-            // emitted. Padding to at least one zero slot (file >= 0x140) is
-            // sufficient to unstick the load path — verified empirically
-            // against UW.EXE under js-dos. A fresh port chargen with all
-            // BP0..BP7 + paperdoll pointers = 0 (no items) used to produce a
-            // 312-byte file; bumping the floor to (InventoryPtr + 8) makes it
-            // 320 bytes and DOS loads cleanly.
-            int slotsToEmit = Math.Max(newLast, 1);
-            int fileLen = playerdat.InventoryPtr + slotsToEmit * 8;
+            // No padding floor. The old one emitted a spare zero record whenever
+            // the inventory was empty, to stop DOS hanging at "You reenter the
+            // Abyss...". That hang was really the head at PlayerObjectStoragePTR+6
+            // being written as 1 with nothing to point at, and the spare record
+            // only gave the bad head somewhere harmless to land. With the head
+            // written correctly a genuinely empty inventory is 312 bytes, which is
+            // byte for byte what DOS itself writes. See issue #44.
+            int fileLen = playerdat.InventoryPtr + newLast * 8;
             byte[] plain = new byte[fileLen];
             Array.Copy(playerdat.pdat, plain, playerdat.InventoryPtr);
 
@@ -203,8 +207,23 @@ namespace Underworld
                 SetSlotPtr(plain, off, newSlot);
             }
 
+            // Derived fields last, so nothing above can overwrite them.
+            SetInventoryCount(plain, newLast + 1);
+
             byte seed = plain[0];
             return playerdat.EncryptDecryptUW1(plain, seed);
+        }
+
+        /// <summary>
+        /// Writes DOS's inventory record count, which is the number of emitted
+        /// records plus one. Sixteen-bit little-endian at 0xD3, in the plaintext
+        /// region, so it is unaffected by the XOR pass over bytes 1..0xD2.
+        /// </summary>
+        private static void SetInventoryCount(byte[] plain, int count)
+        {
+            if (Uw1InventoryCountOffset + 1 >= plain.Length) return;
+            plain[Uw1InventoryCountOffset]     = (byte)(count & 0xFF);
+            plain[Uw1InventoryCountOffset + 1] = (byte)((count >> 8) & 0xFF);
         }
 
         // Hard cap on emitted slots — defends against a pathological source

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -174,9 +174,17 @@ namespace Underworld
         {
             int linkOff = playerdat.PlayerObjectStoragePTR + 6;
             if (linkOff + 1 >= serialised.Length) return serialised;
-            // Set link bits 6-15 = 1, preserve owner bits 0-5 of byte 6.
-            serialised[linkOff]     = (byte)((serialised[linkOff] & 0x3F) | 0x40);
-            serialised[linkOff + 1] = 0;
+
+            // The head must be 0 when no inventory records were emitted. Writing 1
+            // unconditionally told DOS to walk a chain into a file that ends at
+            // InventoryPtr, which hung it at "You reenter the Abyss...". DOS itself
+            // writes 0 for an empty inventory. See issue #43.
+            int records = (serialised.Length - playerdat.InventoryPtr) / 8;
+            int head = records > 0 ? 1 : 0;
+
+            // link occupies bits 6-15 of the little-endian word; owner is bits 0-5.
+            serialised[linkOff]     = (byte)((serialised[linkOff] & 0x3F) | ((head << 6) & 0xC0));
+            serialised[linkOff + 1] = (byte)((head >> 2) & 0xFF);
             return serialised;
         }
 

--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -175,12 +175,21 @@ namespace Underworld
             int linkOff = playerdat.PlayerObjectStoragePTR + 6;
             if (linkOff + 1 >= serialised.Length) return serialised;
 
-            // The head must be 0 when no inventory records were emitted. Writing 1
-            // unconditionally told DOS to walk a chain into a file that ends at
-            // InventoryPtr, which hung it at "You reenter the Abyss...". DOS itself
+            // UW1 only. The head must be 0 when no inventory records were emitted;
+            // writing 1 unconditionally told DOS to walk a chain into a file that ends
+            // at InventoryPtr, which hung it at "You reenter the Abyss...". DOS itself
             // writes 0 for an empty inventory. See issue #43.
-            int records = (serialised.Length - playerdat.InventoryPtr) / 8;
-            int head = records > 0 ? 1 : 0;
+            //
+            // UW2 keeps the previous unconditional 1. Its writer still takes the legacy
+            // straight-copy path, PlayerDatWriter.Serialize says so, and its DOS
+            // invariants are unverified, so deriving a head from a record count computed
+            // against a different InventoryPtr would change a format we cannot test.
+            int head = 1;
+            if (UWClass._RES != UWClass.GAME_UW2)
+            {
+                int records = (serialised.Length - playerdat.InventoryPtr) / 8;
+                head = records > 0 ? 1 : 0;
+            }
 
             // link occupies bits 6-15 of the little-endian word; owner is bits 0-5.
             serialised[linkOff]     = (byte)((serialised[linkOff] & 0x3F) | ((head << 6) & 0xC0));

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -140,6 +140,41 @@ public class PlayerDatRoundTripTests : IDisposable
     //   - out-of-range slot reference throwing IndexOutOfRange
     // -------------------------------------------------------------------------
 
+    [Fact]
+    public void Uw1Serialize_NestedContainers_CountCoversEveryEmittedRecord()
+    {
+        // The count DOS reads must cover records emitted recursively, not just the
+        // top-level chain, or DOS reads too few and follows a link into memory it
+        // never read. A container inside a container inside the backpack.
+        SetupUw1WithPdat();
+        WriteSlot(slot: 1, item_id: 128, is_quant: false, link: 2, next: 0); // sack
+        WriteSlot(slot: 2, item_id: 128, is_quant: false, link: 3, next: 0); // sack inside it
+        WriteSlot(slot: 3, item_id: 143, is_quant: false, link: 0, next: 0); // item inside that
+        SetBp0(1);
+
+        byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
+        byte[] plain = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        int records = (encrypted.Length - Underworld.playerdat.InventoryPtr) / 8;
+        Assert.Equal(3, records);
+        Assert.Equal(records + 1, plain[0xD3] | (plain[0xD4] << 8));
+
+        // And the emitted chain must be walkable within the count: every next/link
+        // that is non-zero has to name a slot the file actually contains.
+        for (int slot = 1; slot <= records; slot++)
+        {
+            int o = Underworld.playerdat.InventoryPtr + (slot - 1) * 8;
+            int next = ((plain[o + 4] | (plain[o + 5] << 8)) >> 6) & 0x3FF;
+            int link = ((plain[o + 6] | (plain[o + 7] << 8)) >> 6) & 0x3FF;
+            bool isQuant = ((plain[o] | (plain[o + 1] << 8)) & 0x8000) != 0;
+            Assert.True(next <= records, $"slot {slot} next={next} beyond {records} records");
+            if (!isQuant)
+            {
+                Assert.True(link <= records, $"slot {slot} link={link} beyond {records} records");
+            }
+        }
+    }
+
     private static void SetupUw1WithPdat()
     {
         Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -37,19 +37,25 @@ public class PlayerDatRoundTripTests : IDisposable
         byte[] decrypted = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
 
         // File length mirrors the load loop in playerdatutil.cs:Load: slot i lives at
-        // PTR = InventoryPtr + (i-1)*8, so N populated slots occupy N*8 bytes past InventoryPtr.
-        // Floor of one zero slot is enforced by SerializeUw1Canonical to avoid the
-        // DOS UW.EXE Journey-Onward hang when PLAYER.DAT ends exactly at InventoryPtr.
-        int slotsExpected = Math.Max(Underworld.PlayerDatWriter.LastPopulatedInventorySlot(), 1);
+        // PTR = InventoryPtr + (i-1)*8, so N emitted slots occupy N*8 bytes past
+        // InventoryPtr. No padding floor: an empty inventory is exactly InventoryPtr
+        // bytes, which is what DOS itself writes.
+        int slotsExpected = Underworld.PlayerDatWriter.LastPopulatedInventorySlot();
         int expectedLen = Underworld.playerdat.InventoryPtr + slotsExpected * 8;
         Assert.Equal(expectedLen, decrypted.Length);
-        // Compare only the populated header region; padded trailing slot is
-        // zeros and is not present in the in-memory pdat at the same offset.
+
+        // The header is copied verbatim EXCEPT the inventory count at 0xD3..0xD4,
+        // which is derived from the number of emitted records rather than carried
+        // over from memory. Skipping it here rather than loosening the comparison,
+        // so any other header drift still fails.
+        const int countOffset = 0xD3;
         for (int i = 0; i < Underworld.playerdat.InventoryPtr; i++)
         {
+            if (i == countOffset || i == countOffset + 1) continue;
             Assert.True(originalPdat[i] == decrypted[i],
                 $"Byte mismatch at 0x{i:X4}: expected 0x{originalPdat[i]:X2}, got 0x{decrypted[i]:X2}");
         }
+        Assert.Equal(slotsExpected + 1, decrypted[countOffset] | (decrypted[countOffset + 1] << 8));
     }
 
     [Fact]
@@ -265,22 +271,30 @@ public class PlayerDatRoundTripTests : IDisposable
     }
 
     [Fact]
-    public void Uw1Serialize_EmptyInventory_PadsToAtLeastOneSlot()
+    public void Uw1Serialize_EmptyInventory_IsExactlyInventoryPtrBytes()
     {
-        // DOS UW.EXE hangs at "You reenter the Abyss..." when PLAYER.DAT
-        // ends exactly at InventoryPtr (0x138) with zero inventory slots.
-        // A fresh port chargen with no items in BP0..BP7 + paperdoll used
-        // to produce a 312-byte file. Verified empirically against UW.EXE
-        // under js-dos that one zero slot (file >= 0x140 = 320 bytes) is
-        // sufficient to unstick the load path.
+        // An empty inventory is InventoryPtr bytes, 312, which is byte for byte what
+        // DOS writes. This used to be padded to 320 to stop DOS hanging at
+        // "You reenter the Abyss...", but the hang was really the head at
+        // PlayerObjectStoragePTR+6 being written as 1 with nothing to point at; the
+        // spare record only gave that bad head somewhere harmless to land. Verified
+        // in real UW.EXE under js-dos while investigating issue #44.
         SetupUw1WithPdat();
         // Leave BP0..BP7 + paperdoll all zero — no items anywhere.
 
         byte[] encrypted = Underworld.PlayerDatWriter.Serialize();
         Assert.NotNull(encrypted);
-        Assert.True(
-            encrypted.Length >= Underworld.playerdat.InventoryPtr + 8,
-            $"empty-inventory PLAYER.DAT must be at least {Underworld.playerdat.InventoryPtr + 8} bytes " +
-            $"to unstick DOS UW.EXE Journey-Onward; got {encrypted.Length}");
+        Assert.Equal(Underworld.playerdat.InventoryPtr, encrypted.Length);
+
+        byte[] plain = Underworld.playerdat.EncryptDecryptUW1(encrypted, encrypted[0]);
+
+        // Count is records + 1, so 1 for an empty inventory. DOS uses it as the number
+        // of records to read; too small and it walks a chain into memory it never read.
+        Assert.Equal(1, plain[0xD3] | (plain[0xD4] << 8));
+
+        // Head must be 0 with no records. 0xDB..0xDC is the word holding it in bits
+        // 6..15; the low six bits are the owner field and are not asserted here.
+        int head = (plain[0xDB] | (plain[0xDC] << 8)) >> 6;
+        Assert.Equal(0, head);
     }
 }

--- a/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/PlayerDatRoundTripTests.cs
@@ -105,15 +105,17 @@ public class PlayerDatRoundTripTests : IDisposable
     }
 
     [Fact]
-    public void Uw1InitEmptyPlayer_PdatD3IsShadesDatLightIndex()
+    public void Uw1InitEmptyPlayer_WritesThreeAtD3()
     {
         Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
         Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
         Underworld.playerdat.InitEmptyPlayer("TestGronk");
 
-        // pdat[0xD3] = ShadeCutOff (per Hank/RE on PR #33). Valid range
-        // 0..7 indexes shades.dat (96 bytes / 12 bytes per entry).
-        // Chargen default is 3 = Light. See docs/save-architecture.md §5.
+        // Records what chargen puts at 0xD3, not what the byte means. It was named
+        // ShadeCutOff and given the value 3, but DOS reads the shade index from the high
+        // nibble of player data +0x63, and every DOS-created save inspected so far holds
+        // the inventory record count plus one at 0xD3. PlayerDatWriter now derives that
+        // value on save, so this in-memory 3 no longer reaches the file.
         Assert.Equal(0x03, Underworld.playerdat.pdat[0xD3]);
     }
 

--- a/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
+++ b/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
@@ -129,6 +129,37 @@ public class SaveGameOrchestratorTests : IDisposable
     // UW1 tests
     // -------------------------------------------------------------------------
 
+    /// <summary>
+    /// The two fields DOS derives from the inventory, checked on the file the
+    /// orchestrator actually writes. Serialize() alone is not enough: the head is
+    /// patched afterwards in SaveGame, so a test that only calls the writer passes
+    /// whatever was already in memory and never exercises the patch.
+    /// </summary>
+    [Fact]
+    public void Save_Uw1_EmptyInventory_WritesCountOneAndHeadZero()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(1, "inventory fields");
+
+        byte[] raw = File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE1", "PLAYER.DAT"));
+        byte[] plain = playerdat.EncryptDecryptUW1(raw, raw[0]);
+
+        // No records emitted, so the file ends at InventoryPtr, exactly as DOS writes it.
+        Assert.Equal(playerdat.InventoryPtr, raw.Length);
+
+        // DOS reads this as the number of records to read: records + 1.
+        Assert.Equal(1, plain[0xD3] | (plain[0xD4] << 8));
+
+        // Head lives in bits 6..15 of the word at PlayerObjectStoragePTR+6. It must be
+        // 0 with no records; writing 1 sent DOS chasing a chain into a file that ends
+        // immediately, which is the hang in issue #43.
+        int linkOff = playerdat.PlayerObjectStoragePTR + 6;
+        int head = (plain[linkOff] | (plain[linkOff + 1] << 8)) >> 6;
+        Assert.Equal(0, head);
+    }
+
     [Fact]
     public void Save_Uw1_WritesExpectedFilesExceptScdArk()
     {

--- a/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
+++ b/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
@@ -226,6 +226,32 @@ public class SaveGameOrchestratorTests : IDisposable
     // UW2 tests — use real SAVE0 fixture
     // -------------------------------------------------------------------------
 
+    /// <summary>
+    /// UW2 must keep the head it had before the UW1 inventory fix. Its writer still
+    /// uses the legacy straight-copy path and its DOS invariants are unverified, so the
+    /// records-derived rule is deliberately UW1-only. Without this, the UW1 fix silently
+    /// rewrote UW2's avatar link, because InventoryPtr differs between the formats
+    /// (0x3E3 versus 0x138) and the derived record count would be computed against the
+    /// wrong base.
+    /// </summary>
+    [Fact]
+    public void Save_Uw2_PlayerObjectLinkUnchangedByUw1InventoryRule()
+    {
+        SetupUw2State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(1, "uw2 head");
+
+        byte[] raw = File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE1", "PLAYER.DAT"));
+        int linkOff = playerdat.PlayerObjectStoragePTR + 6;
+        Assert.True(linkOff + 1 < raw.Length, "UW2 PLAYER.DAT too short to hold the link");
+
+        // UW2 pdat is encrypted differently, so read the raw bytes: the rule under test
+        // writes them directly either way.
+        int head = (raw[linkOff] | (raw[linkOff + 1] << 8)) >> 6;
+        Assert.Equal(1, head);
+    }
+
     [Fact]
     public void Save_Uw2_WritesAllFiveFiles()
     {


### PR DESCRIPTION
Port saves with more than a couple of inventory items fail to load in DOS. Two values in
UW1 `PLAYER.DAT` describe the inventory and the port was writing both wrongly.

The word at `0xD3` holds the number of inventory records plus one. Port-created
characters kept the chargen value of 3 there, since `InitEmptyPlayer` writes it and the
writer copied the header through unchanged. Bits 6 to 15 of the word at
`PlayerObjectStoragePTR + 6` hold the head of the inventory chain, and `SaveGame` set it
to 1 whether or not any records had been written, so a save with nothing in the inventory
still pointed at a record.

## Evidence

Varying only `0xD3` in one port save holding six records, loaded in real DOS `UW.EXE`:

| value | result |
| --- | --- |
| 3, what the save had | hangs on "You reenter the Abyss..." |
| 6 | `Underworld can no longer run.  Error code A003.` |
| 7, records plus one | loads, inventory intact |

A003 is the symptom reported in #44, and the hang is #43.

Three DOS-created saves attached to #44 and #33, all with empty inventories, hold 1 in
that word and are 312 bytes, ending at `InventoryPtr` with no padding.

I have not found the instruction that reads `0xD3`, so the record count reading is
inference from those samples and from the table above rather than something I can point
at in the disassembly. `Guide to the Ultima Underworlds.md` describes the field as a
count plus one and hedges the width as "int16 (I think)". The high byte is zero in every
sample I have, so the width is not settled by the samples either.

## Changes

`PlayerDatWriter` writes `records + 1` at `0xD3`. `SaveGame` writes the head as 0 when no
records were emitted. The 320-byte floor is removed: it masked the bad head by giving it a
zero record to land on, and is unnecessary once the head is right. An empty inventory is
now 312 bytes, matching the DOS saves above.

The head rule is UW1 only. UW2 still goes through the legacy path that
`PlayerDatWriter.Serialize` describes as unverified against DOS, so this leaves its
behaviour as it was. The new UW2 test proves that preservation, not correctness.

## pdat[0xD3] and ShadeCutOff

A comment in `playerdatainit.cs` identifies `0xD3` as `ShadeCutOff` and writes 3 into it.
DOS reads the shade index from the high nibble of player data `+0x63`:

```
mov  bx, PlayerDataPTR_dseg_5c99_7270
mov  al, [bx+63h]
mov  ah, 0
and  ax, 0F0h
sar  ax, 4
push ax
call j_OpenAndApplyShadesDat_ovr142_0
```

The chargen write is left in place, since the writer now derives the count on save, but
the comment, the docs section and a test name all asserted the old reading and have been
updated to describe it as superseded.

## Testing

45 unit tests. Removing each part of the change fails tests: the padding floor three, the
count write four, the head rule one, the UW1 gate one.

In real DOS `UW.EXE`, by hand:

- a save from this branch with an empty inventory, 312 bytes, loads
- a save from this branch with seven records including a bag and its contents, 368 bytes,
  loads with the items intact
- the equivalent save from before the change hangs

The port also reloads its own saves, checked with the seven-record save. The port works
out how much inventory a file holds from its length, and it has not written a 312-byte
file since `91dc1d7` added the floor. The fixture attached to #44 is one, from a build
before that.

Closes #43

For #44, this fixes the reported A003 and I can reproduce it on demand by setting the
count one short. The acceptance criteria there ask for the validation path in the
disassembly, which I have not found, so close it or leave it open as you prefer.
