### PR TITLE
fix(settings): a bad settings file no longer stops the game starting, and SFX startup order

### DIFF
--- a/src/audio/sfx/godot/SfxStreamPlayer.cs
+++ b/src/audio/sfx/godot/SfxStreamPlayer.cs
@@ -80,18 +80,14 @@ public partial class SfxStreamPlayer : Node
         _renderBuffer = new short[FramesPerTick * 2];
         _frames = new Vector2[FramesPerTick];
 
-        // Everything that can fail happens before anything is started. Path.Combine throws if
-        // BasePath is null, which is what happens when the settings could not be read, and if
-        // that throw came after the player was playing and the producer thread was running,
-        // Resolve the path before building anything. Path.Combine throws if BasePath is null,
-        // which is what happens when the settings could not be read, and a throw after the
-        // player was playing and the producer thread was running would leave the node
-        // half-built with live audio attached to it.
+        // Resolve the path before the player and the thread exist. Path.Combine throws if
+        // BasePath is null, which is what happens when the settings could not be read, and a
+        // throw after the generator was playing and the producer thread was running would leave
+        // both going against a construction that had already failed. The chip, the sink and the
+        // buffers above are already built by this point, and _ExitTree is what takes those down.
         //
         // SFX is currently UW1-only (the TVFX engine targets UW.AD; the UW2
-        // path falls back to .voc files which we don't yet wire). Initialising
-        // SoundEffects here means the singleton + scene-tree timing matches
-        // MusicStreamPlayer's lifecycle.
+        // path falls back to .voc files which we don't yet wire).
         //if (UWClass._RES == UWClass.GAME_UW1)
        // {
             if (string.IsNullOrWhiteSpace(UWClass.BasePath))

--- a/src/audio/sfx/godot/SfxStreamPlayer.cs
+++ b/src/audio/sfx/godot/SfxStreamPlayer.cs
@@ -80,6 +80,28 @@ public partial class SfxStreamPlayer : Node
         _renderBuffer = new short[FramesPerTick * 2];
         _frames = new Vector2[FramesPerTick];
 
+        // Everything that can fail happens before anything is started. Path.Combine throws if
+        // BasePath is null, which is what happens when the settings could not be read, and if
+        // that throw came after the player was playing and the producer thread was running,
+        // Resolve the path before building anything. Path.Combine throws if BasePath is null,
+        // which is what happens when the settings could not be read, and a throw after the
+        // player was playing and the producer thread was running would leave the node
+        // half-built with live audio attached to it.
+        //
+        // SFX is currently UW1-only (the TVFX engine targets UW.AD; the UW2
+        // path falls back to .voc files which we don't yet wire). Initialising
+        // SoundEffects here means the singleton + scene-tree timing matches
+        // MusicStreamPlayer's lifecycle.
+        //if (UWClass._RES == UWClass.GAME_UW1)
+       // {
+            if (string.IsNullOrWhiteSpace(UWClass.BasePath))
+            {
+                GD.PushError("SfxStreamPlayer: no game path is configured. SFX disabled.");
+                return;
+            }
+            string soundDir = Path.Combine(UWClass.BasePath, "SOUND");
+        //}
+
         var generator = new AudioStreamGenerator
         {
             MixRate = SampleRate,
@@ -99,15 +121,12 @@ public partial class SfxStreamPlayer : Node
         };
         _audioThread.Start();
 
-        // SFX is currently UW1-only (the TVFX engine targets UW.AD; the UW2
-        // path falls back to .voc files which we don't yet wire). Initialising
-        // SoundEffects here means the singleton + scene-tree timing matches
-        // MusicStreamPlayer's lifecycle.
-        //if (UWClass._RES == UWClass.GAME_UW1)
-       // {
-            string soundDir = Path.Combine(UWClass.BasePath, "SOUND");
-            SoundEffects.Initialize(uwsettings.instance.synth, soundDir);
-        //}
+        // Published last, once there is something behind it. SoundEffects.Initialize makes this
+        // node reachable from SoundEffects.Play, so doing it earlier would mean a failure while
+        // building the player or starting the thread left callers able to enqueue against a
+        // producer that never ran. The thread itself does not read any SoundEffects state, so
+        // it is safe already running.
+        SoundEffects.Initialize(uwsettings.instance.synth, soundDir);
     }
 
     /// <summary>

