### PR TITLE
fix(ui): give the stats numbers the room DOS gives them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,16 @@ jobs:
       # line and this harness keys off that. A run that prints no verdict is a failure,
       # because it died before deciding.
       #
-      # SKIP is expected here and is not a failure: three of these need the shipped .SYS
-      # fonts, which CI has no licence to carry. They report SKIP and start protecting the
-      # branch the moment game data is available.
+      # SKIP is expected here and is not a failure: several of these need the shipped game
+      # data, which CI has no licence to carry. They report SKIP and start protecting the
+      # branch the moment game data is available. Until then CI proves those scenes load and
+      # run, not that their assertions hold.
       - name: Godot tests
         run: |
           chmod +x "$GODOT"
           rc=0
           for scene in font_render_test font_placement_test cursor_placement_test font_boot_test font_failure_test \
-                       font_resize_test font_demo_boot_test launcher_validation_test; do
+                       font_resize_test font_demo_boot_test launcher_validation_test ordinal_fit_test; do
             out="/tmp/$scene.log"
             timeout 180 xvfb-run -a "$GODOT" --rendering-driver opengl3 \
               --path . "res://tests/godot/$scene.tscn" > "$out" 2>&1 || true

--- a/Underworld.csproj
+++ b/Underworld.csproj
@@ -16,6 +16,7 @@
     <Compile Include="tests/godot/LauncherValidationTest.cs" Condition="'$(Configuration)' == 'Debug'" />
     <Compile Include="tests/godot/FontFailureTest.cs" Condition="'$(Configuration)' == 'Debug'" />
     <Compile Include="tests/godot/FontDemoBootTest.cs" Condition="'$(Configuration)' == 'Debug'" />
+    <Compile Include="tests/godot/OrdinalFitTest.cs" Condition="'$(Configuration)' == 'Debug'" />
     <None Remove="tests/**/*" />
     <Compile Remove="tools/**/*.cs" />
     <None Remove="tools/**/*" />

--- a/scenes/Underworld.tscn
+++ b/scenes/Underworld.tscn
@@ -2113,7 +2113,7 @@ scroll_active = false
 
 [node name="VIT" type="RichTextLabel" parent="UI/Common/StatsDisplay"]
 layout_mode = 0
-offset_left = 16.0
+offset_left = -4.0
 offset_top = 177.0
 offset_right = 136.0
 offset_bottom = 242.0
@@ -2125,7 +2125,7 @@ scroll_active = false
 
 [node name="MANA" type="RichTextLabel" parent="UI/Common/StatsDisplay"]
 layout_mode = 0
-offset_left = 16.0
+offset_left = -4.0
 offset_top = 204.0
 offset_right = 136.0
 offset_bottom = 269.0
@@ -2137,7 +2137,7 @@ scroll_active = false
 
 [node name="EXP" type="RichTextLabel" parent="UI/Common/StatsDisplay"]
 layout_mode = 0
-offset_left = 16.0
+offset_left = -4.0
 offset_top = 232.0
 offset_right = 136.0
 offset_bottom = 297.0

