### PR TITLE
fix(save): replace a save slot as a unit so a failed save cannot leave a mixture

### DIFF
--- a/src/savegame/SaveGame.cs
+++ b/src/savegame/SaveGame.cs
@@ -20,42 +20,80 @@ namespace Underworld
             // cannot store has to fail while that is all still untouched.
             byte[] descriptionBytes = SaveDescription.Encode(description);
 
-            string saveDir = Path.Combine(UWClass.BasePath, $"SAVE{slot}");
-            Directory.CreateDirectory(saveDir);
+            // Read the base path once and hand it to the transaction. SlotTransaction is kept
+            // free of UWClass so it can be tested against a temporary directory.
+            string basePath = UWClass.BasePath;
 
-            // Detach the player from its tile's object chain FIRST so the
-            // pdat stash (which copies LevelObjects[1] bytes into pdat) sees
-            // a clean .next = 0 player rather than the chain-inserted
-            // next = <previous head> that PlacePlayerInTile produced during
-            // play. DOS expects the player object to have next = 0.
-            DetachPlayerFromCurrentTile();
-            StashLiveStateToPdat();
-            ApplySlot1Markers();
+            // The slot is replaced as a unit: everything is built in a staging directory and
+            // swapped in, so a failure part way leaves the previous save whole rather than a
+            // mixture of old and new files. See issue #74 and SlotTransaction.
+            SlotTransaction.Replace(basePath, slot, RequiredFiles(), staging =>
+            {
+                // Detach the player from its tile's object chain FIRST so the
+                // pdat stash (which copies LevelObjects[1] bytes into pdat) sees
+                // a clean .next = 0 player rather than the chain-inserted
+                // next = <previous head> that PlacePlayerInTile produced during
+                // play. DOS expects the player object to have next = 0.
+                //
+                // All of this lives inside the callback, and the restore finishes before it
+                // returns. Two reasons. The detach used to happen outside the try, so a throw
+                // in it or in the stash or the markers left the player detached and never put
+                // back. And restoring after the swap would mean a throw there reporting a
+                // failure over a save that had already landed.
+                bool detached = false;
+                try
+                {
+                    detached = DetachPlayerFromCurrentTile();
+                    StashLiveStateToPdat();
+                    ApplySlot1Markers();
 
-            // DOS UW.EXE never writes the player (slot 1) into a tile's
-            // indexObjectList — it tracks player position separately via the
-            // mouse/motion path. The port's PlacePlayerInTile intentionally
-            // inserts slot 1 at the chain head for in-game collision, and
-            // without this detach step the serialised LEV.ARK contains a
-            // tile whose first-object-in-chain points at slot 1, which DOS
-            // treats as an invalid object list ("problems in object list"
-            // error, render bails out with wall/floor/ceiling textures
-            // missing).
-            try
+                    // DOS UW.EXE never writes the player (slot 1) into a tile's
+                    // indexObjectList — it tracks player position separately via the
+                    // mouse/motion path. The port's PlacePlayerInTile intentionally
+                    // inserts slot 1 at the chain head for in-game collision, and
+                    // without this detach step the serialised LEV.ARK contains a
+                    // tile whose first-object-in-chain points at slot 1, which DOS
+                    // treats as an invalid object list ("problems in object list"
+                    // error, render bails out with wall/floor/ceiling textures
+                    // missing).
+                    WriteAllSaveFiles(staging, descriptionBytes);
+                }
+                finally
+                {
+                    // Re-insert slot 1 so in-memory game state stays consistent
+                    // if the user keeps playing after saving. The post-detach
+                    // tile.indexObjectList already holds the previous chain
+                    // head (sans slot 1), so head-inserting slot 1 restores the
+                    // PlacePlayerInTile invariant — no saved-head value needed.
+                    if (detached) { ReattachPlayerToCurrentTile(); }
+                    //Set the player back to being an adventurer
+                    playerdat.playerObject.item_id = 127;
+                }
+            });
+        }
+
+        /// <summary>
+        /// What a complete slot has to contain before it may replace the one already there.
+        ///
+        /// DESC is allowed to be empty: DOS writes a zero length DESC for an empty description
+        /// and the slot still counts as occupied. The level archives are not, because a zero
+        /// byte archive is a write that failed. SCD.ARK is UW2 only, and matters most of all:
+        /// ScdArkWriter.Serialize returns an empty array when its source is missing, so without
+        /// this a UW2 save would commit a zero byte SCD.ARK as if it were finished.
+        /// </summary>
+        private static SlotRequirements RequiredFiles()
+        {
+            var content = UWClass._RES == UWClass.GAME_UW2
+                ? new[] { "PLAYER.DAT", "LEV.ARK", "SCD.ARK" }
+                : new[] { "PLAYER.DAT", "LEV.ARK" };
+            return new SlotRequirements
             {
-                WriteAllSaveFiles(saveDir, descriptionBytes);
-            }
-            finally
-            {
-                // Re-insert slot 1 so in-memory game state stays consistent
-                // if the user keeps playing after saving. The post-detach
-                // tile.indexObjectList already holds the previous chain
-                // head (sans slot 1), so head-inserting slot 1 restores the
-                // PlacePlayerInTile invariant — no saved-head value needed.
-                ReattachPlayerToCurrentTile();
-                //Set the player back to being an adventurer                
-                playerdat.playerObject.item_id = 127;
-            }
+                // BGLOBALS.DAT joins DESC in being allowed to be empty. BGlobalWriter writes
+                // one record per conversation global, so a game with none serialises to zero
+                // bytes, which is a correct file rather than a failed write.
+                MustExist = new[] { "DESC", "BGLOBALS.DAT" },
+                MustHaveContent = content,
+            };
         }
 
         private static void WriteAllSaveFiles(string saveDir, byte[] descriptionBytes)
