### PR TITLE
fix(automap): save note deletion, and match DOS on note entry

### DIFF
--- a/docs/save-architecture.md
+++ b/docs/save-architecture.md
@@ -87,10 +87,16 @@ data at the recorded offsets. Loader reads the per-block compression flag
 and dispatches — flag `0 == UW2_NOCOMPRESSION` is valid.
 
 **`lev.ark` container (UW1).** Simpler: `[Int16 count][offsets×N]` then block
-data. No per-block metadata; the caller supplies `targetDataLen`. The writer
-computes each block's length as `offset[i+1] - offset[i]` (or `fileLen -
-offset[i]` for the last present block) so non-tilemap blocks (overlay,
-texmap, automap, notes) round-trip correctly.
+data. No per-block metadata; the caller supplies `targetDataLen`.
+`LevArkLoader.UW1BlockLength` measures a block from the offset table so
+non-tilemap blocks (overlay, texmap, automap, notes) round-trip correctly.
+
+A block runs to the *smallest* offset larger than its own, whichever block
+that belongs to. It is not `offset[i+1] - offset[i]`: DOS writes blocks in
+whatever order it likes, so the block that follows one in the file often has
+a lower index. Assuming index order is what caused the corruption reported on PR #71, where a note
+block was measured as 15312 bytes instead of 864 and the blocks after it were
+drawn on the automap as text.
 
 **`scd.ark`.** UW2-only. 16-block UW2-format ARK container. Because the
 port's SCD loader is lazy and null-sets blocks after processing, there is no

--- a/main.cs
+++ b/main.cs
@@ -1013,7 +1013,11 @@ public partial class main : Node3D
 							uimanager.StopWritingAutomapNote(false);
 							break;
 						case Key.Escape:
-							uimanager.StopWritingAutomapNote(true);
+							// DOS commits on Escape exactly as on Enter: both jump to the
+							// same routine, which copies the typed string into the note
+							// (UW1_asm.asm:310176-310185, target ovr092_BA1 at :310359).
+							// Nothing in the original cancels a note part way through.
+							uimanager.StopWritingAutomapNote(false);
 							break;
 						case Key.Backspace:
 							{

--- a/main.cs
+++ b/main.cs
@@ -1027,12 +1027,19 @@ public partial class main : Node3D
 								break;
 							}
 
-						default://TODO: Default is too broad. must exclude special chars
+						default:
 							{
+								// DOS accepts 0x20 to 0x7A only and upper-cases as it goes.
+								// Appending the raw key let a note keep lower-case text, which
+								// hangs UW1 when the automap is opened, and let a non-text key
+								// append a NUL that reads back as an empty note.
+								var c = automapnote.NormaliseNoteText(((char)keyinput.Unicode).ToString());
+								if (c.Length == 0) break;
+
 								var text = uimanager.currentmapnote.notetext;
-								if (text.Length < 0x30)//allowing space for \0 ending.
+								if (text.Length < automapnote.MaxNoteLength)
 								{
-									text += ((char)keyinput.Unicode).ToString();
+									text += c;
 									uimanager.currentmapnote.notetext = text;
 									uimanager.currentmapnote.textlabel.Text = $"[color=#331C13]{text}[/color]";
 								}

--- a/src/World/automapnotes.cs
+++ b/src/World/automapnotes.cs
@@ -138,6 +138,32 @@ namespace Underworld
         /// Int16 posX at offset 0x32, Int16 posY at offset 0x34.
         /// Returns an empty byte array when there are no notes.
         /// </summary>
+        /// <summary>
+        /// The longest note DOS will accept. Its entry loop stops inserting once the
+        /// index passes 0x2D, so 46 characters is the maximum.
+        /// </summary>
+        public const int MaxNoteLength = 46;
+
+        /// <summary>
+        /// Reduces a note to what DOS can store and draw. Both games accept only
+        /// 0x20 to 0x7A on entry and upper-case as they go, so a note holding anything
+        /// else was never reachable in the original. A lower-case note hangs UW1 when
+        /// the automap is opened.
+        /// </summary>
+        public static string NormaliseNoteText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return "";
+
+            var sb = new System.Text.StringBuilder(text.Length);
+            foreach (char c in text)
+            {
+                if (c < 0x20 || c > 0x7A) continue;
+                sb.Append(c >= 'a' && c <= 'z' ? (char)(c - 0x20) : c);
+                if (sb.Length == MaxNoteLength) break;
+            }
+            return sb.ToString();
+        }
+
         public byte[] Serialize()
         {
             if (notes == null || notes.Count == 0) return System.Array.Empty<byte>();
@@ -147,7 +173,7 @@ namespace Underworld
             {
                 int recordStart = i * 54;
                 var n = notes[i];
-                string text = n.notetext ?? "";
+                string text = NormaliseNoteText(n.notetext);
 
                 int copyLen = System.Math.Min(text.Length, 0x31);
                 for (int c = 0; c < copyLen; c++)

--- a/src/World/automapnotes.cs
+++ b/src/World/automapnotes.cs
@@ -52,20 +52,18 @@ namespace Underworld
             else
             {
                 int blockno;
-                int noOfPossibleBlocks;
                 int thisAddress;
-                int startblock;
+                // Only UW2 measures by scanning its own note blocks, so only UW2 needs to know
+                // where they start and how many there are.
+                const int uw2NoteBlocks = 80;
+                const int uw2FirstNoteBlock = 240;
                 if (_RES == GAME_UW2)
                 {
-                    blockno = 240 + LevelNo;
-                    noOfPossibleBlocks = 80;
-                    startblock = 240;
+                    blockno = uw2FirstNoteBlock + LevelNo;
                 }
                 else
                 {
                     blockno = LevelNo + 36;
-                    noOfPossibleBlocks = 9;
-                    startblock = 36;
                 }
                 thisAddress = GetBlockAddress(blockno, LevArkLoader.lev_ark_file_data);
                 if (thisAddress == 0)
@@ -73,25 +71,41 @@ namespace Underworld
                     //no data
                     return;
                 }
-                var EOF = LevArkLoader.lev_ark_file_data.GetUpperBound(0) + 1;//end of file is the max length.
-                for (int i = 0; i < noOfPossibleBlocks; i++)
+
+                int blockLen;
+                if (_RES == GAME_UW2)
                 {
-                    if (i != LevelNo)
+                    var EOF = LevArkLoader.lev_ark_file_data.GetUpperBound(0) + 1;//end of file is the max length.
+                    for (int i = 0; i < uw2NoteBlocks; i++)
                     {
-                        var addressToCheck = GetBlockAddress(startblock + i, LevArkLoader.lev_ark_file_data);
-                        if (addressToCheck > thisAddress)
-                        {//block is after the current one.
-                            if (addressToCheck < EOF)
-                            {
-                                EOF = addressToCheck; //try and get the nearest next address to the current block
+                        if (i != LevelNo)
+                        {
+                            var addressToCheck = GetBlockAddress(uw2FirstNoteBlock + i, LevArkLoader.lev_ark_file_data);
+                            if (addressToCheck > thisAddress)
+                            {//block is after the current one.
+                                if (addressToCheck < EOF)
+                                {
+                                    EOF = addressToCheck; //try and get the nearest next address to the current block
+                                }
                             }
                         }
                     }
+                    blockLen = EOF - thisAddress;
+                }
+                else
+                {
+                    // Measure against every block, not just the nine note blocks. The block that
+                    // physically follows this one is often of another type, and stopping at the
+                    // nearest note block runs straight through it. In the save reported on pull
+                    // request #71, block 36 is followed by automap block 29, so this used to read
+                    // 9056 bytes and offer 167 note slots where the block holds 864 bytes and 16
+                    // notes. Whatever those blocks contain is then drawn as text on the map.
+                    blockLen = LevArkLoader.UW1BlockLength(
+                        LevArkLoader.lev_ark_file_data, blockno,
+                        (int)getAt(LevArkLoader.lev_ark_file_data, 0, 16));
                 }
 
-
-
-                if (DataLoader.LoadUWBlock(LevArkLoader.lev_ark_file_data, blockno, EOF - thisAddress, out UWBlock block))
+                if (DataLoader.LoadUWBlock(LevArkLoader.lev_ark_file_data, blockno, blockLen, out UWBlock block))
                 {
                     var addptr = 0;
                     int counter = 0;

--- a/src/World/automapnotes.cs
+++ b/src/World/automapnotes.cs
@@ -164,6 +164,19 @@ namespace Underworld
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Whether a newly typed note is worth keeping.
+        ///
+        /// DOS keeps a note of nothing but spaces, because it only tests the first byte of
+        /// the buffer. Such a note draws as nothing, so a player cannot see it to erase it.
+        /// The port declines to create one. Notes already present in a save still load and
+        /// are written back unchanged, so a DOS save carrying one is not altered.
+        /// </summary>
+        public static bool IsKeepableNewNote(string text)
+        {
+            return !string.IsNullOrWhiteSpace(NormaliseNoteText(text));
+        }
+
         public byte[] Serialize()
         {
             if (notes == null || notes.Count == 0) return System.Array.Empty<byte>();

--- a/src/loaders/levarkloader.cs
+++ b/src/loaders/levarkloader.cs
@@ -13,6 +13,59 @@ namespace Underworld
         /// </summary>
         public static byte[] lev_ark_file_data;
 
+        /// <summary>
+        /// How many bytes block <paramref name="blockNo"/> occupies in a UW1 LEV.ARK. Returns 0
+        /// for a block the table records as absent, and for anything it cannot measure.
+        ///
+        /// UW1 stores an Int16 block count and then one Int32 offset per block, and nothing
+        /// else. A block therefore runs from its own offset to wherever the next block starts,
+        /// and the next block is whichever has the smallest offset larger than this one. It is
+        /// not the next block by index, and it need not have a higher index at all, because DOS
+        /// writes blocks in whatever order it likes. In the save reported on pull request #71
+        /// the tail runs
+        /// 27, 28, 36, 29, 30, 39, 31, 38, 37, 40, so block 36 is followed by block 29.
+        ///
+        /// Measuring against a subset of the blocks is what caused that issue. The writer
+        /// searched forward by index and the note reader looked only at the nine note blocks,
+        /// so both ran past their real neighbours: block 36 measured 15312 and 9056 bytes
+        /// respectively where it holds 864. Notes are counted as length / 54, so the surplus
+        /// was drawn as note records on the automap.
+        ///
+        /// <paramref name="headerBlocks"/> is supplied by the caller and bounds how much of the
+        /// offset table is read. Callers take it from the count in the first two bytes of the
+        /// file, which is why nothing here trusts it.
+        ///
+        /// UW2 is a different format with its own lengths in the header and does not use this.
+        /// </summary>
+        public static int UW1BlockLength(byte[] src, int blockNo, int headerBlocks)
+        {
+            if (src == null || blockNo < 0 || blockNo >= headerBlocks) { return 0; }
+
+            // The count comes from the first two bytes of the file, so it is at most 0xFFFF in
+            // practice. Bound it anyway rather than let 2 + headerBlocks * 4 overflow to a
+            // small number and wave the size check through.
+            if (headerBlocks > (int.MaxValue - 2) / 4) { return 0; }
+            int headerSize = 2 + headerBlocks * 4;
+            if (headerSize > src.Length) { return 0; }
+
+            int thisOff = (int)getAt(src, 2 + blockNo * 4, 32);
+            // Offset 0 records an absent block. Anything pointing into the header or past the
+            // end of the file is a table we cannot trust, so measure nothing rather than guess.
+            if (thisOff < headerSize || thisOff > src.Length) { return 0; }
+
+            int nextOff = src.Length; // the last block by position runs to the end of the file
+            for (int j = 0; j < headerBlocks; j++)
+            {
+                if (j == blockNo) { continue; }
+                int candidate = (int)getAt(src, 2 + j * 4, 32);
+                if (candidate > thisOff && candidate < nextOff && candidate <= src.Length)
+                {
+                    nextOff = candidate;
+                }
+            }
+            return nextOff - thisOff;
+        }
+
         public static bool LoadLevArkFileData(string Lev_Ark_File = "lev.ark", string folder = "DATA")
         {
             //Load up my tile maps

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -140,12 +140,17 @@ namespace Underworld
                 }
             }
 
-            // Replace automap-note blocks (240..319) with the in-memory notes when non-empty.
+            // Replace automap-note blocks (240..319) with the in-memory notes.
+            // A level whose notes were all deleted serialises to an empty array, which the
+            // layout step below turns into an absent block. Skipping the replacement instead
+            // would write the source ARK's notes back out and they would reappear on reload.
+            // automapsnotes[lvl] is only non-null for a level that has been loaded, and the
+            // constructor reads the source block, so an empty list means no notes.
             if (automapnote.automapsnotes != null)
             {
                 for (int lvl = 0; lvl < 80; lvl++)
                 {
-                    if (automapnote.automapsnotes[lvl] != null && automapnote.automapsnotes[lvl].notes.Count > 0)
+                    if (automapnote.automapsnotes[lvl] != null)
                     {
                         blockData[240 + lvl] = automapnote.automapsnotes[lvl].Serialize();
                     }
@@ -192,9 +197,12 @@ namespace Underworld
                 }
                 else
                 {
+                    // An absent block carries no allocation. Every absent block in the
+                    // shipped UW2 archive has offset, length and reserved all zero.
                     offsets[i] = 0;
                     flags[i] = 0;
                     lengths[i] = 0;
+                    reserved[i] = 0;
                 }
             }
 
@@ -358,14 +366,17 @@ namespace Underworld
                 }
             }
 
-            // Replace automap-note blocks (36..44) with the in-memory notes when non-empty.
+            // Replace automap-note blocks (36..44) with the in-memory notes.
             // Without this, newly-created notes are silently lost on save because
-            // ExtractSourceBlock returns the pre-play bytes from the source ARK.
+            // ExtractSourceBlock returns the pre-play bytes from the source ARK. The same
+            // applies in reverse to deletion: a level whose notes were all deleted
+            // serialises to an empty array, which the layout step turns into an absent
+            // block, matching how the shipped archive represents a level with no notes.
             if (automapnote.automapsnotes != null)
             {
                 for (int lvl = 0; lvl < 9; lvl++)
                 {
-                    if (automapnote.automapsnotes[lvl] != null && automapnote.automapsnotes[lvl].notes.Count > 0)
+                    if (automapnote.automapsnotes[lvl] != null)
                     {
                         blockData[36 + lvl] = automapnote.automapsnotes[lvl].Serialize();
                     }

--- a/src/savegame/LevArkWriter.cs
+++ b/src/savegame/LevArkWriter.cs
@@ -253,13 +253,12 @@ namespace Underworld
             byte[][] blockData = new byte[noOfBlocks][];
 
             // For UW1, LoadUWBlock (default case) requires the caller to supply targetDataLen
-            // because the format has no per-block length metadata — only an offset table.
-            // We compute each block's length as offset[i+1] - offset[i] (or fileLen - offset[i]
-            // for the last present block).  This handles all block types (tilemap, overlay,
-            // texmap, automap, notes) correctly without hard-coding per-type sizes.
+            // because the format has no per-block length metadata, only an offset table.
+            // UW1BlockLength measures each block from the offsets, which handles all block
+            // types (tilemap, overlay, texmap, automap, notes) without hard-coding per-type
+            // sizes.
             byte[] uw1Src = LevArkLoader.lev_ark_file_data;
             int uw1HeaderBlocks = (uw1Src != null) ? (int)Loader.getAt(uw1Src, 0, 16) : noOfBlocks;
-            int uw1HeaderSize = 2 + uw1HeaderBlocks * 4;
 
             for (int i = 0; i < noOfBlocks; i++)
             {
@@ -274,26 +273,7 @@ namespace Underworld
                 }
                 else
                 {
-                    // Read this block's offset and find the next non-zero offset to compute length.
-                    int thisOff = (int)Loader.getAt(uw1Src, 2 + i * 4, 32);
-                    if (thisOff == 0)
-                    {
-                        tLen = 0; // absent block
-                    }
-                    else
-                    {
-                        int nextOff = uw1Src.Length; // default: run to end of file
-                        for (int j = i + 1; j < uw1HeaderBlocks; j++)
-                        {
-                            int candidate = (int)Loader.getAt(uw1Src, 2 + j * 4, 32);
-                            if (candidate > thisOff)
-                            {
-                                nextOff = candidate;
-                                break;
-                            }
-                        }
-                        tLen = nextOff - thisOff;
-                    }
+                    tLen = LevArkLoader.UW1BlockLength(uw1Src, i, uw1HeaderBlocks);
                 }
                 UWBlock src = ExtractSourceBlock(i, targetLen: tLen);
                 blockData[i] = src?.Data;

--- a/src/ui/uimanager_map.cs
+++ b/src/ui/uimanager_map.cs
@@ -301,8 +301,9 @@ namespace Underworld
                         break;
 
                     case automapactions.WRITING:
-                        //stop writing
-                        //StopWritingAutomapNote();
+                        // Clicking finishes the note in DOS. A further click then starts
+                        // the next one, because the action is NONE again by that point.
+                        StopWritingAutomapNote(false);
                         break;
 
                     case automapactions.DELETING: //to be implemented.
@@ -319,7 +320,13 @@ namespace Underworld
             CurrentAutomapAction = automapactions.NONE;
             instance.mousecursor.SetCursorToCursor(14);
 
-            if (!cancelled)
+            // DOS tests the first byte of the typed buffer and skips the whole commit
+            // when it is zero, so a note with nothing typed is discarded and the note
+            // count is not incremented (UW1_asm.asm:310364-310382). It only tests the
+            // first byte, so a note of nothing but spaces is kept.
+            bool empty = string.IsNullOrEmpty(currentmapnote?.notetext);
+
+            if (!cancelled && !empty)
             {
                 //Add note to memory
                 var level = automap.currentautomap;
@@ -329,12 +336,10 @@ namespace Underworld
                     automapnote.automapsnotes[blockno] = new automapnote(blockno);
                 }
                 automapnote.automapsnotes[blockno].notes.Add(currentmapnote);
-
-                //TODO fill out remainer of string with nulls.
             }
             else
             {
-                currentmapnote.textlabel.QueueFree();
+                currentmapnote?.textlabel?.QueueFree();
                 currentmapnote = null;
             }
         }

--- a/src/ui/uimanager_map.cs
+++ b/src/ui/uimanager_map.cs
@@ -322,11 +322,16 @@ namespace Underworld
 
             // DOS tests the first byte of the typed buffer and skips the whole commit
             // when it is zero, so a note with nothing typed is discarded and the note
-            // count is not incremented (UW1_asm.asm:310364-310382). It only tests the
-            // first byte, so a note of nothing but spaces is kept.
-            bool empty = string.IsNullOrEmpty(currentmapnote?.notetext);
+            // count is not incremented (UW1_asm.asm:310364-310382).
+            //
+            // DOS also keeps a note of nothing but spaces, because it only tests that
+            // first byte. We deliberately do not: it draws as nothing, so a player cannot
+            // find it to erase it. Loading and saving leave such a note alone, so a DOS
+            // save that already has one keeps it.
+            bool keep = currentmapnote != null
+                        && automapnote.IsKeepableNewNote(currentmapnote.notetext);
 
-            if (!cancelled && !empty)
+            if (!cancelled && keep)
             {
                 //Add note to memory
                 var level = automap.currentautomap;

--- a/tests/Underworld.Save.Tests/AutomapNoteBlockSizingTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNoteBlockSizingTests.cs
@@ -1,0 +1,114 @@
+using System.Text;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Reads notes out of a synthetic UW1 LEV.ARK laid out the way DOS lays one out, with a block
+/// of another type sitting between two note blocks.
+///
+/// Reported on PR #71. The reader measured a note block by looking for the nearest of the nine note
+/// blocks that started later, and ran straight through whatever sat in between. In the save
+/// attached to that pull request, block 36 is followed by automap block 29, so the reader took 9056
+/// bytes where the block holds 864. That is 167 record slots rather than 16, and 17 notes were
+/// drawn rather than 16: a slot is only drawn if its first byte is non-zero and its string
+/// terminates within 0x31 bytes, so most of the surplus is discarded and the rest is drawn as
+/// text on the automap.
+/// </summary>
+[Collection("UWClassState")]
+public class AutomapNoteBlockSizingTests : System.IDisposable
+{
+    private readonly byte _origRes;
+    private readonly byte[] _origArk;
+
+    public AutomapNoteBlockSizingTests()
+    {
+        // The collection serialises these tests against the other stateful ones, but it does
+        // not undo what they write. Both of these are process-wide.
+        _origRes = UWClass._RES;
+        _origArk = LevArkLoader.lev_ark_file_data;
+    }
+
+    public void Dispose()
+    {
+        UWClass._RES = _origRes;
+        LevArkLoader.lev_ark_file_data = _origArk;
+    }
+
+    private const int Blocks = 135;
+    private const int HeaderSize = 2 + Blocks * 4;
+
+    private static byte[] Note(string text, short x, short y)
+    {
+        var rec = new byte[54];
+        Encoding.ASCII.GetBytes(text, 0, text.Length, rec, 0);
+        rec[0x32] = (byte)(x & 0xFF); rec[0x33] = (byte)(x >> 8);
+        rec[0x34] = (byte)(y & 0xFF); rec[0x35] = (byte)(y >> 8);
+        return rec;
+    }
+
+    /// <summary>
+    /// Note block 36 with <paramref name="noteCount"/> notes, then an automap block, then note
+    /// block 39. Block 29 between the two is what a note-blocks-only search misses.
+    /// </summary>
+    private static byte[] Archive(int noteCount)
+    {
+        var body = new System.Collections.Generic.List<byte>();
+        int off36 = HeaderSize;
+        for (int i = 0; i < noteCount; i++) { body.AddRange(Note("NOTE" + i, (short)(10 + i), 20)); }
+
+        // An automap block, physically between the two note blocks. Its contents matter. A real
+        // automap is a buffer of small per-tile values, so it holds a mixture of zero and
+        // non-zero bytes, and the note reader only accepts a record whose string terminates
+        // within 0x31 bytes. Filling this with zeros, or with unbroken text, would make every
+        // bogus record fail that check and the test would pass no matter what the reader did.
+        int off29 = off36 + body.Count;
+        var automap = new byte[4096];
+        for (int i = 0; i < automap.Length; i++) { automap[i] = (byte)(i % 16); }
+        body.AddRange(automap);
+
+        int off39 = off36 + body.Count;
+        body.AddRange(Note("OTHER LEVEL", 5, 5));
+
+        var d = new byte[HeaderSize + body.Count];
+        d[0] = Blocks & 0xFF; d[1] = Blocks >> 8;
+        void Put(int block, int off)
+        {
+            d[2 + block * 4 + 0] = (byte)(off & 0xFF);
+            d[2 + block * 4 + 1] = (byte)((off >> 8) & 0xFF);
+            d[2 + block * 4 + 2] = (byte)((off >> 16) & 0xFF);
+            d[2 + block * 4 + 3] = (byte)((off >> 24) & 0xFF);
+        }
+        Put(36, off36);
+        Put(29, off29);
+        Put(39, off39);
+        body.CopyTo(d, HeaderSize);
+        return d;
+    }
+
+    [Fact]
+    public void ANoteBlockStopsAtTheNextBlockOfAnyType()
+    {
+        UWClass._RES = UWClass.GAME_UW1;
+        LevArkLoader.lev_ark_file_data = Archive(noteCount: 16);
+
+        var level0 = new automapnote(0);
+
+        // 16. Reading on through the automap block to block 39 examines 91 record slots
+        // and adds 81 of them, because most of the filler happens to terminate like a string.
+        Assert.Equal(16, level0.notes.Count);
+        Assert.Equal("NOTE0", level0.notes[0].notetext);
+        Assert.Equal("NOTE15", level0.notes[15].notetext);
+    }
+
+    [Fact]
+    public void TheFollowingBlocksAreNotReadAsNotes()
+    {
+        UWClass._RES = UWClass.GAME_UW1;
+        LevArkLoader.lev_ark_file_data = Archive(noteCount: 16);
+
+        var level0 = new automapnote(0);
+
+        // The note that belongs to the other level must not appear on this one.
+        Assert.DoesNotContain(level0.notes, n => n.notetext == "OTHER LEVEL");
+    }
+}

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -36,12 +36,14 @@ public class AutomapNotesRoundTripTests : System.IDisposable
         note.notes.Add(new Underworld.automapnote.mapnotetext("hello", 42, 7));
         byte[] result = note.Serialize();
 
+        // Upper-cased on the way out. This test previously asserted "hello" byte for byte,
+        // which is a note DOS cannot draw: opening the automap on such a save hangs UW1.
         Assert.Equal(54, result.Length);
-        Assert.Equal((byte)'h', result[0]);
-        Assert.Equal((byte)'e', result[1]);
-        Assert.Equal((byte)'l', result[2]);
-        Assert.Equal((byte)'l', result[3]);
-        Assert.Equal((byte)'o', result[4]);
+        Assert.Equal((byte)'H', result[0]);
+        Assert.Equal((byte)'E', result[1]);
+        Assert.Equal((byte)'L', result[2]);
+        Assert.Equal((byte)'L', result[3]);
+        Assert.Equal((byte)'O', result[4]);
         Assert.Equal((byte)0, result[5]);
         Assert.Equal((byte)42, result[0x32]);
         Assert.Equal((byte)0, result[0x33]);
@@ -279,5 +281,64 @@ public class AutomapNotesRoundTripTests : System.IDisposable
             Underworld.LevArkLoader.lev_ark_file_data = originalFile;
             Underworld.automapnote.automapsnotes = null;
         }
+    }
+    // ---- note text must match what DOS can store and draw ---------------------------
+
+    [Theory]
+    [InlineData("alpha", "ALPHA")]                 // lower-case hangs UW1's automap
+    [InlineData("Mixed Case 12", "MIXED CASE 12")]
+    [InlineData("ALREADY UPPER", "ALREADY UPPER")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void NormaliseNoteText_UpperCasesAndLeavesValidCharacters(string input, string expected)
+    {
+        Assert.Equal(expected, Underworld.automapnote.NormaliseNoteText(input));
+    }
+
+    [Fact]
+    public void NormaliseNoteText_DropsCharactersDosNeverAccepts()
+    {
+        // DOS's entry loop takes 0x20..0x7A only. A NUL from a non-text key event is how
+        // the port produced notes that read back as empty.
+        Assert.Equal("AB", Underworld.automapnote.NormaliseNoteText("A\0B"));
+        Assert.Equal("AB", Underworld.automapnote.NormaliseNoteText("A\u007fB"));
+        Assert.Equal("AB", Underworld.automapnote.NormaliseNoteText("A\u00e9B"));
+        Assert.Equal("", Underworld.automapnote.NormaliseNoteText("\0"));
+    }
+
+    [Fact]
+    public void NormaliseNoteText_TruncatesToTheDosMaximum()
+    {
+        var text = Underworld.automapnote.NormaliseNoteText(new string('A', 100));
+        Assert.Equal(Underworld.automapnote.MaxNoteLength, text.Length);
+        Assert.Equal(46, Underworld.automapnote.MaxNoteLength);
+    }
+
+    [Fact]
+    public void Serialize_LowerCaseNote_IsWrittenUpperCase()
+    {
+        var note = new Underworld.automapnote();
+        note.notes.Add(new Underworld.automapnote.mapnotetext("alpha", 159, 179));
+
+        byte[] result = note.Serialize();
+
+        Assert.Equal(54, result.Length);
+        Assert.Equal("ALPHA", System.Text.Encoding.ASCII.GetString(result, 0, 5));
+        Assert.Equal(0, result[5]);
+        // coordinates are untouched: they were proved harmless in DOS
+        Assert.Equal(159, result[0x32] | (result[0x33] << 8));
+        Assert.Equal(179, result[0x34] | (result[0x35] << 8));
+    }
+
+    [Fact]
+    public void Serialize_NoteStartingWithNul_NoLongerReadsBackAsEmpty()
+    {
+        var note = new Underworld.automapnote();
+        note.notes.Add(new Underworld.automapnote.mapnotetext("\0ALOHA", 47, 47));
+
+        byte[] result = note.Serialize();
+
+        Assert.NotEqual(0, result[0]);
+        Assert.Equal("ALOHA", System.Text.Encoding.ASCII.GetString(result, 0, 5));
     }
 }

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -341,4 +341,35 @@ public class AutomapNotesRoundTripTests : System.IDisposable
         Assert.NotEqual(0, result[0]);
         Assert.Equal("ALOHA", System.Text.Encoding.ASCII.GetString(result, 0, 5));
     }
+    // ---- new notes: what the port declines to create ---------------------------------
+
+    [Theory]
+    [InlineData("ALPHA", true)]
+    [InlineData("a", true)]
+    [InlineData(" A ", true)]      // real text with spaces around it is fine
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("   ", false)]     // DOS would keep this one; we decline it
+    [InlineData("\t", false)]      // normalises away to nothing
+    [InlineData("\0", false)]
+    public void IsKeepableNewNote_DeclinesNotesAPlayerCouldNotSeeOrErase(string text, bool keep)
+    {
+        Assert.Equal(keep, Underworld.automapnote.IsKeepableNewNote(text));
+    }
+
+    [Fact]
+    public void Serialize_SpacesOnlyNoteFromASave_IsWrittenBackUnchanged()
+    {
+        // The port will not create one, but DOS does, and dropping it on save would lose
+        // data from someone else's file. Four spaces is what real DOS writes.
+        var note = new Underworld.automapnote();
+        note.notes.Add(new Underworld.automapnote.mapnotetext("    ", 129, 46));
+
+        byte[] result = note.Serialize();
+
+        Assert.Equal(54, result.Length);
+        Assert.Equal(new byte[] { 0x20, 0x20, 0x20, 0x20, 0x00 }, result[0..5]);
+        Assert.Equal(129, result[0x32] | (result[0x33] << 8));
+        Assert.Equal(46, result[0x34] | (result[0x35] << 8));
+    }
 }

--- a/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
+++ b/tests/Underworld.Save.Tests/AutomapNotesRoundTripTests.cs
@@ -101,4 +101,183 @@ public class AutomapNotesRoundTripTests : System.IDisposable
             Underworld.automapnote.automapsnotes = null;
         }
     }
+
+    // ---- issue #63: deleting every note on a level must survive save and reload -------
+
+    private static int Uw1NotesOffset(byte[] ark, int level) =>
+        (int)Underworld.Loader.getAt(ark, ((36 + level) * 4) + 2, 32);
+
+    private static (int off, int flag, int len, int res) Uw2BlockHeader(byte[] ark, int block)
+    {
+        int n = (int)Underworld.Loader.getAt(ark, 0, 32);
+        return ((int)Underworld.Loader.getAt(ark, 6 + block * 4, 32),
+                (int)Underworld.Loader.getAt(ark, 6 + n * 4 + block * 4, 32),
+                (int)Underworld.Loader.getAt(ark, 6 + n * 8 + block * 4, 32),
+                (int)Underworld.Loader.getAt(ark, 6 + n * 12 + block * 4, 32));
+    }
+
+    /// <summary>
+    /// Builds a UW1 ARK carrying notes on the given levels, so deletion has something to
+    /// delete. The shipped DATA/LEV.ARK has no notes blocks at all.
+    /// </summary>
+    private static byte[] Uw1ArkWithNotesOn(params int[] levels)
+    {
+        Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+        foreach (int lvl in levels)
+        {
+            Underworld.automapnote.automapsnotes[lvl] = new Underworld.automapnote();
+            Underworld.automapnote.automapsnotes[lvl].notes.Add(
+                new Underworld.automapnote.mapnotetext($"NOTE ON LEVEL {lvl}", 10 + lvl, 20 + lvl));
+        }
+        byte[] ark = Underworld.LevArkWriter.Serialize();
+        Underworld.automapnote.automapsnotes = null;
+        return ark;
+    }
+
+    [Fact]
+    public void LevArkWriter_Uw1_DeletingEveryNote_ClearsTheBlockAndSurvivesReload()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+        Assert.True(Underworld.LevArkLoader.LoadLevArkFileData(folder: "DATA"));
+
+        byte[] originalFile = Underworld.LevArkLoader.lev_ark_file_data;
+        try
+        {
+            byte[] withNote = Uw1ArkWithNotesOn(0);
+            Assert.NotEqual(0, Uw1NotesOffset(withNote, 0));
+
+            // Load that ARK, confirm the note is really there, then delete it.
+            Underworld.LevArkLoader.lev_ark_file_data = withNote;
+            Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+            Underworld.automapnote.automapsnotes[0] = new Underworld.automapnote(0);
+            Assert.Single(Underworld.automapnote.automapsnotes[0].notes);
+            Underworld.automapnote.automapsnotes[0].notes.Clear();
+
+            byte[] cleared = Underworld.LevArkWriter.Serialize();
+
+            // The block must be gone, the way the shipped archive represents "no notes".
+            Assert.Equal(0, Uw1NotesOffset(cleared, 0));
+
+            Underworld.LevArkLoader.lev_ark_file_data = cleared;
+            var reloaded = new Underworld.automapnote(0);
+            Assert.NotNull(reloaded.notes);
+            Assert.Empty(reloaded.notes);
+        }
+        finally
+        {
+            Underworld.LevArkLoader.lev_ark_file_data = originalFile;
+            Underworld.automapnote.automapsnotes = null;
+        }
+    }
+
+    [Fact]
+    public void LevArkWriter_Uw1_DeletingNotesOnOneLevel_LeavesAnUnloadedLevelIntact()
+    {
+        // The regression guard for dropping the Count > 0 gate: a level that was never
+        // loaded stays null, so its source block must pass through untouched.
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW1");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW1;
+        Assert.True(Underworld.LevArkLoader.LoadLevArkFileData(folder: "DATA"));
+
+        byte[] originalFile = Underworld.LevArkLoader.lev_ark_file_data;
+        try
+        {
+            byte[] withNotes = Uw1ArkWithNotesOn(0, 1);
+            Underworld.LevArkLoader.lev_ark_file_data = withNotes;
+
+            // Load level 0 only and clear it. Level 1 is left null, as if never visited.
+            Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+            Underworld.automapnote.automapsnotes[0] = new Underworld.automapnote(0);
+            Underworld.automapnote.automapsnotes[0].notes.Clear();
+            Assert.Null(Underworld.automapnote.automapsnotes[1]);
+
+            byte[] cleared = Underworld.LevArkWriter.Serialize();
+
+            Underworld.LevArkLoader.lev_ark_file_data = cleared;
+            Assert.Equal(0, Uw1NotesOffset(cleared, 0));
+
+            var levelOne = new Underworld.automapnote(1);
+            Assert.Single(levelOne.notes);
+            Assert.Equal("NOTE ON LEVEL 1", levelOne.notes[0].notetext);
+            Assert.Equal(11, levelOne.notes[0].posX);
+            Assert.Equal(21, levelOne.notes[0].posY);
+        }
+        finally
+        {
+            Underworld.LevArkLoader.lev_ark_file_data = originalFile;
+            Underworld.automapnote.automapsnotes = null;
+        }
+    }
+
+    [Fact]
+    public void LevArkWriter_Uw2_DeletingEveryNote_ClearsTheBlockAndItsHeaderFields()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+        Assert.True(Underworld.LevArkLoader.LoadLevArkFileData(folder: "SAVE0"));
+
+        byte[] originalFile = Underworld.LevArkLoader.lev_ark_file_data;
+        try
+        {
+            // Level 0 is block 240 and carries notes in the shipped save.
+            var source = new Underworld.automapnote(0);
+            Assert.NotEmpty(source.notes);
+
+            Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+            Underworld.automapnote.automapsnotes[0] = source;
+            source.notes.Clear();
+
+            byte[] cleared = Underworld.LevArkWriter.Serialize();
+
+            var (off, flag, len, res) = Uw2BlockHeader(cleared, 240);
+            Assert.Equal(0, off);
+            Assert.Equal(0, flag);
+            Assert.Equal(0, len);
+            Assert.Equal(0, res);   // an absent block carries no allocation
+
+            Underworld.LevArkLoader.lev_ark_file_data = cleared;
+            var reloaded = new Underworld.automapnote(0);
+            Assert.Empty(reloaded.notes);
+        }
+        finally
+        {
+            Underworld.LevArkLoader.lev_ark_file_data = originalFile;
+            Underworld.automapnote.automapsnotes = null;
+        }
+    }
+
+    [Fact]
+    public void LevArkWriter_Uw2_DeletingNotesOnOneLevel_LeavesAnUnloadedLevelIntact()
+    {
+        Underworld.UWClass.BasePath = Path.Combine(TestData.UW2GogRoot, "UW2");
+        Underworld.UWClass._RES = Underworld.UWClass.GAME_UW2;
+        Assert.True(Underworld.LevArkLoader.LoadLevArkFileData(folder: "SAVE0"));
+
+        byte[] originalFile = Underworld.LevArkLoader.lev_ark_file_data;
+        try
+        {
+            // Block 313 is level 73 and also carries notes in the shipped save.
+            var untouched = new Underworld.automapnote(73);
+            Assert.NotEmpty(untouched.notes);
+            string expectedText = untouched.notes[0].notetext;
+
+            Underworld.automapnote.automapsnotes = new Underworld.automapnote[Underworld.UWTileMap.NO_OF_LEVELS];
+            Underworld.automapnote.automapsnotes[0] = new Underworld.automapnote(0);
+            Underworld.automapnote.automapsnotes[0].notes.Clear();
+            Assert.Null(Underworld.automapnote.automapsnotes[73]);
+
+            byte[] cleared = Underworld.LevArkWriter.Serialize();
+
+            Underworld.LevArkLoader.lev_ark_file_data = cleared;
+            var reloaded = new Underworld.automapnote(73);
+            Assert.NotEmpty(reloaded.notes);
+            Assert.Equal(expectedText, reloaded.notes[0].notetext);
+        }
+        finally
+        {
+            Underworld.LevArkLoader.lev_ark_file_data = originalFile;
+            Underworld.automapnote.automapsnotes = null;
+        }
+    }
 }

--- a/tests/Underworld.Save.Tests/LevArkWriterBlockLengthTests.cs
+++ b/tests/Underworld.Save.Tests/LevArkWriterBlockLengthTests.cs
@@ -1,0 +1,134 @@
+using System.Text;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Drives <see cref="LevArkWriter"/> over a synthetic UW1 archive whose blocks are out of index
+/// order, and checks the blocks it copies come out the size they went in.
+///
+/// Reported on PR #71. The unit tests around LevArkLoader.UW1BlockLength cover the measurement itself,
+/// but they do not prove the writer calls it: putting the old inline scan back at the call site
+/// leaves every one of them green while the archive is written wrong again. This covers the
+/// wiring.
+/// </summary>
+[Collection("UWClassState")]
+public class LevArkWriterBlockLengthTests : System.IDisposable
+{
+    private const int Blocks = 135;
+    private const int HeaderSize = 2 + Blocks * 4;
+
+    private readonly byte _origRes;
+    private readonly byte[] _origArk;
+    private readonly UWTileMap[] _origDungeons;
+    private readonly automap[] _origAutomaps;
+    private readonly automapnote[] _origNotes;
+
+    public LevArkWriterBlockLengthTests()
+    {
+        _origRes = UWClass._RES;
+        _origArk = LevArkLoader.lev_ark_file_data;
+
+        // Serialize() replaces blocks from these caches when they hold anything. Left populated
+        // by an earlier test they would overwrite the very blocks being measured here, and the
+        // test would pass whatever the writer did with the source lengths. Cleared for the run
+        // and put back afterwards.
+        _origDungeons = UWTileMap.dungeons;
+        _origAutomaps = automap.automaps;
+        _origNotes = automapnote.automapsnotes;
+        UWTileMap.dungeons = null;
+        automap.automaps = null;
+        automapnote.automapsnotes = null;
+    }
+
+    public void Dispose()
+    {
+        UWClass._RES = _origRes;
+        LevArkLoader.lev_ark_file_data = _origArk;
+        UWTileMap.dungeons = _origDungeons;
+        automap.automaps = _origAutomaps;
+        automapnote.automapsnotes = _origNotes;
+    }
+
+    private static void Put(byte[] d, int block, int off)
+    {
+        d[2 + block * 4 + 0] = (byte)(off & 0xFF);
+        d[2 + block * 4 + 1] = (byte)((off >> 8) & 0xFF);
+        d[2 + block * 4 + 2] = (byte)((off >> 16) & 0xFF);
+        d[2 + block * 4 + 3] = (byte)((off >> 24) & 0xFF);
+    }
+
+    /// <summary>
+    /// Note block 36, then automap block 29, then note block 39. That is the shape from the
+    /// save on #71: the block following 36 has a lower index, so a forward-by-index search
+    /// runs past it and swallows the automap block.
+    /// </summary>
+    private static byte[] Archive()
+    {
+        var body = new System.Collections.Generic.List<byte>();
+
+        int off36 = HeaderSize;
+        for (int i = 0; i < 16; i++)
+        {
+            var rec = new byte[54];
+            Encoding.ASCII.GetBytes("NOTE" + i, 0, ("NOTE" + i).Length, rec, 0);
+            body.AddRange(rec);
+        }
+
+        int off29 = off36 + body.Count;
+        var automap = new byte[4096];
+        for (int i = 0; i < automap.Length; i++) { automap[i] = (byte)(i % 16); }
+        body.AddRange(automap);
+
+        int off39 = off36 + body.Count;
+        for (int i = 0; i < 20; i++)
+        {
+            var rec = new byte[54];
+            Encoding.ASCII.GetBytes("OTHER" + i, 0, ("OTHER" + i).Length, rec, 0);
+            body.AddRange(rec);
+        }
+
+        var d = new byte[HeaderSize + body.Count];
+        d[0] = Blocks & 0xFF; d[1] = Blocks >> 8;
+        Put(d, 36, off36);
+        Put(d, 29, off29);
+        Put(d, 39, off39);
+        body.CopyTo(d, HeaderSize);
+        return d;
+    }
+
+    [Fact]
+    public void RewritingAnArchiveKeepsEveryBlockTheSizeItWas()
+    {
+        UWClass._RES = UWClass.GAME_UW1;
+        LevArkLoader.lev_ark_file_data = Archive();
+
+        byte[] rewritten = LevArkWriter.Serialize();
+        Assert.NotNull(rewritten);
+
+        // Measure the result with the same rule, which is sound here because the writer lays
+        // its blocks out in index order.
+        int len36 = LevArkLoader.UW1BlockLength(rewritten, 36, Blocks);
+        int len29 = LevArkLoader.UW1BlockLength(rewritten, 29, Blocks);
+        int len39 = LevArkLoader.UW1BlockLength(rewritten, 39, Blocks);
+
+        Assert.Equal(16 * 54, len36);
+        Assert.Equal(4096, len29);
+        Assert.Equal(20 * 54, len39);
+    }
+
+    [Fact]
+    public void TheNotesInARewrittenArchiveStillReadBackAsThemselves()
+    {
+        UWClass._RES = UWClass.GAME_UW1;
+        LevArkLoader.lev_ark_file_data = Archive();
+
+        LevArkLoader.lev_ark_file_data = LevArkWriter.Serialize();
+        var level0 = new automapnote(0);
+
+        // 16 notes, and none of the automap block or the other level's notes among them.
+        Assert.Equal(16, level0.notes.Count);
+        Assert.Equal("NOTE0", level0.notes[0].notetext);
+        Assert.Equal("NOTE15", level0.notes[15].notetext);
+        Assert.DoesNotContain(level0.notes, n => n.notetext.StartsWith("OTHER"));
+    }
+}

--- a/tests/Underworld.Save.Tests/SourceBlockLengthTests.cs
+++ b/tests/Underworld.Save.Tests/SourceBlockLengthTests.cs
@@ -1,0 +1,147 @@
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Covers <see cref="LevArkLoader.UW1BlockLength"/>, which measures a block in a UW1 LEV.ARK
+/// from the offset table because the format carries no per-block length.
+///
+/// Reported on PR #71. Two callers measured against a subset of the blocks and both ran past
+/// the real neighbour. The writer searched forward from blockNo + 1 and took the first offset larger
+/// than this one, which assumes blocks sit in the file in index order. The note reader looked
+/// only at the nine note blocks. DOS writes blocks in whatever order it likes, and the block
+/// that physically follows one is often of another type. Notes are counted as Data.Length / 54,
+/// so the surplus was drawn as note records along the bottom of the automap.
+/// </summary>
+public class SourceBlockLengthTests
+{
+    /// <summary>
+    /// Build a UW1 LEV.ARK header: Int16 block count, then an Int32 offset per block.
+    /// Offset 0 means the block is absent.
+    /// </summary>
+    private static byte[] Archive(int fileLength, params (int block, int offset)[] blocks)
+    {
+        int count = 135;
+        var d = new byte[fileLength];
+        d[0] = (byte)(count & 0xFF);
+        d[1] = (byte)(count >> 8);
+        foreach (var (b, o) in blocks)
+        {
+            d[2 + b * 4 + 0] = (byte)(o & 0xFF);
+            d[2 + b * 4 + 1] = (byte)((o >> 8) & 0xFF);
+            d[2 + b * 4 + 2] = (byte)((o >> 16) & 0xFF);
+            d[2 + b * 4 + 3] = (byte)((o >> 24) & 0xFF);
+        }
+        return d;
+    }
+
+    [Fact]
+    public void ABlockIsMeasuredToTheNextBlockByPosition_NotByIndex()
+    {
+        // Block 36 sits between 28 and 29 in the file, which is the shape that breaks a
+        // forward-only search: the next block physically is 29, a *lower* index.
+        var src = Archive(4000, (28, 1000), (36, 2000), (29, 2200), (30, 3000));
+
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 28, 135));
+        Assert.Equal(200, LevArkLoader.UW1BlockLength(src, 36, 135));
+        Assert.Equal(800, LevArkLoader.UW1BlockLength(src, 29, 135));
+    }
+
+    [Fact]
+    public void TheBlockOrderFromTheReportedSave_MeasuresEveryBlockCorrectly()
+    {
+        // The real tail order from the DOS save attached to PR #71: 28, 36, 29, 30, 39, 31, 38.
+        // Every block is 100 bytes long, laid out back to back, so each answer must be 100.
+        var order = new[] { 28, 36, 29, 30, 39, 31, 38 };
+        var placed = new (int, int)[order.Length];
+        for (int k = 0; k < order.Length; k++) { placed[k] = (order[k], 1000 + k * 100); }
+        var src = Archive(1000 + order.Length * 100, placed);
+
+        foreach (int b in order)
+        {
+            Assert.Equal(100, LevArkLoader.UW1BlockLength(src, b, 135));
+        }
+    }
+
+    [Fact]
+    public void TheOldForwardOnlySearchWouldHaveOvershot()
+    {
+        // Pins the defect itself rather than only the fix. Searching forward from 37 for the
+        // first offset larger than block 36's would skip 29 and 30 and land on 39, giving 300
+        // instead of 100. If this ever equals 300 again the bug is back.
+        var src = Archive(1400, (28, 1000), (36, 1100), (29, 1200), (30, 1300), (39, 1400));
+
+        // 300 is what the forward-by-index scan returned, so equality with 100 is the check.
+        Assert.Equal(100, LevArkLoader.UW1BlockLength(src, 36, 135));
+    }
+
+    [Fact]
+    public void TheLastBlockByPositionRunsToTheEndOfTheFile()
+    {
+        // Block 28 has the higher offset, so it is the last one by position and runs to the
+        // end of the file. Block 36 runs up to it, even though 28 is the lower index.
+        var src = Archive(5000, (36, 1000), (28, 4000));
+        Assert.Equal(3000, LevArkLoader.UW1BlockLength(src, 36, 135));
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 28, 135));
+    }
+
+    [Fact]
+    public void AnAbsentBlockHasNoLength()
+    {
+        // Offset 0 records an absent block. It is not a block sitting at position 0, so it
+        // must not be treated as the neighbour of anything either.
+        var src = Archive(3000, (28, 1000), (36, 0), (29, 2000));
+
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(src, 36, 135));
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 28, 135));
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 29, 135));
+    }
+
+    [Fact]
+    public void TwoBlocksSharingAnOffsetBothRunToTheNextDistinctOne()
+    {
+        // The offset table cannot express anything else, so both get the same extent.
+        var src = Archive(3000, (28, 1000), (29, 1000), (30, 2000));
+
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 28, 135));
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 29, 135));
+    }
+
+    [Fact]
+    public void AMalformedTableIsMeasuredAsNothingRatherThanThrowing()
+    {
+        // The block count comes from the first two bytes of the file, so none of this is
+        // trustworthy input. Measuring nothing is recoverable; an exception out of a loader is
+        // not, and a negative length would reach an array allocation.
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(null, 36, 135));
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(Archive(3000, (36, 1000)), -1, 135));
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(Archive(3000, (36, 1000)), 135, 135));
+
+        // A count larger than the file can hold.
+        var stub = new byte[20];
+        stub[0] = 135;
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(stub, 3, 135));
+
+        // An offset inside the header, and one past the end of the file.
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(Archive(3000, (36, 10)), 36, 135));
+        Assert.Equal(0, LevArkLoader.UW1BlockLength(Archive(3000, (36, 99999)), 36, 135));
+    }
+
+    [Fact]
+    public void ANeighbourOffsetPastTheEndOfTheFileIsIgnored()
+    {
+        // Otherwise a single bad entry elsewhere in the table silently truncates a good block.
+        var src = Archive(4000, (28, 1000), (29, 99999), (30, 3000));
+        Assert.Equal(2000, LevArkLoader.UW1BlockLength(src, 28, 135));
+    }
+
+    [Fact]
+    public void OffsetsOutsideTheCallerSuppliedBoundAreNotConsultedAsNeighbours()
+    {
+        // headerBlocks is supplied by the caller and bounds how much of the table is read.
+        // Anything beyond it is not part of the table being measured and must not shorten a
+        // real block. The header here always declares 135; this pins the bound, not the header.
+        var src = Archive(4000, (28, 1000), (40, 2000), (50, 1500));
+
+        Assert.Equal(1000, LevArkLoader.UW1BlockLength(src, 28, 45));
+        Assert.Equal(500, LevArkLoader.UW1BlockLength(src, 28, 135));
+    }
+}


### PR DESCRIPTION
Two automap-note bugs, both about the port writing note data DOS cannot use. They touch
different files and are in separate commits.

## Deleting every note on a level did not save (#63)

The notes came back on reload. Adding notes worked, and deleting some of them worked,
because only deletion down to zero was affected. It applied to both games.

Both note replacement loops were gated on the in-memory list being non-empty, so an empty
list skipped the replacement. `blockData` still held the block read from the source ARK, so
the deleted notes were written straight back out.

The count check is gone from both loops. Every current assignment into `automapsnotes`
constructs the object with its level number, and that constructor reads the level's block
from the source ARK, so an empty list means the level really has no notes. A level that was
never loaded stays null and its source block passes through untouched.

The safety of dropping the check rests on that construction rule rather than on anything the
type enforces. `automapnote` also has a parameterless constructor, which builds an empty
object without reading the ARK. Nothing in `src/` uses it, only the tests. Assigning one into
`automapsnotes` for a level that has notes in the ARK would now erase them.

An empty `Serialize()` result is a zero length block, and the layout step already records one
as absent. The shipped `DATA/LEV.ARK` represents a level with no notes the same way, with
offsets 36 to 44 all zero.

The UW2 writer also now clears `reserved` for an absent block. It preserved the source value
whether or not the block survived, so clearing a notes block wrote a zero offset against a
non-zero reserved size. In the shipped UW2 archive all 230 absent blocks have offset, length
and reserved zero together, and reserved is an allocation size, at least equal to the length
on all 90 present blocks.

## A lower-case note hangs DOS (#70)

Opening the automap in DOS on a save with a lower-case note hangs the game. It draws the
notes ahead of it in order, then stops redrawing and ignores all input.

I found it by loading a port save in DOS and bisecting, a few bytes at a time. Upper-casing
the two offending notes, nine bytes, makes the map open and draw all four. Moving their
coordinates instead changes nothing, and removing the notes block makes the hang go away, so
it is the text.

DOS accepts `0x20` to `0x7A` on entry and upper-cases as it goes, at `UW1_asm.asm:310189`,
`:310194` and `:310203`, with the conversion at `33569` and `33574`. Its length limit is 46.
UW2 does the same, checked by hand in the game, so this is not gated by game.

`main.cs` appended the raw key value with no filtering, which also let a non-text key event
append a NUL. A note starting with NUL reads back as empty, and the loader skips any record
whose first byte is NUL, so the port dropped it on load while leaving it in the file for DOS.

Notes are now filtered and upper-cased on input, and again in `Serialize`, so a note reaching
the list from anywhere else cannot write a save that hangs the real game.

I did not find the instruction that hangs. The draw loop is `ovr092_D80` at
`UW1_asm.asm:310700` and the renderer is called at `:310771`, but I did not trace it into the
glyph lookup.

## Note entry did not match the original (#70)

Three more differences, found by driving DOS side by side with the port.

Escape commits the note. Enter and Escape jump to the same routine, at `UW1_asm.asm:310176`
and `:310183`, and it copies the typed string into the note. Nothing in the original cancels
part way through, so the port discarding on Escape had no counterpart. The `cancelled` branch
of `StopWritingAutomapNote` is now unreachable, left in place rather than changing the
signature.

Clicking off the note commits it too. The call was already in `uimanager_map.cs`, commented
out.

A note with nothing typed is discarded. DOS tests the first byte of the buffer and skips both
the copy and the note-count increment when it is zero, at `:310364-310382`. The port added
the note whatever was typed, which is where the blank records came from. The test is on the
first byte only, so a note of nothing but spaces is kept, and the check is `IsNullOrEmpty`
rather than `IsNullOrWhiteSpace` to match.

Both confirmed in DOS: an empty note leaves no notes block at all, and a note of four spaces
writes one record holding `20 20 20 20 00`.

## One deliberate difference from the original

The port will not create a note of nothing but spaces. DOS does, and such a note draws as
nothing, so a player cannot see it to erase it.

The check is in the commit path only. Loading and serialization stay faithful, so a save that
already carries one keeps it through a load and save. A test pins that, because moving the
policy into `Serialize` would drop notes from someone else's file.

Say if you would rather the port matched DOS here and I will take it out.

## Testing

Run with `cd tests/Underworld.Save.Tests && dotnet test`. I get 64 cases passing, 42 of them
already present. The tests read the game data at `../UW2GOG`, so the suite needs it.

Removing each part fails tests. For the deletion fix: either count check two and one, and the
`reserved` line one. For the note text: the upper-casing four, the range filter two, the
length cap one, and the serializer's normalisation three.

One existing test asserted `"hello"` byte for byte through `Serialize`. A save carrying that
note hangs UW1, so the assertion was wrong and now expects the upper-cased form.

The DOS behaviour above was checked in real `UW.EXE`, driving the original and the port side
by side. The note entry changes are input paths, so they are covered by hand rather than by
the save tests.

Every change here has also been run by hand in the port. For the deletion fix: erasing some
of a level's notes rewrites the block with the survivors, erasing the rest makes the block
absent, and the notes stay gone after a reload.

Closes #63
Closes #70