--- a/tests/godot/OrdinalFitTest.cs
+++ b/tests/godot/OrdinalFitTest.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Godot;
+using Underworld;
+
+/// <summary>
+/// Measures whether the stats panel strings fit their boxes, with the real shaper.
+///
+/// Two backlog items say they do not: "Stats display sometimes cuts off hp numbers. Eg 56/78
+/// hp renders as 56/7" and "ordinal is cut off when player level >10 eg 11th is 11t". Both
+/// predate the runtime fonts, which take each advance from the glyph's declared width byte
+/// where the converted TTFs derived it from the ink and came out too wide.
+///
+/// Measured here rather than computed, because a hand parser has been wrong about this before.
+/// </summary>
+public partial class OrdinalFitTest : Node2D
+{
+    private const int Size = 64;              // 4 screen pixels per source pixel
+    private int _failures;
+
+    /// <summary>node, and the strings it has to hold. Widths come from the scene.</summary>
+    private static readonly (string Node, string[] Text)[] Cases =
+    {
+        // DOS saves a 35 source pixel background rectangle at x 277 for the three numeric
+        // rows and right aligns each value to source x 311. At four screen pixels per source
+        // pixel that is 140, and the port had 120, which clipped 100/100. See issue #92.
+        ("VIT",       new[] { "56/78", "100/100" }),
+        ("MANA",      new[] { "100/100" }),
+        ("EXP",       new[] { "999999" }),
+        ("CharLevel", new[] { "10TH", "11TH", "12TH", "13TH", "14TH", "15TH", "16TH" }),
+    };
+
+    private const string ScenePath = "res://scenes/Underworld.tscn";
+
+    /// <summary>
+    /// The node's width, read from the scene rather than restated here.
+    ///
+    /// Hard coding the widths made this test pass against a scene that still clipped: it
+    /// measured strings against numbers in its own source, so reverting the scene would not
+    /// have failed it. Reading the scene is what makes it pin the fix.
+    ///
+    /// The scene text is parsed rather than instantiated, because instantiating
+    /// Underworld.tscn starts the game.
+    /// </summary>
+    private static float BoxWidth(string sceneText, string node)
+    {
+        var m = Regex.Match(
+            sceneText,
+            "\\[node name=\"" + Regex.Escape(node) + "\" type=\"RichTextLabel\"[^\\]]*\\]\\n(?<body>(?:(?!\\[node)[\\s\\S])*)");
+        if (!m.Success) { return float.NaN; }
+        string body = m.Groups["body"].Value;
+        var l = Regex.Match(body, "^offset_left = (-?[0-9.]+)$", RegexOptions.Multiline);
+        var r = Regex.Match(body, "^offset_right = (-?[0-9.]+)$", RegexOptions.Multiline);
+        if (!l.Success || !r.Success) { return float.NaN; }
+        return float.Parse(r.Groups[1].Value) - float.Parse(l.Groups[1].Value);
+    }
+
+    public override void _Ready() => Callable.From(Run).CallDeferred();
+    private void Fail(string m) { _failures++; GD.PrintErr("FAIL " + m); }
+
+    private void Run()
+    {
+        _ = uwsettings.instance;
+        string dir = string.IsNullOrWhiteSpace(UWClass.BasePath)
+            ? null : Path.Combine(UWClass.BasePath, "DATA");
+        string sysPath = dir == null ? null : Path.Combine(dir, "FONT5X6I.SYS");
+        if (sysPath == null || !File.Exists(sysPath))
+        {
+            GD.Print("GODOT-TEST-VERDICT SKIP FONT5X6I.SYS is not present");
+            GetTree().Quit(0); return;
+        }
+
+        var sys = SysFont.Parse(File.ReadAllBytes(sysPath));
+        var (a, d) = SysFontProvider.LegacyMetricsFor("FONT5X6I");
+        FontFile runtime = SysFontBuilder.Build(sys, a, d);
+        var legacy = GD.Load<FontFile>("res://resources/fonts/FONT5X6I.ttf");
+
+        using var scene = Godot.FileAccess.Open(ScenePath, Godot.FileAccess.ModeFlags.Read);
+        if (scene == null)
+        {
+            GD.Print("GODOT-TEST-VERDICT FAIL cannot read " + ScenePath);
+            GetTree().Quit(1); return;
+        }
+        string sceneText = scene.GetAsText();
+
+        foreach (var (node, texts) in Cases)
+        {
+            float box = BoxWidth(sceneText, node);
+            if (float.IsNaN(box)) { Fail($"{node} has no offsets in the scene"); continue; }
+
+            foreach (string t in texts)
+            {
+                float now = runtime.GetStringSize(t, HorizontalAlignment.Left, -1, Size).X;
+                float was = legacy == null ? float.NaN
+                          : legacy.GetStringSize(t, HorizontalAlignment.Left, -1, Size).X;
+                GD.Print($"  {node,-9} {t,-8} scene box {box,5:0} runtime {now,6:0.0} ({now / 4:0.0} src) "
+                       + $"legacy {was,6:0.0} ({was / 4:0.0} src)  {(now <= box ? "fits" : "OVERFLOWS")}");
+                if (now > box) { Fail($"{node} '{t}' needs {now:0.0} of the scene's {box:0}"); }
+            }
+        }
+
+        GD.Print(_failures == 0 ? "GODOT-TEST-VERDICT PASS" : $"GODOT-TEST-VERDICT FAIL {_failures}");
+        GetTree().Quit(_failures == 0 ? 0 : 1);
+    }
+}