--- a/src/utility/config.cs
+++ b/src/utility/config.cs
@@ -63,26 +63,35 @@ public class uwsettings
             main.cameraPitchGimbal_sprites.Fov = main.cameraPitchGimbal_world.Fov;
         }
 
-        switch (instance.gametoload.ToUpper())
+        // A file can parse and still be unusable. gametoload set to null, or to something that
+        // names no game, used to throw from here, and this runs from the static constructor, so
+        // the effect was the same as an unreadable file: the type faults and the game cannot
+        // start. Treat it the same way, and keep the file so it can be looked at.
+        if (!GameSelection.TryResolve(instance.gametoload, out byte res))
         {
-            case "UW2":
-            case "2":
-                UWClass._RES = UWClass.GAME_UW2;
-                UWClass.BasePath = instance.pathuw2;
-                break;
-            case "UW1":
-            case "1":
-                UWClass._RES = UWClass.GAME_UW1;
-                UWClass.BasePath = instance.pathuw1;
-                break;
-            case "UWDEMO":
-            case "0":
-                UWClass._RES = UWClass.GAME_UWDEMO;
-                UWClass.BasePath = instance.pathuw1;
-                break;
-            default:
-                throw new InvalidOperationException("Invalid Game Selected");
+            string keptBadGame = JsonFile.PreserveUnreadable(FilePath);
+            GD.PushWarning(
+                $"{FilePath} names no game I recognise (gametoload was "
+                + (instance.gametoload == null ? "not set" : $"'{instance.gametoload}'")
+                + "). Loading defaults."
+                + (keptBadGame != null
+                    ? $" The file was kept as {keptBadGame}."
+                    : " The file could not be moved aside, so the next save will replace it."));
+            instance = new();
+            if (!GameSelection.TryResolve(instance.gametoload, out res))
+            {
+                // Only reachable if the default in this class stops naming a game, which would
+                // be a mistake in this file rather than in anyone's settings. Say so instead of
+                // running on with a selection nothing chose.
+                GD.PushError(
+                    $"uwsettings default gametoload '{instance.gametoload}' names no game. "
+                    + "Falling back to UW1.");
+                res = UWClass.GAME_UW1;
+            }
         }
+
+        UWClass._RES = res;
+        UWClass.BasePath = (res == UWClass.GAME_UW2) ? instance.pathuw2 : instance.pathuw1;
 
         // Backward compat: if legacy 'rompath' is set but new 'synthpath' isn't,
         // promote rompath to synthpath.

--- a/src/utility/config.cs
+++ b/src/utility/config.cs
@@ -57,12 +57,6 @@ public class uwsettings
                 break;
         }
 
-        if (main.cameraPitchGimbal_world != null)
-        {
-            main.cameraPitchGimbal_world.Fov = Math.Max(50, instance.FOV);
-            main.cameraPitchGimbal_sprites.Fov = main.cameraPitchGimbal_world.Fov;
-        }
-
         // A file can parse and still be unusable. gametoload set to null, or to something that
         // names no game, used to throw from here, and this runs from the static constructor, so
         // the effect was the same as an unreadable file: the type faults and the game cannot
@@ -92,6 +86,14 @@ public class uwsettings
 
         UWClass._RES = res;
         UWClass.BasePath = (res == UWClass.GAME_UW2) ? instance.pathuw2 : instance.pathuw1;
+
+        // After the game selection, so a file that is about to be discarded does not get to
+        // move the camera on its way out.
+        if (main.cameraPitchGimbal_world != null)
+        {
+            main.cameraPitchGimbal_world.Fov = Math.Max(50, instance.FOV);
+            main.cameraPitchGimbal_sprites.Fov = main.cameraPitchGimbal_world.Fov;
+        }
 
         // Backward compat: if legacy 'rompath' is set but new 'synthpath' isn't,
         // promote rompath to synthpath.

