### PR TITLE
fix(ui): take the UI colours from the palette DOS uses

### DIFF
--- a/src/ui/MessageDisplay.cs
+++ b/src/ui/MessageDisplay.cs
@@ -11,20 +11,29 @@ namespace Underworld
     /// </summary>
     public class MessageDisplay
     {
-        string DefaultSay
+        /// <summary>
+        /// DOS's seven message scroll escape colours, \0 to \6, as palette 0 indices.
+        ///
+        /// UW1 writes them as consecutive immediates through its font colour global in the
+        /// scroll parser, UW.EXE 0x3976E through 0x397AA. UW2 looks them up in a table at
+        /// UW2.EXE 0x69407, bytes 75 68 01 02 21 50 48.
+        ///
+        /// Three of these used to be hardcoded hex here, which is why they drifted: #883E14
+        /// for \1 where DOS has (132,68,32) in UW1 and (124,64,36) in UW2, so it did not vary
+        /// by game at all; white for \3 where DOS has (252,252,252); and 0x76 for \0 in UW2
+        /// where the table says 0x75. Only the black for \2 was right.
+        /// </summary>
+        private static readonly byte[] ScrollColoursUw1 = { 0x2E, 0x26, 0xF1, 0x60, 0xB4, 0xC4, 0xD4 };
+        private static readonly byte[] ScrollColoursUw2 = { 0x75, 0x68, 0x01, 0x02, 0x21, 0x50, 0x48 };
+
+        /// <summary>The colour for one of DOS's scroll escapes, falling back to \0.</summary>
+        public static string ScrollColour(int escape)
         {
-            get
-            {
-                if (UWClass._RES == UWClass.GAME_UW2)
-                {
-                    return PaletteLoader.ToBBCode(0, 0x76);
-                }
-                else
-                {
-                    return PaletteLoader.ToBBCode(0, 0x2e);
-                }
-            }
+            var table = UWClass._RES == UWClass.GAME_UW2 ? ScrollColoursUw2 : ScrollColoursUw1;
+            if (escape < 0 || escape >= table.Length) { escape = 0; }
+            return PaletteLoader.ToBBCode(0, table[escape]);
         }
+
         public enum MessageDisplayMode
         {
             NormalMode = 0,
@@ -72,22 +81,7 @@ namespace Underworld
         private IEnumerator AddLineWithMore(string newText, int Option, int Colour = 0)
         {
             if (newText.Trim() == "") { yield return 0; }
-            switch (Colour)
-            {
-                case ConversationVM.PC_SAY:
-                    newText = $"[color=#883E14]{newText}[/color]";
-                    break;
-                case ConversationVM.PRINT_SAY:
-                    newText = $"[color=black]{newText}[/color]";
-                    break;
-                case ConversationVM.UI_SAY:
-                    newText = $"[color=white]{newText}[/color]";
-                    break;
-                case ConversationVM.NPC_SAY:
-                default:
-                    newText = $"[color={DefaultSay}]{newText}[/color]";  //#331C13
-                    break;
-            }
+            newText = $"[color={ScrollColour(Colour)}]{newText}[/color]";
             if (LinePtr <= Lines.GetUpperBound(0))
             {
                 Lines[LinePtr++].SetLine(newText, Option);

--- a/src/ui/uimanager_mainmenu.cs
+++ b/src/ui/uimanager_mainmenu.cs
@@ -9,6 +9,20 @@ namespace Underworld
 {
 	public partial class uimanager : Node2D
 	{
+		/// <summary>
+		/// Font colour for the main menu save list and the loading message, into palette 2.
+		///
+		/// DOS sets these through its font colour global immediately before drawing. Selected
+		/// UW1 0xA2 at UW.EXE 0x7FA77, unselected 0xAA at 0x7FA89; UW2 0x07 at UW2.EXE
+		/// 0x98B97 and 0xCD at 0x98BA9. The loading message uses the selected colour in both,
+		/// UW1 0x7FA77's value again at 0x802EE and UW2's at 0x993F9.
+		///
+		/// Palette 2 because the main menu loads it before drawing (the 6A 02 argument in
+		/// MainMenu_ovr138_248 at 0x7FC3F). Palette 0 holds different colours at these
+		/// indices, so reading them from 0 gives a plausible but wrong shade.
+		/// </summary>
+		const int MainMenuPalette = 2;
+
 		byte PaletteIndexSaveGameSelected
 		{
 			get
@@ -23,6 +37,19 @@ namespace Underworld
 				}
 
 			}
+		}
+
+		/// <summary>
+		/// The loading message takes the same colour DOS gives the highlighted save slot:
+		/// the write at UW.EXE 0x802EE is the same index as 0x7FA77, and UW2.EXE 0x993F9
+		/// matches 0x98B97. The scene carried a hardcoded green that is in no palette.
+		/// </summary>
+		private void SetLoadingLabelColour()
+		{
+			if (LoadingLabel == null) { return; }
+			LoadingLabel.Set(
+				"theme_override_colors/font_color",
+				PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
 		}
 
 		byte PaletteIndexSaveGameUnSelected
@@ -85,7 +112,7 @@ namespace Underworld
 			//Set the font for the save games.
 			foreach (var sgn in SaveGamesNames)
 			{
-				sgn.Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				sgn.Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
 			}
 
 			//MainMenuBG.Material = bitmaps.GetMaterial(BytLoader.OPSCR_BYT);
@@ -249,10 +276,12 @@ namespace Underworld
 			if (UWClass._RES == UWClass.GAME_UW2)
 			{
 				LoadingLabel.Text = GameStrings.GetString(1, 273);
+				SetLoadingLabelColour();
 			}
 			else
 			{
 				LoadingLabel.Text = GameStrings.GetString(1, 257);
+				SetLoadingLabelColour();
 			}
 			yield return 0;
 		}
@@ -391,10 +420,10 @@ namespace Underworld
 			if (@event is InputEventMouse eventMouse)
 			{
 				//Set the font for the save games.
-				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
-				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
+				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
 			}
 			if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
 			{
@@ -410,10 +439,10 @@ namespace Underworld
 			if (@event is InputEventMouse eventMouse)
 			{
 				//Set the font for the save games.
-				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
-				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
+				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
 			}
 			if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
 			{
@@ -431,10 +460,10 @@ namespace Underworld
 			if (@event is InputEventMouse eventMouse)
 			{
 				//Set the font for the save games.
-				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
-				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
+				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
 			}
 			if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)
 			{
@@ -452,10 +481,10 @@ namespace Underworld
 			if (@event is InputEventMouse eventMouse)
 			{
 				//Set the font for the save games.
-				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
-				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[0].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
+				SaveGamesNames[0].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[1].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[2].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameUnSelected, false, false));
+				SaveGamesNames[3].Set("theme_override_colors/font_color", PaletteLoader.Palettes[MainMenuPalette].ColorAtIndex(PaletteIndexSaveGameSelected, false, false));
 			}
 
 			if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == MouseButton.Left)

--- a/src/ui/uimanager_options.cs
+++ b/src/ui/uimanager_options.cs
@@ -742,6 +742,11 @@ namespace Underworld
         /// </summary>
         public const string UnusedSlotPlaceholder = "<not used yet>";
 
+        /// <summary>
+        /// DOS's \6 escape, which the save description list is drawn under. See issue #82.
+        /// </summary>
+        private const int SaveDescriptionEscape = 6;
+
         private static readonly SaveDescriptionPrompt SaveDescription_Prompt = new();
         private static LineEdit SaveDescriptionField;
 
@@ -1030,6 +1035,9 @@ namespace Underworld
 
         static void listsaves()
         {
+            // DOS lists these under a \6 heading and leaves the colour set, so every
+            // description inherits it: 0xD4 in UW1, 0x48 in UW2. The port passed 2, which is
+            // \2, a flat black in both games. See issue #82.
             string[] romannumerals = new string[] { "I", "II", "III", "IV" };
             instance.scroll.Clear();
             for (int i = 1; i <= 4; i++)
@@ -1038,11 +1046,13 @@ namespace Underworld
                 if (SaveDescription.TryReadSlot(path, out string savename))
                 {
                     AddToMessageScroll(
-                        $"{romannumerals[i - 1]}- {GameStringFormat.EscapeBbcode(savename)}", colour: 2);
+                        $"{romannumerals[i - 1]}- {GameStringFormat.EscapeBbcode(savename)}",
+                        colour: SaveDescriptionEscape);
                 }
                 else
                 {
-                    AddToMessageScroll($"{romannumerals[i - 1]}- {UnusedSlotPlaceholder}", colour: 2);
+                    AddToMessageScroll($"{romannumerals[i - 1]}- {UnusedSlotPlaceholder}",
+                        colour: SaveDescriptionEscape);
                 }
             }
         }

--- a/src/ui/uimanager_views.cs
+++ b/src/ui/uimanager_views.cs
@@ -424,11 +424,25 @@ namespace Underworld
             // }
         }
 
