### PR TITLE
fix: hand our objects back before Godot 4.3 tears its servers down

### DIFF
--- a/src/audio/MusicStreamPlayer.cs
+++ b/src/audio/MusicStreamPlayer.cs
@@ -36,7 +36,10 @@ public partial class MusicStreamPlayer : Node
 	private ISynthEngine _synth;
 	private XmiPlayer _xmiPlayer;
 	private AudioStreamPlayer _player;
+	private AudioStreamGenerator _generator;
 	private AudioStreamGeneratorPlayback _playback;
+	private bool _producerStopped;
+	private bool _bindingsReleased;
 
 	// Pre-allocated buffers for the producer thread
 	private short[] _renderBuffer;
@@ -101,7 +104,7 @@ public partial class MusicStreamPlayer : Node
 
 		_xmiPlayer = new XmiPlayer(_synth, SampleRate);
 
-		var generator = new AudioStreamGenerator
+		_generator = new AudioStreamGenerator
 		{
 			MixRate = SampleRate,
 			BufferLength = BufferLengthSec,
@@ -109,7 +112,7 @@ public partial class MusicStreamPlayer : Node
 
 		_player = new AudioStreamPlayer();
 		AddChild(_player);
-		_player.Stream = generator;
+		_player.Stream = _generator;
 		_player.Play();
 
 		_playback = (AudioStreamGeneratorPlayback)_player.GetStreamPlayback();
@@ -228,10 +231,26 @@ public partial class MusicStreamPlayer : Node
 	/// disposes the XmiPlayer and synth. Join timeout is 500 ms — the loop
 	/// sleeps at most 100 ms so this is comfortable headroom.
 	/// </summary>
-	public override void _ExitTree()
+	/// <summary>
+	/// Stops the producer and hands the playback back to the AudioServer, without yet
+	/// disposing the C# wrappers. Stop() only marks the server-side playback for deletion:
+	/// the audio thread has to mix it out and a later main-thread AudioServer.update() has to
+	/// collect it, so the caller must let real time and several frames pass before calling
+	/// <see cref="ReleaseGodotAudioBindings"/>. See issue #78.
+	/// </summary>
+	public bool BeginGodotAudioShutdown(int joinMs = 500)
 	{
+		if (_producerStopped) return true;
+
 		_audioThreadRunning = false;
-		_audioThread?.Join(500);
+		if (_audioThread != null && !_audioThread.Join(joinMs))
+		{
+			// The producer holds the synth and pushes into the playback, so disposing
+			// anything now would be a use after dispose. Leaving it all alone risks the
+			// shutdown hang instead, which is the lesser fault of the two.
+			GD.PushError($"Music producer did not stop within {joinMs} ms; retrying before release.");
+			return false;
+		}
 
 		lock (_playerLock)
 		{
@@ -239,6 +258,48 @@ public partial class MusicStreamPlayer : Node
 			_xmiPlayer = null;
 		}
 		_synth?.Dispose();
+		_synth = null;
+
+		if (_player != null && GodotObject.IsInstanceValid(_player))
+		{
+			_player.Stop();
+			_player.Stream = null;
+		}
+
+		_producerStopped = true;
+		return true;
+	}
+
+	/// <summary>
+	/// Disposes the audio wrappers once the server has let go of the playback. Doing this
+	/// before the server has collected it leaves a binding attached to an object the server
+	/// still owns, which is the state that hangs teardown on Godot 4.3.
+	/// </summary>
+	public void ReleaseGodotAudioBindings()
+	{
+		// Never retries phase one here. Stopping the player and releasing its wrappers in
+		// the same call is the ordering that hangs; the caller retries phase one and only
+		// then lets the server drain before calling this.
+		if (_bindingsReleased || !_producerStopped) return;
+		_bindingsReleased = true;
+
+		if (_player != null && GodotObject.IsInstanceValid(_player))
+		{
+			_player.QueueFree();
+			_player = null;
+		}
+		_playback?.Dispose();
+		_playback = null;
+		_generator?.Dispose();
+		_generator = null;
+	}
+
+	public override void _ExitTree()
+	{
+		// Stop only. Releasing the wrappers here would be the same-frame ordering that
+		// leaves the playback in the server's list; UnderworldRoot releases them on the
+		// quit path once the server has had time to collect it.
+		BeginGodotAudioShutdown();
 		if (Instance == this) Instance = null;
 	}
 

--- a/src/audio/sfx/godot/SfxStreamPlayer.cs
+++ b/src/audio/sfx/godot/SfxStreamPlayer.cs
@@ -32,7 +32,10 @@ public partial class SfxStreamPlayer : Node
 
     private OplChip _chip;
     private AudioStreamPlayer _player;
+    private AudioStreamGenerator _generator;
     private AudioStreamGeneratorPlayback _playback;
+    private bool _producerStopped;
+    private bool _bindingsReleased;
     private short[] _renderBuffer;
     private Vector2[] _frames;
 
@@ -98,14 +101,14 @@ public partial class SfxStreamPlayer : Node
             string soundDir = Path.Combine(UWClass.BasePath, "SOUND");
         //}
 
-        var generator = new AudioStreamGenerator
+        _generator = new AudioStreamGenerator
         {
             MixRate = SampleRate,
             BufferLength = BufferLengthSec,
         };
         _player = new AudioStreamPlayer();
         AddChild(_player);
-        _player.Stream = generator;
+        _player.Stream = _generator;
         _player.Play();
         _playback = (AudioStreamGeneratorPlayback)_player.GetStreamPlayback();
 
@@ -175,11 +178,61 @@ public partial class SfxStreamPlayer : Node
         }
     }
 