@@ -88,25 +126,33 @@ namespace Underworld
         /// to slot 1's old .next (or leaves it alone if slot 1 was mid-chain
         /// with the parent's .next rewritten). slot 1's .next is then cleared.
         /// </summary>
-        private static void DetachPlayerFromCurrentTile()
+        /// <returns>
+        /// Whether the player was actually taken out of a chain. The caller only puts it back
+        /// if it was: the removal reports failure when slot 1 was not in this tile's list, and
+        /// head-inserting it regardless would add the player to a chain it had never been in,
+        /// or splice another tile's chain into this one through the cleared next pointer.
+        /// </returns>
+        private static bool DetachPlayerFromCurrentTile()
         {
             if (UWTileMap.current_tilemap == null ||
                 UWTileMap.current_tilemap.LevelObjects == null ||
                 UWTileMap.current_tilemap.LevelObjects[1] == null)
             {
-                return;
+                return false;
             }
             int tx = motion.playerMotionParams.x_0 >> 8;
             int ty = motion.playerMotionParams.y_2 >> 8;
-            if (!UWTileMap.ValidTile(tx, ty)) return;
+            if (!UWTileMap.ValidTile(tx, ty)) { return false; }
             var tile = UWTileMap.current_tilemap.Tiles[tx, ty];
-            ObjectRemover_OLD.RemoveObjectFromLinkedList(
+            bool removed = ObjectRemover_OLD.RemoveObjectFromLinkedList(
                 tile.indexObjectList, 1,
                 UWTileMap.current_tilemap.LevelObjects,
                 tile.Ptr + 2);
+            if (!removed) { return false; }
             // Clear slot 1's next so a freshly loaded save has a clean player
             // slot with no dangling chain pointer.
             UWTileMap.current_tilemap.LevelObjects[1].next = 0;
+            return true;
         }
 
         /// <summary>

--- a/src/savegame/SlotTransaction.cs
+++ b/src/savegame/SlotTransaction.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Underworld
+{
+    /// <summary>
+    /// What a slot must contain before it is allowed to replace the one already there.
+    /// The caller supplies this because only it knows which files the game writes:
+    /// SCD.ARK is required for UW2 and never written for UW1.
+    /// </summary>
+    public sealed class SlotRequirements
+    {
+        /// <summary>Files that must exist, whatever their length. DESC is one: DOS writes a
+        /// zero-length DESC for an empty description and the slot is still occupied.</summary>
+        public string[] MustExist = Array.Empty<string>();
+
+        /// <summary>Files that must exist and hold something. An empty archive is a failed
+        /// write, not a save: ScdArkWriter returns an empty array when its source is missing,
+        /// which would otherwise be committed as a complete UW2 save.</summary>
+        public string[] MustHaveContent = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Replaces a save slot as a unit, so a failure leaves either the whole previous save or
+    /// the whole new one, never a mixture of the two.
+    ///
+    /// Issue #74. SaveGame.Save used to write DESC, PLAYER.DAT, BGLOBALS.DAT and LEV.ARK
+    /// straight into the live slot, so anything going wrong part way left old and new files
+    /// together. DESC is written first and the two slot listers key off it, while restore keys
+    /// off LEV.ARK, so the usual result was a slot listed with a name that refused to load.
+    ///
+    /// Real DOS behaves the same way, measured by driving UW.EXE: saving over an occupied slot
+    /// overwrites the files it writes and leaves everything else alone. So this is a deliberate
+    /// improvement on the original rather than emulation of it, and the foreign files DOS
+    /// leaves behind are carried across so that much still matches.
+    ///
+    /// Godot-free, and takes its base path rather than reading UWClass.BasePath, so it can be
+    /// tested against a temporary directory.
+    /// </summary>
+    public static class SlotTransaction
+    {
+        /// <summary>
+        /// Names this class owns, all beside the slot directory. The journal is a fixed name so
+        /// recovery can find it; the other two carry the attempt's id so they cannot collide
+        /// with anything this class did not create.
+        /// </summary>
+        private static string JournalPath(string basePath, int slot) =>
+            Path.Combine(basePath, $"SAVE{slot}.txn");
+        private static string SlotPath(string basePath, int slot) =>
+            Path.Combine(basePath, $"SAVE{slot}");
+        private static string StagingPath(string basePath, int slot, string id) =>
+            Path.Combine(basePath, $"SAVE{slot}.tmp-{id}");
+        private static string BackupPath(string basePath, int slot, string id) =>
+            Path.Combine(basePath, $"SAVE{slot}.old-{id}");
+
+        /// <summary>An id is 32 lower-case hex characters and nothing else. Recovery derives
+        /// path names from it, so a journal that does not carry one is ignored rather than
+        /// acted on.</summary>
+        private static bool IsWellFormedId(string id)
+        {
+            if (id == null || id.Length != 32) { return false; }
+            foreach (char c in id)
+            {
+                bool ok = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+                if (!ok) { return false; }
+            }
+            return true;
+        }
+
+        private sealed class Journal
+        {
+            public int Slot;
+            public string Id;
+            public bool Staged;
+        }
+
+        /// <summary>
+        /// The journal records only the slot, the attempt's id, and whether the staging
+        /// directory passed validation. It deliberately does not record paths: recovery derives
+        /// them, so a journal can only ever name its own two siblings.
+        /// </summary>
+        private static void WriteJournal(string basePath, int slot, string id, bool staged)
+        {
+            string body = $"slot={slot}\nid={id}\nstaged={(staged ? 1 : 0)}\n";
+            string final = JournalPath(basePath, slot);
+            // The scratch name carries the id like everything else this class creates, so
+            // publishing a journal cannot truncate a file somebody else left at a fixed name.
+            string scratch = Path.Combine(basePath, $"SAVE{slot}.txn-{id}.writing");
+            File.WriteAllBytes(scratch, Encoding.ASCII.GetBytes(body));
+            File.Move(scratch, final, overwrite: true);
+        }
+
+        private static Journal ReadJournal(string basePath, int slot)
+        {
+            string path = JournalPath(basePath, slot);
+            string text;
+            try
+            {
+                if (!File.Exists(path)) { return null; }
+                text = File.ReadAllText(path);
+            }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
+            {
+                return null;
+            }
+
+            var j = new Journal { Slot = -1, Id = null, Staged = false };
+            foreach (string line in text.Split('\n'))
+            {
+                int eq = line.IndexOf('=');
+                if (eq <= 0) { continue; }
+                string k = line.Substring(0, eq).Trim();
+                string v = line.Substring(eq + 1).Trim();
+                if (k == "slot" && int.TryParse(v, out int n)) { j.Slot = n; }
+                else if (k == "id") { j.Id = v; }
+                else if (k == "staged") { j.Staged = v == "1"; }
+            }
+            // A journal for another slot, or without a usable id, authorises nothing.
+            if (j.Slot != slot || !IsWellFormedId(j.Id)) { return null; }
+            return j;
+        }
+
+        /// <summary>
+        /// The directory holding save <paramref name="slot"/>, with any interrupted replacement
+        /// finished or undone first.
+        ///
+        /// Everything that reads a slot goes through this rather than building the path itself,
+        /// so a save interrupted by a crash is resolved before anyone looks at what it left.
+        /// The two listers and the restore path all need it: without recovery at the read side,
+        /// an interrupted save would leave the slot missing until the next save happened to
+        /// clean it up.
+        /// </summary>
+        public static string SlotDirectory(string basePath, int slot)
+        {
+            Recover(basePath, slot);
+            return SlotPath(basePath, slot);
+        }
+
+        /// <summary>
+        /// Finish or undo an interrupted replacement of <paramref name="slot"/>. Safe to call
+        /// at any time and safe to call twice: the journal is removed last, so an interruption
+        /// part way leaves the next call repeating the same steps.
+        ///
+        /// Touches only the two names derived from the journal's id. A SAVE1.old, a
+        /// SAVE1.tmp-something from another attempt, or a slot left torn by an older build are
+        /// all left exactly as they are.
+        /// </summary>
+        public static void Recover(string basePath, int slot)
+        {
+            Journal j = ReadJournal(basePath, slot);
+            if (j == null) { return; }
+
+            string live = SlotPath(basePath, slot);
+            string staging = StagingPath(basePath, slot, j.Id);
+            string backup = BackupPath(basePath, slot, j.Id);
+
+            bool cleared;
+            if (Directory.Exists(live))
+            {
+                // Either the swap completed, or it never started. The slot in place is the one
+                // to keep either way, and both of the others are ours to remove.
+                cleared = TryDeleteDirectory(backup) & TryDeleteDirectory(staging);
+            }
+            else if (Directory.Exists(backup))
+            {
+                // Stopped between the two renames. Put the previous save back.
+                Directory.Move(backup, live);
+                cleared = TryDeleteDirectory(staging);
+            }
+            else if (j.Staged && Directory.Exists(staging))
+            {
+                // The new save was complete but never landed. Finish the job rather than throw
+                // it away: it is what the player asked for, and on a filesystem where a
+                // directory rename is not atomic it may be the only copy left.
+                Directory.Move(staging, live);
+                cleared = true;
+            }
+            else
+            {
+                // Nothing worth keeping, or nothing left to keep. A journal claiming a staged
+                // directory that is no longer there has nothing to recover from.
+                cleared = TryDeleteDirectory(staging);
+            }
+
+            // Only now, and only if what it named has gone. Removing it while a directory it
+            // names survives would leave that directory with nothing to record it.
+            if (cleared) { TryDeleteFile(JournalPath(basePath, slot)); }
+        }
+
+        /// <summary>
+        /// Build the new contents of <paramref name="slot"/> in a staging directory and swap it
+        /// in. <paramref name="writeInto"/> is given the staging directory and must write the
+        /// whole slot; it is called after any foreign files have been copied across.
+        ///
+        /// Returns once the new slot is in place. Anything after the swap is cleanup and cannot
+        /// fail the save.
+        /// </summary>
+        public static void Replace(string basePath, int slot, SlotRequirements required,
+                                   Action<string> writeInto)
+        {
+            if (basePath == null) { throw new ArgumentNullException(nameof(basePath)); }
+            if (writeInto == null) { throw new ArgumentNullException(nameof(writeInto)); }
+            required = required ?? new SlotRequirements();
+
+            // Anything left by an earlier attempt is resolved before this one starts.
+            Recover(basePath, slot);
+
+            // Recovery consumes a journal it recognises, so one still sitting here is not ours.
+            // Publishing over it would destroy whatever it is.
+            if (File.Exists(JournalPath(basePath, slot)))
+            {
+                throw new IOException(
+                    $"save slot {slot}: {Path.GetFileName(JournalPath(basePath, slot))} already "
+                    + "exists and was not written by the game");
+            }
+
+            string live = SlotPath(basePath, slot);
+            string id = Guid.NewGuid().ToString("N");
+            string staging = StagingPath(basePath, slot, id);
+            string backup = BackupPath(basePath, slot, id);
+
+            // Refuse rather than adopt a name that is already taken. Astronomically unlikely
+            // with a GUID, but the whole scheme rests on those two names being ours.
+            if (Directory.Exists(staging) || File.Exists(staging) ||
+                Directory.Exists(backup) || File.Exists(backup))
+            {
+                throw new IOException($"save slot {slot}: a working name is already in use");
+            }
+
+            WriteJournal(basePath, slot, id, staged: false);
+            Directory.CreateDirectory(staging);
+            CopyForeignEntries(live, staging, required);
+
+            writeInto(staging);
+            Validate(staging, required);
+
+            // Only now is the staging directory worth keeping if everything else falls over.
+            WriteJournal(basePath, slot, id, staged: true);
+
+            if (Directory.Exists(live)) { Directory.Move(live, backup); }
+            Directory.Move(staging, live);
+
+            // Committed. Nothing below here may throw out of this method: the save has landed
+            // and reporting it as failed would be a lie, and the slot listing that follows
+            // would try again and fail again.
+            // Same rule as recovery: the journal may only go once what it names has, or the
+            // backup would be left with nothing recording it.
+            if (TryDeleteDirectory(backup)) { TryDeleteFile(JournalPath(basePath, slot)); }
+        }
+
+        /// <summary>
+        /// Carry across anything already in the slot that this save does not write itself. DOS
+        /// leaves such files alone, and swapping a fresh directory in would silently delete
+        /// them.
+        ///
+        /// Regular files only. Anything else stops the save, because the alternative is to drop
+        /// it quietly: a subdirectory would be lost when the backup is deleted, and copying a
+        /// symlink would follow it and replace the link with its target.
+        /// </summary>
+        private static void CopyForeignEntries(string live, string staging, SlotRequirements required)
+        {
+            if (!Directory.Exists(live)) { return; }
+
+            // Ordinal, not case-insensitive: on a case-sensitive filesystem a foreign "desc"
+            // is a different file from the "DESC" we write, and treating it as ours would skip
+            // it here and lose it when the backup goes.
+            var ours = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string n in required.MustExist) { ours.Add(n); }
+            foreach (string n in required.MustHaveContent) { ours.Add(n); }
+
+            foreach (string entry in Directory.GetFileSystemEntries(live))
+            {
+                string name = Path.GetFileName(entry);
+                var info = new FileInfo(entry);
+                bool plainFile = info.Exists
+                    && (info.Attributes & FileAttributes.Directory) == 0
+                    && (info.Attributes & FileAttributes.ReparsePoint) == 0;
+                if (!plainFile)
+                {
+                    throw new IOException(
+                        $"save slot: {name} is not a plain file, so saving would lose it");
+                }
+                if (ours.Contains(name)) { continue; }
+                File.Copy(entry, Path.Combine(staging, name));
+            }
+        }
+
+        private static void Validate(string staging, SlotRequirements required)
+        {
+            foreach (string name in required.MustExist)
+            {
+                if (!File.Exists(Path.Combine(staging, name)))
+                {
+                    throw new IOException($"save is incomplete: {name} was not written");
+                }
+            }
+            foreach (string name in required.MustHaveContent)
+            {
+                var f = new FileInfo(Path.Combine(staging, name));
+                if (!f.Exists) { throw new IOException($"save is incomplete: {name} was not written"); }
+                if (f.Length == 0) { throw new IOException($"save is incomplete: {name} is empty"); }
+            }
+        }
+
+        /// <summary>Returns whether the directory is gone afterwards. The journal may only be
+        /// removed once everything it names has been, or a later run would have no record of
+        /// what is left to clear up.</summary>
+        private static bool TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path)) { Directory.Delete(path, recursive: true); }
+                return !Directory.Exists(path);
+            }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try { if (File.Exists(path)) { File.Delete(path); } }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -222,7 +222,7 @@ namespace Underworld
 			{
 				for (int i = 1; i <= 4; i++)
 				{
-					var path = Path.Combine(UWClass.BasePath, $"SAVE{i}", "DESC");
+					var path = Path.Combine(SlotTransaction.SlotDirectory(UWClass.BasePath, i), "DESC");
 					if (SaveDescription.TryReadSlot(path, out string savename))
 					{
 						EnableDisable(SaveGamesNames[i - 1], true);

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -460,7 +460,7 @@ namespace Underworld
                                 case 3:
                                 case 4://try and restore game
                                     {
-                                        var path = System.IO.Path.Combine(UWClass.BasePath, $"SAVE{extra_arg_0}", "LEV.ARK");
+                                        var path = System.IO.Path.Combine(SlotTransaction.SlotDirectory(UWClass.BasePath, (int)extra_arg_0), "LEV.ARK");
                                         if (System.IO.File.Exists(path))
                                         {
                                             JourneyOnwards($"SAVE{extra_arg_0}");
@@ -802,7 +802,7 @@ namespace Underworld
         /// </summary>
         private static void BeginSaveDescription(int slot)
         {
-            var descPath = System.IO.Path.Combine(UWClass.BasePath, $"SAVE{slot}", "DESC");
+            var descPath = System.IO.Path.Combine(SlotTransaction.SlotDirectory(UWClass.BasePath, slot), "DESC");
             string existing = SaveDescription.TryReadSlot(descPath, out string stored)
                 ? stored
                 : UnusedSlotPlaceholder;
@@ -1034,7 +1034,7 @@ namespace Underworld
             instance.scroll.Clear();
             for (int i = 1; i <= 4; i++)
             {
-                var path = System.IO.Path.Combine(UWClass.BasePath, $"SAVE{i}", "DESC");
+                var path = System.IO.Path.Combine(SlotTransaction.SlotDirectory(UWClass.BasePath, i), "DESC");
                 if (SaveDescription.TryReadSlot(path, out string savename))
                 {
                     AddToMessageScroll(

--- a/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
+++ b/tests/Underworld.Save.Tests/SaveGameOrchestratorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -332,4 +333,111 @@ public class SaveGameOrchestratorTests : IDisposable
         SaveGame.Save(3, "second");
         Assert.Equal(Encoding.ASCII.GetBytes("second"), File.ReadAllBytes(descPath));
     }
+    // ---- issue #74: the slot is replaced as a unit ---------------------------------------
+
+    /// <summary>Working files left beside a slot, which a finished save must not leave.</summary>
+    private string[] LeftoversBeside(int slot)
+    {
+        return System.IO.Directory.GetFileSystemEntries(_tempRoot)
+            .Select(System.IO.Path.GetFileName)
+            .Where(x => x.StartsWith($"SAVE{slot}.", StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    [Fact]
+    public void Save_LeavesNoWorkingFilesBehind()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(1, "first");
+
+        // No journal, no staging directory, no backup.
+        Assert.Empty(LeftoversBeside(1));
+        Assert.True(File.Exists(Path.Combine(_tempRoot, "SAVE1", "LEV.ARK")));
+    }
+
+    [Fact]
+    public void Save_OverAnOccupiedSlot_KeepsAFileTheGameDidNotWrite()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+        SaveGame.Save(1, "first");
+        File.WriteAllText(Path.Combine(_tempRoot, "SAVE1", "NOTES.TXT"), "mine");
+
+        SaveGame.Save(1, "second");
+
+        // DOS leaves such files alone, measured by driving UW.EXE, so swapping a fresh
+        // directory in without carrying them across would be a regression.
+        Assert.Equal("mine", File.ReadAllText(Path.Combine(_tempRoot, "SAVE1", "NOTES.TXT")));
+        Assert.Equal("second", File.ReadAllText(Path.Combine(_tempRoot, "SAVE1", "DESC")));
+        Assert.Empty(LeftoversBeside(1));
+    }
+
+    [Fact]
+    public void Save_TwiceToTheSameSlot_LeavesOnlyTheSecond()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+
+        SaveGame.Save(1, "first");
+        long firstLen = new FileInfo(Path.Combine(_tempRoot, "SAVE1", "LEV.ARK")).Length;
+        SaveGame.Save(1, "second");
+
+        // The second save runs recovery first, then replaces the slot again.
+        Assert.Equal("second", File.ReadAllText(Path.Combine(_tempRoot, "SAVE1", "DESC")));
+        Assert.Equal(firstLen, new FileInfo(Path.Combine(_tempRoot, "SAVE1", "LEV.ARK")).Length);
+        Assert.Empty(LeftoversBeside(1));
+    }
+
+    [Fact]
+    public void Save_DoesNotDisturbAnotherSlot()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+        SaveGame.Save(2, "two");
+
+        SaveGame.Save(1, "one");
+
+        Assert.Equal("two", File.ReadAllText(Path.Combine(_tempRoot, "SAVE2", "DESC")));
+        Assert.Empty(LeftoversBeside(2));
+    }
+
+    [Fact]
+    public void Save_ThatFailsPartWay_LeavesThePreviousSaveIntact()
+    {
+        SetupUw1State();
+        UWClass.BasePath = _tempRoot;
+        SaveGame.Save(1, "good save");
+        var before = Directory.GetFiles(Path.Combine(_tempRoot, "SAVE1"))
+            .ToDictionary(Path.GetFileName, File.ReadAllBytes);
+
+        // Make the third file fail. BGlobalWriter iterates the globals it is given, so a null
+        // array throws after DESC and PLAYER.DAT have been written. This is issue #74 itself:
+        // writing straight into the slot got that far and left the slot holding the new DESC
+        // and the new PLAYER.DAT beside the old LEV.ARK, listed under a name that would not
+        // load.
+        bglobal.bGlobals = null;
+
+        Assert.ThrowsAny<Exception>(() => SaveGame.Save(1, "doomed"));
+
+        // The previous save is untouched, byte for byte across every file. This is the whole
+        // point of the issue.
+        foreach (var kv in before)
+        {
+            Assert.Equal(kv.Value, File.ReadAllBytes(Path.Combine(_tempRoot, "SAVE1", kv.Key)));
+        }
+        Assert.Equal(before.Count,
+            Directory.GetFiles(Path.Combine(_tempRoot, "SAVE1")).Length);
+
+        // The journal and the abandoned staging directory are still there, because they are
+        // what tells the next run there is something to tidy.
+        Assert.NotEmpty(LeftoversBeside(1));
+
+        // And the next read clears them, since every reader resolves the slot through recovery.
+        string dir = SlotTransaction.SlotDirectory(_tempRoot, 1);
+        Assert.Equal("good save", File.ReadAllText(Path.Combine(dir, "DESC")));
+        Assert.Empty(LeftoversBeside(1));
+    }
+
 }

--- a/tests/Underworld.Save.Tests/SlotTransactionTests.cs
+++ b/tests/Underworld.Save.Tests/SlotTransactionTests.cs
@@ -1,0 +1,437 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Underworld.Save.Tests;
+
+/// <summary>
+/// Covers <see cref="SlotTransaction"/>, which replaces a save slot as a unit.
+///
+/// Issue #74: the slot was written in place, so a failure part way left old and new files
+/// mixed. DESC is written first and both slot listers key off it while restore keys off
+/// LEV.ARK, so the usual result was a slot listed with a name that refused to load.
+///
+/// These drive the helper against a temporary directory. It takes its base path rather than
+/// reading UWClass.BasePath precisely so this is possible without touching global state.
+/// </summary>
+public class SlotTransactionTests : IDisposable
+{
+    private readonly string _root;
+
+    public SlotTransactionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "uwslot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private string Slot(int n = 1) => Path.Combine(_root, $"SAVE{n}");
+    private string Journal(int n = 1) => Path.Combine(_root, $"SAVE{n}.txn");
+    /// <summary>Working directories left beside a slot. Excludes the slot itself: .NET's
+    /// "SAVE1.*" also matches "SAVE1", which is not what this is asking.</summary>
+    private string[] Siblings(int n = 1) =>
+        Directory.GetFileSystemEntries(_root)
+                 .Select(Path.GetFileName)
+                 .Where(x => x.StartsWith($"SAVE{n}.", StringComparison.Ordinal))
+                 .ToArray();
+
+    private static SlotRequirements Uw1 => new()
+    {
+        MustExist = new[] { "DESC" },
+        MustHaveContent = new[] { "PLAYER.DAT", "LEV.ARK" },
+    };
+
+    private static void WriteCompleteSlot(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "DESC"), "new");
+        File.WriteAllText(Path.Combine(dir, "PLAYER.DAT"), "player");
+        File.WriteAllText(Path.Combine(dir, "LEV.ARK"), "level");
+    }
+
+    private void GiveSlotAnExistingSave(int n = 1)
+    {
+        Directory.CreateDirectory(Slot(n));
+        File.WriteAllText(Path.Combine(Slot(n), "DESC"), "old");
+        File.WriteAllText(Path.Combine(Slot(n), "PLAYER.DAT"), "old player");
+        File.WriteAllText(Path.Combine(Slot(n), "LEV.ARK"), "old level");
+    }
+
+    // ---- the ordinary paths -------------------------------------------------------------
+
+    [Fact]
+    public void ReplacingAnEmptySlotLeavesTheNewSaveAndNothingElse()
+    {
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void ReplacingAnOccupiedSlotLeavesOnlyTheNewSave()
+    {
+        GiveSlotAnExistingSave();
+
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Equal("player", File.ReadAllText(Path.Combine(Slot(), "PLAYER.DAT")));
+        // No journal, no staging directory, no backup left behind.
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void AWriterThatThrowsLeavesThePreviousSaveExactlyAsItWas()
+    {
+        GiveSlotAnExistingSave();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "DESC"), "half");
+                throw new InvalidOperationException("writer gave up");
+            }));
+
+        // This is the whole point of the issue: the old save survives intact.
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Equal("old player", File.ReadAllText(Path.Combine(Slot(), "PLAYER.DAT")));
+        Assert.Equal("old level", File.ReadAllText(Path.Combine(Slot(), "LEV.ARK")));
+    }
+
+    [Fact]
+    public void AWriterThatThrowsOnAnEmptySlotLeavesTheSlotEmpty()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "DESC"), "half");
+                throw new InvalidOperationException("writer gave up");
+            }));
+
+        Assert.False(Directory.Exists(Slot()));
+    }
+
+    // ---- validation ---------------------------------------------------------------------
+
+    [Fact]
+    public void AMissingRequiredFileStopsTheSaveAndKeepsTheOldOne()
+    {
+        GiveSlotAnExistingSave();
+
+        Assert.ThrowsAny<IOException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "DESC"), "new");
+                File.WriteAllText(Path.Combine(dir, "PLAYER.DAT"), "player");
+                // LEV.ARK never written.
+            }));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void AnEmptyArchiveStopsTheSave()
+    {
+        GiveSlotAnExistingSave();
+
+        // ScdArkWriter returns an empty array when its source is missing, which without this
+        // check would be committed as a finished UW2 save.
+        Assert.ThrowsAny<IOException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "DESC"), "new");
+                File.WriteAllText(Path.Combine(dir, "PLAYER.DAT"), "player");
+                File.WriteAllBytes(Path.Combine(dir, "LEV.ARK"), Array.Empty<byte>());
+            }));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void AnEmptyDescriptionIsAllowed()
+    {
+        // DOS writes a zero length DESC for an empty description and the slot is still
+        // occupied, so this must not be treated as an incomplete save.
+        SlotTransaction.Replace(_root, 1, Uw1, dir =>
+        {
+            File.WriteAllBytes(Path.Combine(dir, "DESC"), Array.Empty<byte>());
+            File.WriteAllText(Path.Combine(dir, "PLAYER.DAT"), "player");
+            File.WriteAllText(Path.Combine(dir, "LEV.ARK"), "level");
+        });
+
+        Assert.True(File.Exists(Path.Combine(Slot(), "DESC")));
+        Assert.Equal(0, new FileInfo(Path.Combine(Slot(), "DESC")).Length);
+    }
+
+    // ---- foreign entries ----------------------------------------------------------------
+
+    [Fact]
+    public void AFileTheGameDidNotWriteSurvivesTheSave()
+    {
+        GiveSlotAnExistingSave();
+        File.WriteAllText(Path.Combine(Slot(), "NOTES.TXT"), "mine");
+
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        // DOS leaves such files alone, so a bare directory swap would be a regression.
+        Assert.Equal("mine", File.ReadAllText(Path.Combine(Slot(), "NOTES.TXT")));
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void ASubdirectoryInTheSlotStopsTheSaveRatherThanBeingLost()
+    {
+        GiveSlotAnExistingSave();
+        Directory.CreateDirectory(Path.Combine(Slot(), "SUBDIR"));
+
+        // Copying only files would drop it silently when the backup is deleted.
+        Assert.ThrowsAny<IOException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot));
+
+        Assert.True(Directory.Exists(Path.Combine(Slot(), "SUBDIR")));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    // ---- recovery -----------------------------------------------------------------------
+
+    [Fact]
+    public void RecoveryWithNoJournalDoesNothingAtAll()
+    {
+        GiveSlotAnExistingSave();
+        Directory.CreateDirectory(Path.Combine(_root, "SAVE1.old"));
+        Directory.CreateDirectory(Path.Combine(_root, "SAVE1.tmp-whatever"));
+
+        SlotTransaction.Recover(_root, 1);
+
+        // Names that look like ours but are not named by a journal are none of our business.
+        Assert.True(Directory.Exists(Path.Combine(_root, "SAVE1.old")));
+        Assert.True(Directory.Exists(Path.Combine(_root, "SAVE1.tmp-whatever")));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void AJournalWithAMalformedIdIsIgnored()
+    {
+        GiveSlotAnExistingSave();
+        File.WriteAllText(Journal(), "slot=1\nid=../../etc\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        // Ignored means untouched. Acting on it at all, even to tidy it away, would mean the
+        // id had been used to derive a path.
+        Assert.True(File.Exists(Journal()));
+    }
+
+    [Fact]
+    public void AJournalNamingAnotherSlotIsIgnored()
+    {
+        GiveSlotAnExistingSave();
+        string id = new string('a', 32);
+        File.WriteAllText(Journal(), $"slot=2\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.True(File.Exists(Journal()));
+    }
+
+    [Fact]
+    public void AnInterruptionBetweenTheTwoRenamesPutsThePreviousSaveBack()
+    {
+        // The state after SAVE1 was renamed aside but the new one had not landed.
+        string id = new string('a', 32);
+        string backup = Path.Combine(_root, $"SAVE1.old-{id}");
+        string staging = Path.Combine(_root, $"SAVE1.tmp-{id}");
+        Directory.CreateDirectory(backup);
+        File.WriteAllText(Path.Combine(backup, "DESC"), "old");
+        Directory.CreateDirectory(staging);
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void AStagedSaveThatNeverLandedIsCompletedRatherThanDiscarded()
+    {
+        // Slot and backup both absent, staging validated. Deleting it would throw away a
+        // complete save the player asked for, and on a filesystem where a directory rename is
+        // not atomic it could be the only copy left.
+        string id = new string('b', 32);
+        string staging = Path.Combine(_root, $"SAVE1.tmp-{id}");
+        Directory.CreateDirectory(staging);
+        File.WriteAllText(Path.Combine(staging, "DESC"), "rescued");
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("rescued", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void AnUnstagedDirectoryThatNeverLandedIsDiscarded()
+    {
+        string id = new string('c', 32);
+        string staging = Path.Combine(_root, $"SAVE1.tmp-{id}");
+        Directory.CreateDirectory(staging);
+        File.WriteAllText(Path.Combine(staging, "DESC"), "half written");
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=0\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.False(Directory.Exists(Slot()));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void AnInterruptionAfterTheCommitClearsUpAndKeepsTheNewSave()
+    {
+        string id = new string('d', 32);
+        GiveSlotAnExistingSave();
+        File.WriteAllText(Path.Combine(Slot(), "DESC"), "new");
+        Directory.CreateDirectory(Path.Combine(_root, $"SAVE1.old-{id}"));
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void RecoveryRunsTwiceWithoutChangingItsAnswer()
+    {
+        string id = new string('e', 32);
+        string backup = Path.Combine(_root, $"SAVE1.old-{id}");
+        Directory.CreateDirectory(backup);
+        File.WriteAllText(Path.Combine(backup, "DESC"), "old");
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void ReplacingRunsRecoveryFirst()
+    {
+        // A save left half done by a previous run must be resolved before the next one starts,
+        // not layered on top of.
+        string id = new string('f', 32);
+        string backup = Path.Combine(_root, $"SAVE1.old-{id}");
+        Directory.CreateDirectory(backup);
+        File.WriteAllText(Path.Combine(backup, "DESC"), "old");
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+        Assert.Empty(Siblings());
+    }
+
+    [Fact]
+    public void SlotDirectoryResolvesAnInterruptedSaveBeforeAnyoneReadsIt()
+    {
+        // The listers and the restore path go through this, so a crash mid-save is undone
+        // before the slot is inspected rather than showing as missing.
+        string id = new string('a', 32);
+        string backup = Path.Combine(_root, $"SAVE1.old-{id}");
+        Directory.CreateDirectory(backup);
+        File.WriteAllText(Path.Combine(backup, "DESC"), "old");
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        string dir = SlotTransaction.SlotDirectory(_root, 1);
+
+        Assert.Equal(Slot(), dir);
+        Assert.Equal("old", File.ReadAllText(Path.Combine(dir, "DESC")));
+    }
+
+    [Fact]
+    public void AJournalWeDidNotWriteStopsTheSaveRatherThanBeingOverwritten()
+    {
+        GiveSlotAnExistingSave();
+        File.WriteAllText(Journal(), "something else entirely");
+
+        // Recovery ignores a journal it does not recognise, so publishing over it would
+        // destroy whatever it is.
+        Assert.ThrowsAny<IOException>(() =>
+            SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot));
+
+        Assert.Equal("something else entirely", File.ReadAllText(Journal()));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void AScratchNameSomebodyElseLeftIsNotTruncated()
+    {
+        // The journal used to be published through a fixed SAVE1.txn.writing, which would
+        // overwrite whatever was sitting there.
+        File.WriteAllText(Path.Combine(_root, "SAVE1.txn.writing"), "not ours");
+
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        Assert.Equal("not ours", File.ReadAllText(Path.Combine(_root, "SAVE1.txn.writing")));
+    }
+
+    [Fact]
+    public void AForeignFileDifferingOnlyByCaseIsNotLost()
+    {
+        GiveSlotAnExistingSave();
+        string lower = Path.Combine(Slot(), "desc");
+        bool caseSensitive = !File.Exists(lower);
+        File.WriteAllText(lower, "mine");
+
+        SlotTransaction.Replace(_root, 1, Uw1, WriteCompleteSlot);
+
+        if (caseSensitive)
+        {
+            // "desc" is a different file from the "DESC" we write. Comparing owned names
+            // case-insensitively would treat it as ours, skip the copy, and lose it with the
+            // backup.
+            Assert.Equal("mine", File.ReadAllText(lower));
+        }
+        else
+        {
+            // Same file, so the save simply overwrites it. What must not happen either way is
+            // the name disappearing.
+            Assert.Equal("new", File.ReadAllText(lower));
+        }
+        Assert.Equal("new", File.ReadAllText(Path.Combine(Slot(), "DESC")));
+    }
+
+    [Fact]
+    public void AJournalNamingAStagedDirectoryThatIsGoneIsCleanedUp()
+    {
+        string id = new string('a', 32);
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=1\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        // Nothing to recover from, so the journal goes rather than blocking the slot.
+        Assert.False(File.Exists(Journal()));
+        Assert.False(Directory.Exists(Slot()));
+    }
+
+    [Fact]
+    public void OneSlotsRecoveryLeavesAnotherAlone()
+    {
+        GiveSlotAnExistingSave(2);
+        string id = new string('a', 32);
+        Directory.CreateDirectory(Path.Combine(_root, $"SAVE1.tmp-{id}"));
+        File.WriteAllText(Journal(), $"slot=1\nid={id}\nstaged=0\n");
+
+        SlotTransaction.Recover(_root, 1);
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(Slot(2), "DESC")));
+    }
+}


### PR DESCRIPTION
Closes #74. A save that fails part way now leaves the previous save whole rather than a mixture of old and new files.

## What was wrong

`SaveGame.Save` wrote `DESC`, `PLAYER.DAT`, `BGLOBALS.DAT` and `LEV.ARK` straight into the live slot. Anything going wrong part way left old and new files together, and because `DESC` is written first and both slot listers key off it while restore keys off `LEV.ARK`, the usual result was a slot listed with its new name that refused to load.

## What DOS does

I drove real `UW.EXE` under js-dos with a normal save in a slot plus two files the game never writes. I loaded it, saved back over the same slot, and pulled the slot out afterwards. `DESC`, `LEV.ARK` and `PLAYER.DAT` had been rewritten, `BGLOBALS.DAT` was byte identical, and both planted files were still there untouched.

That is a final-state observation, not a trace of what DOS did in between, so I cannot tell you it wrote in place rather than through some scratch of its own. What it does show is that a slot is not cleared before a save, and that files the game did not write survive one.

Two things follow. Emulating it would not fix this issue, since nothing in that behaviour prevents a torn slot. And leaving foreign files alone is worth keeping, so they are carried across into the new slot rather than lost when it is swapped in.

## How it works

The slot is built in a staging directory and swapped in.

```
write SAVE{n}.txn holding the slot and a fresh id
create SAVE{n}.tmp-{id}
copy across anything already in the slot that we do not write ourselves
write our files
validate
record "staged" in the journal
rename SAVE{n} to SAVE{n}.old-{id}
rename SAVE{n}.tmp-{id} to SAVE{n}      <- committed
delete the backup, then the journal
```

Recovery runs first, and a journal still present after it is treated as not ours and stops the save rather than being written over.

The staging directory and the backup carry a per-attempt id; the journal and the slot itself have fixed names. The journal holds that id rather than paths, and recovery derives the two sibling names from it, so it can only ever act on those two names. That is confinement rather than proof of ownership: a file at `SAVE{n}.txn` holding a plausible slot and a 32 character hex id would be believed. It does mean a `SAVE1.old` or `SAVE1.tmp` somebody already had is never touched, and neither is a slot left torn by an older build.

Recovery has four branches, on whether the slot exists, whether the backup exists, and whether the journal says the staging directory was validated. The journal is deleted last, and only once the directories it names have gone, so an interruption just means the next run repeats it. A staging directory that passed validation but never landed is completed rather than discarded, since that is the save the player asked for.

Four call sites resolve a slot through the accessor that runs recovery: both listers, the restore check and the description prefill. `JourneyOnwards` and the loaders below it still take paths directly; those four are the entry points that arrange for recovery first.

Validation is per file and only checks presence and length. `DESC` and `BGLOBALS.DAT` must exist and may be empty: DOS writes a zero length `DESC` for an empty description, and `BGlobalWriter` writes one record per conversation global so a game with none serialises to nothing. `PLAYER.DAT` and `LEV.ARK` must be non-empty, and `SCD.ARK` too on UW2. Nothing checks that an archive is well formed. The `SCD.ARK` case is the one that bites today: `ScdArkWriter` returns an empty array when its source is missing, so a UW2 save would otherwise commit a zero byte file as though it were finished.

## Two other things this fixes

The detach used to run before the `try`, so a throw in the stash or the markers left the player detached from its tile and never put back. It is now inside, though a throw partway through the detach itself would still leave the chain modified without a reattach.

`RemoveObjectFromLinkedList` reports whether slot 1 was actually in that tile's chain, and that result was discarded. The player's `next` was cleared and it was reattached at the chain head regardless, so a save taken when it was not in that tile would insert it into a chain it had never been in and drop whatever chain it had been in before. The detach now reports, and only a successful one is undone.

## What it promises

An exception during the writing leaves the previous save whole. If the second of the two renames fails, the slot is briefly absent and the previous save sits under the backup name until the next save or slot read runs recovery.

Process kill is covered on macOS and Linux, where a directory move is one `rename` and POSIX specifies that as atomic. On Windows the guarantee is weaker: neither `Directory.Move` nor `MoveFile` is documented as atomic.

It is not a promise about power loss, since nothing here is flushed to stable storage. One writer is assumed.

## Testing

210 tests, 29 of them new.

Five drive `SaveGame.Save` rather than the helper, because the helper being right does not prove the save uses it. The one that matters makes the third file fail, by handing `BGlobalWriter` a null globals array so it throws after `DESC` and `PLAYER.DAT` are written, and compares the whole slot directory against a snapshot taken before. On the success path writing in place and replacing atomically give the same result, so only that failing case tells them apart: bypassing `SlotTransaction` in `SaveGame.Save` while leaving everything else alone fails that one test and no other.

Not covered by tests, and checked by hand or not at all: the detach and reattach, which need a tilemap and a scene; the case-sensitivity guard, whose test can only fail on a case-sensitive filesystem so it does nothing on macOS; a kill at either rename; Windows; a cleanup that fails after the commit; and the UW2 `SCD.ARK` requirement, which is asserted through the generic empty-archive test rather than a UW2 one.

## Not in scope

The listers key off `DESC` and restore keys off `LEV.ARK`. That disagreement remains, and slots torn by older builds are still listed and still refuse to load. Both keep their current behaviour.