+        /// <summary>
+        /// DOS's colour for the encumbrance figure, into the gameplay palette.
+        ///
+        /// UW1 writes 0xE0 through its font colour global in UpdateWeightDisplay_ovr121_1827
+        /// (UW.EXE 0x7B7FA, C4 1E D4 23 26 C6 07 E0). UW2 writes 0x88 in
+        /// UpdateWeightCapacityOnScreen_ovr125_1935 (UW2.EXE 0x90518). The label had no
+        /// colour at all and fell back to Godot's white. See issue #82.
+        /// </summary>
+        private static byte WeightCapacityColourIndex =>
+            UWClass._RES == UWClass.GAME_UW2 ? (byte)0x88 : (byte)0xE0;
+
         public static void RefreshWeightDisplay()
         {
             // Called from playerdat inventory paths that also run headlessly.
             if (uimanager.instance == null) { return; }
             uimanager.instance.WeightCapacity.Text = (playerdat.WeightCapacity / 0xA).ToString();
+            uimanager.instance.WeightCapacity.Set(
+                "theme_override_colors/font_color",
+                PaletteLoader.Palettes[0].ColorAtIndex(WeightCapacityColourIndex, false, false));
             Debug.Print($"player weight capacity is now {playerdat.WeightCapacity}");
         }
 


