### PR TITLE
fix(objects): open doors to the angle DOS opens them to

### DIFF
--- a/src/objects/door.cs
+++ b/src/objects/door.cs
@@ -77,15 +77,28 @@ namespace Underworld
             }
         }
 
+        /// <summary>
+        /// The angle a door sits at for one animation state.
+        ///
+        /// DOS shifts the state number into a 16 bit angle space, `state << 12` in
+        /// RenderDoor_seg032_2DCA_C56 (UW.EXE 0x2FD9F), where 0x10000 is a full turn. One
+        /// state is therefore 0x1000/0x10000 of a turn, 22.5 degrees, and that is fixed
+        /// regardless of how many states the door type has.
+        ///
+        /// This used to be (PI/2) / NoOfFrames, which is the same 22.5 degrees for the four
+        /// state portcullis but only 18 for a five state door, leaving it 22.5 degrees short
+        /// of DOS at full open. See issue #99.
+        /// </summary>
+        private const double RadiansPerDoorState = Math.PI / 8;
+
         public static float GetRadiansForIndex(uwObject obj, int index, int doordir)
         {
-            var unit = (Math.PI / 2) / NoOfFrames(obj);
             var dir = 1;
             if (doordir == 1)
             {
                 dir = -1;
             }
-            return (float)(dir * index * unit);
+            return (float)(dir * index * RadiansPerDoorState);
         }
 
         public static float GetHeightForIndex(uwObject obj, int index)


### PR DESCRIPTION
Closes #99.

A fully open door stopped at 90 degrees where DOS reaches 112.5.

## What DOS does

`RenderDoor_seg032_2DCA_C56` takes the animation state out of the object, applies the door direction as a sign, and shifts the result into a 16 bit angle space where `0x10000` is a full turn.

At `UW.EXE 0x2FD4E`:

```
C4 5E 08 26 8B 07 25 00 1E C1 E8 09 25 07 00
26 8B 17 81 E2 00 20 C1 EA 0D D1 E2 4A F7 EA
```

and the shift at `0x2FD9F`:

```
8B 46 FC C1 E0 0C
```

so one state is `0x1000 / 0x10000` of a turn, 22.5 degrees, fixed regardless of how many states the door type has. The initialiser at `0x386AD` sets five states for a normal door, so full open is 112.5 degrees, through 0, 22.5, 45, 67.5 and 90.

UW2 has the equivalent sequences at `0x3192B` and `0x3197C`.

## What changes

`GetRadiansForIndex` divided a right angle by the frame count:

```csharp
var unit = (Math.PI / 2) / NoOfFrames(obj);
```

For four states that is 22.5 degrees and right by coincidence. For the five state door it is 18, leaving it 22.5 short at full open. It is now the constant DOS uses.

Portcullises are unaffected. They animate by height through `GetHeightForIndex` rather than by rotation, and the four state angle is unchanged at 90 degrees either way.

## Checked

The two byte sequences above were read out of the shipped `UW.EXE`.

Opened doors in the running port and they look right, with no clipping into the frame or the surrounding wall.

There is no automated test. Door rotation is scene geometry driven by an animation timer, and the existing suite does not reach it.