+    /// <summary>
+    /// Stops the producer and returns the playback to the AudioServer. See
+    /// MusicStreamPlayer.BeginGodotAudioShutdown and issue #78 for why disposal is deferred.
+    /// </summary>
+    public bool BeginGodotAudioShutdown(int joinMs = 500)
+    {
+        if (_producerStopped) return true;
+
+        _audioThreadRunning = false;
+        if (_audioThread != null && !_audioThread.Join(joinMs))
+        {
+            // The producer drives the chip and the playback; disposing either while it is
+            // still running would be a use after dispose.
+            GD.PushError($"SFX producer did not stop within {joinMs} ms; retrying before release.");
+            return false;
+        }
+        _chip?.Dispose();
+        _chip = null;
+
+        if (_player != null && GodotObject.IsInstanceValid(_player))
+        {
+            _player.Stop();
+            _player.Stream = null;
+        }
+
+        _producerStopped = true;
+        return true;
+    }
+
+    /// <summary>Disposes the audio wrappers once the server has collected the playback.</summary>
+    public void ReleaseGodotAudioBindings()
+    {
+        // Never retries phase one here. Stopping the player and releasing its wrappers in
+        // the same call is the ordering that hangs; the caller retries phase one and only
+        // then lets the server drain before calling this.
+        if (_bindingsReleased || !_producerStopped) return;
+        _bindingsReleased = true;
+
+        if (_player != null && GodotObject.IsInstanceValid(_player))
+        {
+            _player.QueueFree();
+            _player = null;
+        }
+        _playback?.Dispose();
+        _playback = null;
+        _generator?.Dispose();
+        _generator = null;
+    }
+
     public override void _ExitTree()
     {
-        _audioThreadRunning = false;
-        _audioThread?.Join(500);
-        _chip?.Dispose();
+        // Stop only. Releasing the wrappers here would be the same-frame ordering that
+        // leaves the playback in the server's list; UnderworldRoot releases them on the
+        // quit path once the server has had time to collect it.
+        BeginGodotAudioShutdown();
         if (Instance == this) Instance = null;
     }
 }

--- a/src/loaders/paletteloader.cs
+++ b/src/loaders/paletteloader.cs
@@ -184,6 +184,38 @@ namespace Underworld
             //     defaultValue:  (Texture)uimanager.instance.uwsubviewport_sprites.GetTexture());
         }
 