### PR DESCRIPTION
Closes #82.

The issue reported UI numbers rendering white where DOS colours them, and named the encumbrance figure. Surveying the rest turned up four more places, and one place the issue's premise did not hold.

## What was already right

The stats panel is not affected. `AttributesFontColor` and `SkillsFontColor` already resolve through `PaletteLoader.ToBBCode`, so those numbers were correct.

The twelve inventory stack counts are deliberately unchanged. DOS uses its white palette entry for them, `0x60` in UW1 and `0x02` in UW2, both `(252,252,252)`, against Godot's default `(255,255,255)`. That is a visual match rather than an exact one, and colouring them would be a regression.

In UW1, ordinary default colour scroll text needed no change: `0x2E`, which is `(60,40,32)`, was already correct. UW2's was not, and is covered below.

## The encumbrance figure

It had no colour at all and fell back to Godot's white. DOS writes palette index `0xE0` in UW1 through its font colour global in `UpdateWeightDisplay_ovr121_1827` (`UW.EXE 0x7B7FA`) and `0x88` in UW2 (`UW2.EXE 0x90518`), both into the gameplay palette.

## The main menu, on the wrong palette

The save slot names already used the right indices, selected `0xA2` and unselected `0xAA` in UW1, `0x07` and `0xCD` in UW2, but read them out of palette 0. The main menu runs on palette 2, which it loads before drawing: the `6A 02` argument in `MainMenu_ovr138_248` at `UW.EXE 0x7FC45`, and independently in UW2 at `UW2.EXE 0x98D4C`.

Reading them from palette 0 was wrong in both games, but only changes what you see in UW1: `0xA2` is `(220,160,12)` in palette 0 against `(236,196,68)` in palette 2, while UW2's `0x07` and `0xCD` happen to hold the same values in both.

The loading message carried a hardcoded green that is in no palette. DOS gives it the same index as the highlighted slot, written at `UW.EXE 0x802EE` and `UW2.EXE 0x993F9`.

## The message scroll

Its seven escapes resolved to four outcomes: one hex literal, two named colours, and one palette lookup. Every one of them was wrong in at least one game.

DOS keeps them per game. UW1 writes them in seven consecutive branches in the scroll parser, whose write sequences begin at `UW.EXE 0x3976E` through `0x397AA`, each carrying its index seven bytes in. UW2 looks them up in a table at `UW2.EXE 0x69407`.

| escape | UW1 | UW2 | was |
| --- | --- | --- | --- |
| `\0` | `0x2E` | `0x75` | UW1 right, UW2 `0x76` |
| `\1` | `0x26` | `0x68` | `#883E14`, the same for both games |
| `\2` | `0xF1` | `0x01` | hardcoded black: exact in UW1, near black in UW2 |
| `\3` | `0x60` | `0x02` | pure white against `(252,252,252)` |
| `\4` | `0xB4` | `0x21` | fell through to the default, drew as `\0` |
| `\5` | `0xC4` | `0x50` | fell through to the default, drew as `\0` |
| `\6` | `0xD4` | `0x48` | fell through to the default, drew as `\0` |

Both tables are now here and `ScrollColour` resolves an escape through the palette.

Separately, the save and restore description list asked for colour 2, which the old switch drew as a hardcoded black. DOS lists those under a `\6` heading and prints the descriptions without resetting it, so every description inherits it, resetting afterwards. The list now asks for `\6`.

## Checked

Every index above was read out of the shipped binaries at the offsets given, rather than taken from the disassembly alone.

In the running port against DOS side by side, in UW1: the encumbrance figure is the expected `(252,172,120)` rather than white, the main menu slots are right, the save description list is green where it was black, and the player's own conversation lines are the dark orange DOS gives `\1` where they were a hardcoded brown. The stack counts and ordinary scroll text are unchanged.

The UW2 half of the scroll tables is not visually confirmed. Its `\6` is `(20,28,4)`, so the save list change is nearly invisible there by design.