--- a/src/utility/config.cs
+++ b/src/utility/config.cs
@@ -27,16 +27,34 @@ public class uwsettings
     public static void LoadSettings()
     {
 
-        if (File.Exists(FilePath))
+        switch (JsonFile.TryRead<uwsettings>(FilePath, JsonOpts, out var loaded, out string error))
         {
-            Debug.Print($"Loading settings from {FilePath}");
-            using var stream = File.OpenRead(FilePath);
-            instance = JsonSerializer.Deserialize<uwsettings>(stream, JsonOpts);
-        }
-        else
-        {
-            Debug.Print($"No existing settings at {FilePath}. Loading defaults.");
-            instance = new();
+            case JsonReadOutcome.Ok:
+                Debug.Print($"Loading settings from {FilePath}");
+                instance = loaded;
+                break;
+
+            case JsonReadOutcome.NotFound:
+                Debug.Print($"No existing settings at {FilePath}. Loading defaults.");
+                instance = new();
+                break;
+
+            default:
+                // This runs from the static constructor, so letting the failure out faults the
+                // type for the whole process: every later read of uwsettings.instance throws,
+                // BasePath is never set, and the game cannot start with nothing on screen to
+                // say why. Keep the file so it can be looked at, and carry on with defaults.
+                //
+                // GD.PushWarning rather than Debug.Print: Debug.Print is [Conditional("DEBUG")]
+                // and compiles out of a release build, and this is the one message that explains
+                // why the settings just reverted.
+                string kept = JsonFile.PreserveUnreadable(FilePath);
+                GD.PushWarning($"Could not read {FilePath} ({error}). Loading defaults."
+                    + (kept != null
+                        ? $" The file was kept as {kept}."
+                        : " The file could not be moved aside, so the next save will replace it."));
+                instance = new();
+                break;
         }
 
         if (main.cameraPitchGimbal_world != null)

--- a/src/utility/gameselection.cs
+++ b/src/utility/gameselection.cs
@@ -1,0 +1,44 @@
+namespace Underworld;
+
+/// <summary>
+/// Turns the <c>gametoload</c> setting into the game it names.
+///
+/// Godot-free so it can be unit tested. <see cref="uwsettings"/> resolves its path through
+/// <c>ProjectSettings.GlobalizePath</c>, and touching that class at all runs its static
+/// constructor, which a headless test process cannot do.
+/// </summary>
+public static class GameSelection
+{
+    /// <summary>
+    /// Resolve <paramref name="gametoload"/> to a game. Returns false for a value naming no
+    /// game, including null, rather than throwing.
+    ///
+    /// This used to throw out of <c>LoadSettings</c>, which runs from a static constructor, so
+    /// a settings file that parsed but named nothing recognisable faulted the type for the rest
+    /// of the process and the game could not start. A file being unusable is the same problem
+    /// as a file being unreadable and gets the same treatment.
+    /// </summary>
+    public static bool TryResolve(string gametoload, out byte res)
+    {
+        res = UWClass.GAME_UW1;
+        if (gametoload == null) { return false; }
+
+        switch (gametoload.ToUpper())
+        {
+            case "UW2":
+            case "2":
+                res = UWClass.GAME_UW2;
+                return true;
+            case "UW1":
+            case "1":
+                res = UWClass.GAME_UW1;
+                return true;
+            case "UWDEMO":
+            case "0":
+                res = UWClass.GAME_UWDEMO;
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/utility/jsonfile.cs
+++ b/src/utility/jsonfile.cs
@@ -99,8 +99,10 @@ public static class JsonFile
                 File.Move(path, kept);
                 return kept;
             }
-            catch (IOException) when (File.Exists(kept))
+            catch (IOException) when (File.Exists(kept) || Directory.Exists(kept))
             {
+                // Something is already at that name, so try the next one. File.Exists alone
+                // reports false for a directory, which would end the search on the first slot.
                 continue;
             }
             catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)

--- a/src/utility/jsonfile.cs
+++ b/src/utility/jsonfile.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Underworld;
+
+/// <summary>Why a read did not produce a value.</summary>
+public enum JsonReadOutcome
+{
+    Ok,
+    /// <summary>There is no file at that path.</summary>
+    NotFound,
+    /// <summary>There is a file, and it could not be read or did not parse.</summary>
+    Unreadable,
+}
+
+/// <summary>
+/// Reading the small JSON documents the game keeps in its user directory.
+///
+/// This is deliberately free of Godot types so it can be unit tested. <see cref="uwsettings"/>
+/// resolves its path through <c>ProjectSettings.GlobalizePath</c>, and touching that class at
+/// all runs its static constructor, which a headless test process cannot do.
+/// </summary>
+public static class JsonFile
+{
+    /// <summary>
+    /// Read and deserialise <paramref name="path"/>, reporting failure rather than throwing.
+    ///
+    /// The outcome distinguishes a missing file from one that is present and unusable, so the
+    /// caller does not have to go back to the filesystem to find out which it was. Asking twice
+    /// is a race: the file can appear, change or vanish in between, and the caller would then
+    /// act on the wrong answer and move a perfectly good file aside.
+    /// </summary>
+    public static JsonReadOutcome TryRead<T>(
+        string path, JsonSerializerOptions options, out T value, out string error)
+    {
+        value = default;
+        error = null;
+
+        FileStream stream;
+        try
+        {
+            stream = File.OpenRead(path);
+        }
+        catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
+        {
+            error = "no such file";
+            return JsonReadOutcome.NotFound;
+        }
+        catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
+        {
+            // Present but cannot be opened, e.g. permissions. Distinct from absent, and it must
+            // not escape: the caller runs from a static constructor, where an exception faults
+            // the type for the rest of the process.
+            error = e.Message;
+            return JsonReadOutcome.Unreadable;
+        }
+
+        try
+        {
+            using (stream)
+            {
+                value = JsonSerializer.Deserialize<T>(stream, options);
+            }
+            if (value == null)
+            {
+                // A document holding literal "null" parses and gives us nothing to use.
+                error = "the document holds no object";
+                return JsonReadOutcome.Unreadable;
+            }
+            return JsonReadOutcome.Ok;
+        }
+        catch (Exception e) when (e is JsonException || e is IOException || e is NotSupportedException)
+        {
+            error = e.Message;
+            value = default;
+            return JsonReadOutcome.Unreadable;
+        }
+    }
+
+    /// <summary>
+    /// Move a file that could not be read to one side, so it survives being replaced by the
+    /// defaults that take over from it. Returns where it was put, or null if it could not be
+    /// moved.
+    /// </summary>
+    public static string PreserveUnreadable(string path)
+    {
+        // Never overwrite a copy already kept. The first bad file is usually the one holding
+        // the settings somebody actually wants back, and a second bad file arriving later
+        // would otherwise destroy it. Number them instead, and stop rather than sprawl.
+        const int MaxKept = 10;
+        for (int n = 0; n < MaxKept; n++)
+        {
+            string kept = path + ".corrupt" + (n == 0 ? "" : "." + (n + 1));
+            try
+            {
+                // overwrite: false, so an existing copy makes this throw and we try the next
+                // name rather than replacing it.
+                File.Move(path, kept);
+                return kept;
+            }
+            catch (IOException) when (File.Exists(kept))
+            {
+                continue;
+            }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/Underworld.Save.Tests/GameSelectionTests.cs
+++ b/tests/Underworld.Save.Tests/GameSelectionTests.cs
@@ -57,18 +57,4 @@ public class GameSelectionTests
         Assert.False(GameSelection.TryResolve(value, out byte res));
         Assert.Equal(UWClass.GAME_UW1, res);
     }
-
-    [Fact]
-    public void TheValueUsedAsTheFallbackResolves()
-    {
-        // LoadSettings falls back to a fresh uwsettings when the file names no game, and then
-        // resolves that. If this stopped resolving, the fallback would be selecting a game
-        // nobody asked for, so LoadSettings reports it rather than carrying on quietly.
-        //
-        // Spelled out rather than read from uwsettings.gametoload: constructing that class runs
-        // its static constructor, which calls into Godot and takes a headless test host down
-        // with it. If the default in config.cs ever changes, change it here too.
-        Assert.True(GameSelection.TryResolve("UW1", out byte res));
-        Assert.Equal(UWClass.GAME_UW1, res);
-    }
 }

--- a/tests/Underworld.Save.Tests/GameSelectionTests.cs
+++ b/tests/Underworld.Save.Tests/GameSelectionTests.cs
@@ -1,0 +1,74 @@
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Covers <see cref="GameSelection.TryResolve"/>, which decides what game the gametoload
+/// setting names.
+///
+/// It used to be a switch inside LoadSettings whose default threw. LoadSettings runs from a
+/// static constructor, so a settings file that parsed but named no game faulted the type for
+/// the rest of the process: every later read of uwsettings.instance threw and the game could
+/// not start, with nothing on screen to say why. Verified against a real build before the
+/// change, with gametoload set to null and to a nonsense string, and the launcher was never
+/// reached in either case.
+/// </summary>
+public class GameSelectionTests
+{
+    [Theory]
+    [InlineData("UW1")]
+    [InlineData("uw1")]
+    [InlineData("1")]
+    public void TheFirstGameIsRecognisedByNameAndByNumber(string value)
+    {
+        Assert.True(GameSelection.TryResolve(value, out byte res));
+        Assert.Equal(UWClass.GAME_UW1, res);
+    }
+
+    [Theory]
+    [InlineData("UW2")]
+    [InlineData("uw2")]
+    [InlineData("2")]
+    public void TheSecondGameIsRecognisedByNameAndByNumber(string value)
+    {
+        Assert.True(GameSelection.TryResolve(value, out byte res));
+        Assert.Equal(UWClass.GAME_UW2, res);
+    }
+
+    [Theory]
+    [InlineData("UWDEMO")]
+    [InlineData("uwdemo")]
+    [InlineData("0")]
+    public void TheDemoIsRecognisedByNameAndByNumber(string value)
+    {
+        Assert.True(GameSelection.TryResolve(value, out byte res));
+        Assert.Equal(UWClass.GAME_UWDEMO, res);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("banana")]
+    [InlineData("UW3")]
+    [InlineData("3")]
+    public void AValueNamingNoGameIsRefusedRatherThanThrown(string value)
+    {
+        // Null is the case that matters most: a settings file holding "gametoload": null parses
+        // perfectly well, and calling ToUpper on it threw a NullReferenceException out of the
+        // static constructor.
+        Assert.False(GameSelection.TryResolve(value, out byte res));
+        Assert.Equal(UWClass.GAME_UW1, res);
+    }
+
+    [Fact]
+    public void TheValueUsedAsTheFallbackResolves()
+    {
+        // LoadSettings falls back to a fresh uwsettings when the file names no game, and then
+        // resolves that. If this stopped resolving, the fallback would be selecting a game
+        // nobody asked for, so LoadSettings reports it rather than carrying on quietly.
+        //
+        // Spelled out rather than read from uwsettings.gametoload: constructing that class runs
+        // its static constructor, which calls into Godot and takes a headless test host down
+        // with it. If the default in config.cs ever changes, change it here too.
+        Assert.True(GameSelection.TryResolve("UW1", out byte res));
+        Assert.Equal(UWClass.GAME_UW1, res);
+    }
+}

--- a/tests/Underworld.Save.Tests/JsonFileTests.cs
+++ b/tests/Underworld.Save.Tests/JsonFileTests.cs
@@ -199,14 +199,35 @@ public class JsonFileTests
     }
 
     [Fact]
-    public void PreserveUnreadable_WhenItCannotMove_ReportsFailureRatherThanThrowing()
+    public void PreserveUnreadable_WithNothingToMove_ReportsFailureRatherThanThrowing()
     {
         string dir = TempDir();
         try
         {
-            // Nothing to move. The caller uses the null to tell the user that the bad file is
-            // still in place and the next save will replace it.
             Assert.Null(JsonFile.PreserveUnreadable(Path.Combine(dir, "absent.json")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PreserveUnreadable_StepsPastADirectorySittingOnTheName()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            File.WriteAllText(path, "the bad one");
+            // A directory where the first copy would go. File.Exists reports false for one, so
+            // a collision check that only asks File.Exists gives up here instead of trying the
+            // next name, and the bad file is left to be overwritten by the next save.
+            Directory.CreateDirectory(path + ".corrupt");
+
+            string kept = JsonFile.PreserveUnreadable(path);
+
+            Assert.NotNull(kept);
+            Assert.Equal(path + ".corrupt.2", kept);
+            Assert.Equal("the bad one", File.ReadAllText(kept));
+            Assert.False(File.Exists(path));
         }
         finally { Directory.Delete(dir, true); }
     }

--- a/tests/Underworld.Save.Tests/JsonFileTests.cs
+++ b/tests/Underworld.Save.Tests/JsonFileTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Covers <see cref="JsonFile"/>, which is how the settings file is read.
+///
+/// Issue #77 reported that a settings file could be left holding the tail of an older, longer
+/// document, and 1f46059f fixed the write that caused it. What is covered here is the other
+/// half: a settings file that cannot be read for any reason used to take the game down with it,
+/// because LoadSettings runs from a static constructor and nothing caught the failure. That is
+/// still reachable for a file corrupted by an earlier build, and for a write interrupted between
+/// truncating the file and filling it.
+/// </summary>
+public class JsonFileTests
+{
+    private static readonly JsonSerializerOptions Opts = new() { WriteIndented = true };
+
+    private sealed class Settings
+    {
+        public string game { get; set; } = "";
+        public string synth { get; set; } = "";
+    }
+
+    private static string TempDir()
+    {
+        string d = Path.Combine(Path.GetTempPath(), "uwjson-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    [Fact]
+    public void TryRead_WithATailFromAnOlderDocument_SaysItIsUnreadable()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            // Exactly the shape #77 produced: a complete document with stale bytes after it.
+            File.WriteAllText(path, "{\n  \"game\": \"UW1\"\n}: \"\"\n}\n");
+
+            Assert.Equal(JsonReadOutcome.Unreadable,
+                JsonFile.TryRead<Settings>(path, Opts, out var value, out string error));
+            Assert.Null(value);
+            Assert.False(string.IsNullOrEmpty(error));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void TryRead_WithATruncatedDocument_SaysItIsUnreadable()
+    {
+        string dir = TempDir();
+        try
+        {
+            // What a write interrupted after truncating but before finishing leaves behind.
+            string path = Path.Combine(dir, "settings.json");
+            File.WriteAllText(path, "{\n  \"game\": \"UW");
+
+            Assert.Equal(JsonReadOutcome.Unreadable,
+                JsonFile.TryRead<Settings>(path, Opts, out var value, out _));
+            Assert.Null(value);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void TryRead_WithNoFile_SaysNotFoundRatherThanUnreadable()
+    {
+        string dir = TempDir();
+        try
+        {
+            // The caller acts differently on the two, so they must not be conflated: one loads
+            // defaults quietly, the other moves the file aside and warns.
+            Assert.Equal(JsonReadOutcome.NotFound, JsonFile.TryRead<Settings>(
+                Path.Combine(dir, "absent.json"), Opts, out var value, out _));
+            Assert.Null(value);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void TryRead_WhenTheFileCannotBeOpened_SaysUnreadableRatherThanThrowing()
+    {
+        string dir = TempDir();
+        try
+        {
+            // A directory where the file should be. Opening it fails in the same way a
+            // permissions problem does, and the point is that nothing escapes: the caller runs
+            // from a static constructor, where an exception faults the type for the process.
+            string path = Path.Combine(dir, "settings.json");
+            Directory.CreateDirectory(path);
+
+            Assert.Equal(JsonReadOutcome.Unreadable,
+                JsonFile.TryRead<Settings>(path, Opts, out var value, out string error));
+            Assert.Null(value);
+            Assert.False(string.IsNullOrEmpty(error));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void TryRead_WithALiteralNull_SaysUnreadable()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            File.WriteAllText(path, "null");
+            Assert.Equal(JsonReadOutcome.Unreadable,
+                JsonFile.TryRead<Settings>(path, Opts, out var value, out _));
+            Assert.Null(value);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void TryRead_WithAGoodDocument_ReturnsIt()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            File.WriteAllText(path, JsonSerializer.Serialize(
+                new Settings { game = "UW2", synth = "mt32" }, Opts));
+
+            Assert.Equal(JsonReadOutcome.Ok,
+                JsonFile.TryRead<Settings>(path, Opts, out var value, out string error));
+            Assert.Null(error);
+            Assert.Equal("UW2", value.game);
+            Assert.Equal("mt32", value.synth);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PreserveUnreadable_MovesTheFileAsideAndReportsWhere()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            File.WriteAllText(path, "not json at all");
+
+            string kept = JsonFile.PreserveUnreadable(path);
+
+            Assert.Equal(path + ".corrupt", kept);
+            Assert.False(File.Exists(path));
+            Assert.Equal("not json at all", File.ReadAllText(kept));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PreserveUnreadable_DoesNotDestroyACopyItAlreadyKept()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+
+            File.WriteAllText(path, "the first bad one");
+            string first = JsonFile.PreserveUnreadable(path);
+
+            File.WriteAllText(path, "the second bad one");
+            string second = JsonFile.PreserveUnreadable(path);
+
+            // The first copy is usually the one holding settings somebody wants back. A second
+            // bad file arriving later must not overwrite it.
+            Assert.NotEqual(first, second);
+            Assert.Equal("the first bad one", File.ReadAllText(first));
+            Assert.Equal("the second bad one", File.ReadAllText(second));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PreserveUnreadable_StopsRatherThanKeepingCopiesForever()
+    {
+        string dir = TempDir();
+        try
+        {
+            string path = Path.Combine(dir, "settings.json");
+            for (int i = 0; i < 10; i++)
+            {
+                File.WriteAllText(path, "bad " + i);
+                Assert.NotNull(JsonFile.PreserveUnreadable(path));
+            }
+
+            // Eleventh. The caller uses the null to say the file is still in place.
+            File.WriteAllText(path, "one too many");
+            Assert.Null(JsonFile.PreserveUnreadable(path));
+            Assert.Equal("one too many", File.ReadAllText(path));
+            Assert.Equal(10, Directory.GetFiles(dir, "*.corrupt*").Length);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PreserveUnreadable_WhenItCannotMove_ReportsFailureRatherThanThrowing()
+    {
+        string dir = TempDir();
+        try
+        {
+            // Nothing to move. The caller uses the null to tell the user that the bad file is
+            // still in place and the next save will replace it.
+            Assert.Null(JsonFile.PreserveUnreadable(Path.Combine(dir, "absent.json")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}

--- a/tests/Underworld.Save.Tests/SfxStartupOrderTests.cs
+++ b/tests/Underworld.Save.Tests/SfxStartupOrderTests.cs
@@ -8,9 +8,11 @@ namespace Underworld.Save.Tests;
 ///
 /// Two orderings matter, at opposite ends.
 ///
-/// The sound directory must be resolved before anything is built. <c>Path.Combine</c> throws
-/// when no game path is configured, and a throw after the generator was playing and the
-/// producer thread was running left the node half-built, with live audio attached to it.
+/// The sound directory must be resolved before the player and the producer thread exist.
+/// <c>Path.Combine</c> throws when no game path is configured, and a throw after the generator
+/// was playing and the thread was running left both going against a construction that had
+/// already failed. The chip and the singleton are created earlier still and are taken down by
+/// <c>_ExitTree</c>, so this is about what gets started, not about leaks.
 ///
 /// <c>SoundEffects.Initialize</c> must come last, because it is what makes this node reachable
 /// from <c>SoundEffects.Play</c>. Publishing it earlier would mean a failure while building the
@@ -45,7 +47,7 @@ public class SfxStartupOrderTests
 
         Assert.True(combine < play,
             "the sound directory must be resolved before the generator plays, or a failure to "
-            + "resolve it leaves audio running with no way to stop it (#79)");
+            + "resolve it leaves audio playing that nothing asked to start (#79)");
         Assert.True(combine < startThread,
             "the sound directory must be resolved before the producer thread starts (#79)");
     }
@@ -67,7 +69,7 @@ public class SfxStartupOrderTests
     {
         string s = Source;
 
-        int initialise = PositionOf(s, "SoundEffects.Initialize");
+        int initialise = PositionOf(s, "SoundEffects.Initialize(uwsettings");
         int play = PositionOf(s, "_player.Play()");
         int startThread = PositionOf(s, "_audioThread.Start()");
 

--- a/tests/Underworld.Save.Tests/SfxStartupOrderTests.cs
+++ b/tests/Underworld.Save.Tests/SfxStartupOrderTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Pins the order of work in <c>SfxStreamPlayer._Ready</c>. See issue #79.
+///
+/// Two orderings matter, at opposite ends.
+///
+/// The sound directory must be resolved before anything is built. <c>Path.Combine</c> throws
+/// when no game path is configured, and a throw after the generator was playing and the
+/// producer thread was running left the node half-built, with live audio attached to it.
+///
+/// <c>SoundEffects.Initialize</c> must come last, because it is what makes this node reachable
+/// from <c>SoundEffects.Play</c>. Publishing it earlier would mean a failure while building the
+/// player or starting the thread left callers able to enqueue against a producer that never
+/// ran, which is the same defect the other way round.
+///
+/// This reads the file as text rather than running the node, because constructing it needs a
+/// Godot scene tree and an audio device, neither of which exists in a headless test process.
+/// It is therefore a check on the source and not on behaviour, which is worth knowing when it
+/// fails: the fix is to restore the ordering, not to satisfy the string match.
+/// </summary>
+public class SfxStartupOrderTests
+{
+    private static string Source => File.ReadAllText(Path.Combine(
+        TestData.RepoRoot, "src", "audio", "sfx", "godot", "SfxStreamPlayer.cs"));
+
+    private static int PositionOf(string source, string needle)
+    {
+        int at = source.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(at >= 0, $"SfxStreamPlayer.cs no longer contains \"{needle}\"");
+        return at;
+    }
+
+    [Fact]
+    public void TheSoundDirectoryIsResolvedBeforeAnythingIsStarted()
+    {
+        string s = Source;
+
+        int combine = PositionOf(s, "Path.Combine(UWClass.BasePath");
+        int play = PositionOf(s, "_player.Play()");
+        int startThread = PositionOf(s, "_audioThread.Start()");
+
+        Assert.True(combine < play,
+            "the sound directory must be resolved before the generator plays, or a failure to "
+            + "resolve it leaves audio running with no way to stop it (#79)");
+        Assert.True(combine < startThread,
+            "the sound directory must be resolved before the producer thread starts (#79)");
+    }
+
+    [Fact]
+    public void AMissingGamePathIsRefusedRatherThanThrown()
+    {
+        string s = Source;
+
+        int guard = PositionOf(s, "string.IsNullOrWhiteSpace(UWClass.BasePath)");
+        int combine = PositionOf(s, "Path.Combine(UWClass.BasePath");
+
+        Assert.True(guard < combine,
+            "BasePath must be checked before Path.Combine uses it, which throws on null (#79)");
+    }
+
+    [Fact]
+    public void TheBackendIsPublishedOnlyOnceThereIsSomethingBehindIt()
+    {
+        string s = Source;
+
+        int initialise = PositionOf(s, "SoundEffects.Initialize");
+        int play = PositionOf(s, "_player.Play()");
+        int startThread = PositionOf(s, "_audioThread.Start()");
+
+        Assert.True(initialise > play,
+            "SoundEffects.Initialize makes this node reachable from SoundEffects.Play, so it "
+            + "must come after the player exists");
+        Assert.True(initialise > startThread,
+            "publishing before the producer thread starts would let callers enqueue against a "
+            + "producer that never ran");
+    }
+}


### PR DESCRIPTION
Two faults that both end the same way: the game will not start, and nothing on screen says why.

Closes #79. References #77, which you already closed with 1f46059f. That fixed the write. This
is the read, which the write fix does not reach.

## The settings file

`LoadSettings` runs from a static constructor, so anything thrown there faults the type for the
rest of the process. Every later read of `uwsettings.instance` throws, `UWClass.BasePath` is
never set, and the launcher is never reached. The file has to be repaired by hand.

Three ways in, all still reachable on main today:

- A file that will not parse. Corrupted by a build from before 1f46059f, or by an interruption
  between `File.Create` emptying the file and the write finishing.
- A file that cannot be opened at all, for instance on permissions.
- A file that parses and is still unusable. `"gametoload": null` threw `NullReferenceException`
  on `ToUpper` before the switch was entered, and a value naming no game reached a
  `default: throw`.

Any of those now keeps the file beside the original, says so, and carries on with defaults.
Copies are numbered rather than overwritten, because the first bad file is usually the one
holding the settings somebody wants back.

Checked against a real build, before and after. Each row is a game that will not start on main:

| settings.json | reaches launcher | file kept |
| --- | --- | --- |
| `gametoload: null` | yes | yes |
| `gametoload: "banana"` | yes | yes |
| trailing garbage after the closing brace | yes | yes |
| not JSON at all | yes | yes |
| unchanged | yes | not touched |

## SfxStreamPlayer

`_Ready` played the generator and started the producer thread, and only then resolved the sound
directory. `Path.Combine` throws when `BasePath` is null, which is exactly what the settings
failure above produces, so the node was left with audio playing and a thread running against a
construction that had already failed.

The path is resolved first now, and `SoundEffects.Initialize` comes last. The first version of
this change only moved the problem: publishing the backend early meant a failure while building
the player or starting the thread left callers able to enqueue against a producer that never
ran. The thread reads no `SoundEffects` state, so it is safe already running when the backend
is published.

An early return still leaves the OPL chip allocated and the singleton published, since both
happen earlier in `_Ready`. `_ExitTree` takes them down. What it stops is the generator and the
thread starting against a node that is going to fail.

## What is not covered

`LoadSettings` itself has no test. Touching `uwsettings` runs its static constructor, which
calls into Godot and takes a headless test host down with it, so the wiring is covered by
running the game rather than by a test. The parts that can be isolated, `JsonFile` and
`GameSelection`, are unit tested.

The SFX test reads the source as text and asserts statement order. It pins the ordering and not
the behaviour, which is worth knowing when it fails, and it is there because constructing the
node needs a scene tree and an audio device.

## Testing

209 tests pass, none skipped. Every fix was checked by reverting it and confirming tests fail:
the game-selection guards 5, the JSON read guard 1, the preserved-copy overwrite 2, the
directory collision 1, publishing the backend early 1, the SFX ordering 2.

Played on UW1 with `synth: opl`, which is the configuration where SFX actually has a backend.
Combat, doors and footsteps all sound normal, and the session log holds no audio messages at
all.