+        /// <summary>
+        /// Names of the global shader parameters that hold a texture. Kept beside the
+        /// GlobalShaderParameterAdd calls above so the two lists cannot drift apart.
+        /// </summary>
+        private static readonly string[] TextureGlobals =
+        {
+            "uipalette", "simpleshade", "smoothpalette", "xfer",
+        };
+
+        /// <summary>
+        /// Drop the texture-valued global shader parameters.
+        ///
+        /// These four are the only globals holding an object reference; the rest are bools and
+        /// a float. On Godot 4.3 the engine finalises the C# language before it clears the
+        /// renderer's globals, and CSharpLanguage::finalize() there does not free instance
+        /// bindings, so clearing them afterwards unreferences a RefCounted through a stale
+        /// binding and hits CRASH_COND(!rc_owner). Releasing them while C# is still alive
+        /// leaves the engine's own pass with nothing to unreference.
+        ///
+        /// This does not fix issue #78 on its own. The same fault also occurs via
+        /// AudioServer::~AudioServer, which nothing on our side can reach. It removes the
+        /// renderer route only, and is a no-op on 4.4 and later, where the engine frees the
+        /// bindings itself.
+        /// </summary>
+        public static void ReleaseTextureShaderGlobals()
+        {
+            foreach (string name in TextureGlobals)
+            {
+                RenderingServer.GlobalShaderParameterRemove(name);
+            }
+        }
+
         public static int[] LoadAuxilaryPalIndices(string auxPalPath, int auxPalIndex)
         {
             int[] auxpal = new int[16];

--- a/src/ui/UnderworldRoot.cs
+++ b/src/ui/UnderworldRoot.cs
@@ -22,6 +22,11 @@ namespace Underworld
         public bool FontsReady { get; private set; }
         public string FontError { get; private set; }
 
+        private bool _quitStarted;
+        private long _quitAfterFrame = -1;
+        private bool _autoAcceptQuitWasSet;
+        private bool _previousAutoAcceptQuit;
+
         private static readonly Dictionary<string, string> PlaceholderPaths = new()
         {
             { "FONT4X5P", "res://resources/fonts/FONT4X5P.tres" },
@@ -85,8 +90,155 @@ namespace Underworld
 
         public override void _Ready()
         {
-            if (FontsReady) return;
-            ShowFontError();
+            // AutoAcceptQuit belongs to the SceneTree, not to this scene, so the previous
+            // value has to go back when this root leaves. The game can return to its
+            // launcher, and leaving the tree refusing quits with our handler gone would
+            // stop the window close button working entirely.
+            var tree = GetTree();
+            if (tree != null)
+            {
+                _previousAutoAcceptQuit = tree.AutoAcceptQuit;
+                tree.AutoAcceptQuit = false;
+                _autoAcceptQuitWasSet = true;
+            }
+            _quitAfterFrame = ParseQuitAfter();
+
+            if (!FontsReady) ShowFontError();
+        }
+
+        public override void _Process(double delta)
+        {
+            // --quit-after tears the tree down on its own deadline, which is too late to
+            // drain audio. Start early enough that the drain finishes first.
+            if (_quitAfterFrame >= 0 && !_quitStarted &&
+                (long)GetTree().GetFrame() >= _quitAfterFrame)
+            {
+                RequestQuit();
+            }
+        }
+
+        public override void _Notification(int what)
+        {
+            if (what == NotificationWMCloseRequest) RequestQuit();
+        }
+
+        /// <summary>
+        /// Quits after letting the AudioServer let go of our stream playbacks.
+        ///
+        /// On Godot 4.3 the engine finalises C# before it destroys the AudioServer, and its
+        /// CSharpLanguage::finalize does not free instance bindings, so a playback the server
+        /// still owns is unreferenced through a stale binding and hangs the process. Stop()
+        /// only marks the playback for deletion, so the audio thread and a later main-thread
+        /// AudioServer.update() both have to run before the wrappers can be disposed. See #78.
+        /// </summary>
+        public void RequestQuit(int exitCode = 0)
+        {
+            if (_quitStarted) return;
+            _quitStarted = true;
+            DrainAudioThenQuit(exitCode);
+        }
+
+        private async void DrainAudioThenQuit(int exitCode)
+        {
+            // Captured before the first await: the continuation can resume after this node
+            // has left the tree, and GetTree() would then return null or throw. Quitting has
+            // to happen whatever else fails, because AutoAcceptQuit is false.
+            SceneTree tree = GetTree();
+            try
+            {
+                // Held across the awaits. Both nodes clear their static Instance in
+                // _ExitTree, so if this root is freed mid-drain the release below would
+                // find nothing and the wrappers would never be disposed.
+                var music = MusicStreamPlayer.Instance;
+                var sfx = Sfx.SfxStreamPlayer.Instance;
+
+                // Phase one has to succeed before the drain wait means anything: the wait
+                // exists to let the server collect a playback that Stop() has detached, and
+                // a producer that missed its join has not detached one yet. Retry first,
+                // then drain, so the two never collapse into the same frame.
+                bool stopped = Stop(music) & Stop(sfx);
+                for (int attempt = 0; !stopped && attempt < 3; attempt++)
+                {
+                    var retry = tree.CreateTimer(0.1, true, false, true);
+                    await ToSignal(retry, SceneTreeTimer.SignalName.Timeout);
+                    // A short join on retries: the 100ms wait above already gave the
+                    // producer time, and blocking another half second per node per attempt
+                    // would freeze quitting for seconds.
+                    stopped = Stop(music, 50) & Stop(sfx, 50);
+                }
+
+                // Real time for the audio thread to mix the playback out, then main-thread
+                // frames for AudioServer.update() to collect it.
+                var timer = tree.CreateTimer(0.25, true, false, true);
+                await ToSignal(timer, SceneTreeTimer.SignalName.Timeout);
+                await ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+                await ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+
+                if (!stopped)
+                {
+                    GD.PushError("Audio producers did not stop; leaving their objects alone.");
+                }
+
+                else
+                {
+                    if (music != null && GodotObject.IsInstanceValid(music))
+                    {
+                        music.ReleaseGodotAudioBindings();
+                    }
+                    if (sfx != null && GodotObject.IsInstanceValid(sfx))
+                    {
+                        sfx.ReleaseGodotAudioBindings();
+                    }
+                }
+
+                await ToSignal(tree, SceneTree.SignalName.ProcessFrame);
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"Audio shutdown failed while quitting: {ex.Message}. Quitting anyway.");
+            }
+            finally
+            {
+                try
+                {
+                    tree.Quit(exitCode);
+                }
+                catch (Exception ex)
+                {
+                    GD.PushError($"Quit failed: {ex.Message}. Terminating.");
+                    OS.Kill(OS.GetProcessId());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test hook. Godot consumes --quit-after itself, so it never reaches
+        /// OS.GetCmdlineArgs and cannot be intercepted. This drives the same RequestQuit
+        /// path the Quit menu item and the window close button use.
+        /// </summary>
+        /// <summary>Runs phase one on a node that may already have left the tree.</summary>
+        private static bool Stop(Node node, int joinMs = 500)
+        {
+            if (node == null || !GodotObject.IsInstanceValid(node)) return true;
+            return node is MusicStreamPlayer m
+                ? m.BeginGodotAudioShutdown(joinMs)
+                : ((Sfx.SfxStreamPlayer)node).BeginGodotAudioShutdown(joinMs);
+        }
+
+        private static long ParseQuitAfter()
+        {
+            // A user argument rather than an environment variable, so nothing a packaged or
+            // launcher-managed build happens to inherit can quit the game on its own. Godot
+            // consumes --quit-after itself, so it never reaches a script and the drain
+            // cannot be exercised through it.
+            //   Godot --path . res://scenes/Underworld.tscn -- --uwtest-quit-after 300
+            string[] args = OS.GetCmdlineUserArgs();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "--uwtest-quit-after" && i + 1 < args.Length &&
+                    long.TryParse(args[i + 1], out long n)) return n;
+            }
+            return -1;
         }
 
         /// <summary>
@@ -99,6 +251,11 @@ namespace Underworld
         /// </summary>
         public override void _ExitTree()
         {
+            if (_autoAcceptQuitWasSet)
+            {
+                var tree = GetTree();
+                if (tree != null) tree.AutoAcceptQuit = _previousAutoAcceptQuit;
+            }
             PaletteLoader.ReleaseTextureShaderGlobals();
         }
 

--- a/src/ui/UnderworldRoot.cs
+++ b/src/ui/UnderworldRoot.cs
@@ -90,6 +90,19 @@ namespace Underworld
         }
 
         /// <summary>
+        /// Releases the texture-valued global shader parameters on the way out.
+        ///
+        /// The root leaves the tree before the engine finalises C# and long before it clears
+        /// the renderer's globals, so this is early enough for every exit route: the Quit menu
+        /// item, closing the window and --quit-after all tear the tree down through here.
+        /// See PaletteLoader.ReleaseTextureShaderGlobals and issue #78.
+        /// </summary>
+        public override void _ExitTree()
+        {
+            PaletteLoader.ReleaseTextureShaderGlobals();
+        }
+
+        /// <summary>
         /// Reports the failure in the engine default font, which is the only text this scene
         /// can still draw. No theme override is set, deliberately.
         /// </summary>

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -590,7 +590,25 @@ namespace Underworld
                             switch (extra_arg_0)
                             {
                                 case 2://confirm quit yes
-                                    GetTree().Quit();
+                                    // Through the root so audio is handed back to the
+                                    // AudioServer before the tree goes. Quitting straight
+                                    // from here hangs the process on Godot 4.3. See #78.
+                                    var uwroot = UnderworldRoot.Find(this);
+                                    if (uwroot != null)
+                                    {
+                                        uwroot.RequestQuit();
+                                    }
+                                    else
+                                    {
+                                        // Unreachable while the uiManager sits under the
+                                        // scene root. Saying so is the point: quitting
+                                        // straight from here brings the hang back, so a
+                                        // hierarchy change that breaks Find must be loud.
+                                        GD.PushError(
+                                            "No UnderworldRoot above the options UI, so quitting "
+                                          + "without handing audio back. See issue #78.");
+                                        GetTree().Quit();
+                                    }
                                     break;
                                 case 3://cancel quit
                                     ReturnToTopOptionsMenu();


### PR DESCRIPTION
Closes #78.

Quitting never exited the process. It reproduced every time on Godot 4.3 mono, macOS arm64.

## What it is

Godot 4.3's `Main::cleanup` finalises the C# language before it tears down its servers, and 4.3's `CSharpLanguage::finalize()` does not free the instance bindings. When a server later unreferences a `RefCounted` that C# had touched, the binding callback runs against a stale binding and hits `CRASH_COND(!rc_owner)` at `csharp_script.cpp:1237`. On macOS that fatal turns into a livelock inside CoreCLR exception dispatch rather than an abort, so the process neither exits nor dies. This is [godotengine/godot#99129](https://github.com/godotengine/godot/issues/99129).

Two things we own reach it, and each hangs the process on its own.

## The renderer

We hold four texture-valued global shader parameters: `uipalette`, `simpleshade`, `smoothpalette` and `xfer`. They are the only globals holding an object reference, the rest being bools and a float. Dropping them while C# is still alive leaves the engine's own `global_shader_parameters_clear` with nothing to unreference.

## The audio server

`AudioStreamPlayer.Stop()` does not hand the playback back. It marks the server-side playback for deletion, the audio thread then has to mix it out, and a later main-thread `AudioServer.update()` has to collect it. Stopping and quitting in the same frame leaves the playback in the server's list with a live C# binding on it, which is what the destructor then trips over.

So audio shutdown is now two phases with a wait between them. `BeginGodotAudioShutdown` stops the producer thread and the player. Real time and several frames pass. Only then does `ReleaseGodotAudioBindings` dispose the playback and generator wrappers.

`UnderworldRoot` coordinates that and quits afterwards, so the Quit menu item and the window close button both go through it.

## Measured

Godot 4.3 mono, macOS arm64, Vulkan, real audio driver, quitting through the in-game path.

| shader release | audio drain | hangs |
| --- | --- | --- |
| no | no | 8 of 8 |
| yes | no | 8 of 8 |
| no | yes | 8 of 8 |
| yes | yes | 0 of 12 |

The two faults are independent. With only the audio fix the renderer route appears instead, and with only the renderer fix the audio route does. Every hang was confirmed from a `sample` of the stopped process rather than inferred: the renderer route through `Variant::_clear_internal`, the audio route through `AudioServer::~AudioServer`. A further 6 of 6 pass under a dummy audio driver.

## What this costs

Quitting now waits for audio. Normally that is the 250 ms drain plus a few frames. If a producer thread misses its join the coordinator retries it three times at 100 ms, so the worst case, with both producers timing out on every attempt, is about 1.9 seconds before the window closes.

If a producer never stops, nothing is disposed and an error is logged. A possible hang is the better failure there, because disposing objects a running thread is still using is worse.

## Notes

`--quit-after` cannot be intercepted, because Godot consumes it before any script sees it, so it cannot exercise this path. `--uwtest-quit-after N`, after a bare `--`, drives the same `RequestQuit` the menu uses. It is a user argument rather than an environment variable so that nothing a packaged build happens to inherit can quit the game on its own.

`AutoAcceptQuit` is set false so the window close button routes through the drain. It belongs to the `SceneTree` rather than to this scene, so the previous value is restored when the root leaves the tree; the game can return to its launcher, and leaving the tree refusing quits with our handler gone would stop the window closing at all.

The 250 ms is a heuristic. Godot 4.3 exposes no way to ask whether the server has actually released a playback, so there is nothing better to wait on. The retry joins are a liveness confirmation rather than a real wait, since the 100 ms between attempts is what gives the producer time.

The quit menu resolves the root with `UnderworldRoot.Find`, which is reliable in this scene, and reports an error before quitting directly if it ever fails, because that path would bring the hang back.

Everything here was measured on macOS arm64, and I cannot test Windows or Linux. The livelock is macOS specific in how it presents, since the same fatal aborts elsewhere rather than spinning in CoreCLR exception dispatch, but the underlying stale binding is not, and the shutdown reordering this makes applies to every platform. That is the part worth a second pair of eyes on another machine.

## Testing

244 unit tests pass. The shutdown numbers above are 12 real-audio and 6 dummy-audio runs of the built game, each quitting through the same path the menu uses, with hangs detected by timeout and attributed from a process sample.

No automated test covers this. It needs a built game, a real audio driver and a window, and it is a timeout rather than an assertion.