--- a/tests/godot/ordinal_fit_test.tscn
+++ b/tests/godot/ordinal_fit_test.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/godot/OrdinalFitTest.cs" id="1_oft"]
+
+[node name="OrdinalFitTest" type="Node2D"]
+script = ExtResource("1_oft")


### PR DESCRIPTION
Closes #92.

A vitality of `100/100` drew as `100/10`. The three numeric rows in the stats panel each had 120 pixels, which is 30 source pixels at the port's four to one scale, and `100/100` measures 31.

## What DOS does

The stats renderer builds `<current>/<max>`, measures it, and right aligns it with `start_x = 312 - measured_width`, so the last occupied column is x 311. It reads current vitality from `PlayerObject + 8` and the maximum from `PlayerCritterData + 4`. The routine is `ovr145_14F`, called from `ovr145_35F`, and the same instructions are in `UW.EXE` at file offset `0x8308F`, with `mov dx,0x0138` at `0x830ED` followed by `sub dx,ax`.

DOS saves one background rectangle for the three numeric rows, at x 277, width 35, height 21. I am treating that saved region as the width DOS intends for those rows. It is not an explicit clipping boundary in the code, so that step is interpretation rather than something the binary states.

## Measurements from a running DOS

These are mine, from a frame of real `UW.EXE` with a character edited to level 14 and 100 maximum vitality. They are not reproducible from the repository.

| row | inked columns, source x | columns |
| --- | --- | --- |
| ordinal | 270 to 311 | 42 |
| STR | 301 to 311 | 11 |
| VIT | 286 to 311 | 26 |
| MANA | 297 to 311 | 15 |
| EXP | 302 to 311 | 10 |

Every value in the column ends at source x 311, which is what the disassembly says it should be, and `100/100` drew whole.

## What changes

`VIT`, `MANA` and `EXP` go from 120 pixels to 140, which is DOS's 35 source pixels. The right edge does not move, because both DOS and the port right align; only the left edge does.

That matches the width of DOS's saved region rather than taking all the room there is. The captions to the left are not drawn text: they are baked into stats panel image 2 in `DATA/PANELS.GR`, blitted at source x 236, and the longest, `MANA`, has its last inked column at source x 266. A field ending at 311 could therefore run to 45 columns without touching it. DOS uses 35 of that 45.

## Testing

`tests/godot/ordinal_fit_test.tscn` measures each string with Godot's shaper and compares it against the node's width **read from the scene**, so reverting this change fails it. Checked: putting `VIT` back to 120 gives `FAIL VIT '100/100' needs 124.0 of the scene's 120`.

It reads the scene as text rather than instantiating it, because instantiating `Underworld.tscn` starts the game. An earlier version of this test hard coded the widths, which meant it compared strings against numbers in its own source and would have passed against the unfixed scene.

| string | old box | new box | converted TTF | runtime fonts |
| --- | --- | --- | --- | --- |
| 56/78 | 120 | 140 | 128 | 108 |
| 100/100 | 120 | 140 | 152 | 124 |
| 10TH | 84 | 84 | 88 | 72 |
| 11TH | 84 | 84 | 80 | 64 |
| 14TH | 84 | 84 | 88 | 72 |

Two separate things are visible there, and only the second is this PR. `56/78` overflowed the old 120 pixel box at 128 and was brought inside it by the runtime fonts, which take each advance from the glyph's declared width byte where the converted TTFs derived it from the ink. `100/100` still measures 124 with the runtime fonts, so it needs the wider box, and that is what this changes.

The ordinal rows are here as history rather than as a claim. Issue #91 was addressed by the earlier runtime font work, not by this. This test shows only that the runtime font gives levels 10 to 16 advances of at most 76 against a nominal 84, which does not by itself explain the reported clipping of `11TH`, whose converted TTF advance was already 80.

CI registers and runs the scene, but skips its assertions without the shipped `.SYS` fonts, so it does not protect this width on CI as things stand.

I compared the port and DOS side by side before and after, and confirmed `100/10` became `100/100`.
