### PR TITLE
fix(combat): keep the enchantment bonus at the top minor class

### DIFF
--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -168,11 +168,17 @@ namespace Underworld
 
                                         if ((enchant.SpellMinorClass & 8) == 0)
                                         {
-                                            AttackScore += (1 + enchant.SpellMinorClass & 0x7);
+                                            // (minor & 7) + 1, not (1 + minor) & 7. C# binds + tighter
+                                            // than &, so the original lost the whole bonus at minor 7:
+                                            // DOS adds 8 there, this added 0. UW.EXE 0x254FD masks with
+                                            // `and ax,7` and only then `inc ax`. See issue #102.
+                                            AttackScore += (enchant.SpellMinorClass & 0x7) + 1;
                                         }
                                         else
                                         {
-                                            AttackDamage += (1 + enchant.SpellMinorClass & 0x7);
+                                            // Same precedence trap as the accuracy arm above. DOS masks
+                                            // then increments in both, so minor 15 adds 8 here, not 0.
+                                            AttackDamage += (enchant.SpellMinorClass & 0x7) + 1;
                                         }
                                         break;
                                     }


### PR DESCRIPTION
Closes #102.

The strongest weapon enchantment in each arm gave no benefit at all.

## The bug

Both arms of the class `0x0C` enchantment bonus were written as:

```csharp
AttackScore += (1 + enchant.SpellMinorClass & 0x7);
```

C# binds `+` tighter than `&`, so that is `(1 + minor) & 7`. DOS masks first and increments second.

## What DOS does

`CalculateAttackScorePlayer_seg022_FF6`. The guard and the arithmetic are at `UW.EXE 0x254FD`:

```
83 7E FE 0C          cmp  word [bp-4],0Ch      ; enchantment class 0x0C
75 1F                jne  skip
F7 46 FC 08 00       test word [bp-4],8        ; bit 3 selects the arm
74 0D                jz   accuracy
```

and the calculation itself at `0x2550D`:

```
25 07 00             and  ax,7
40                   inc  ax
01 06 70 26          add  [2670],ax
```

Mask, then increment. The reverse order does not appear anywhere in that routine.

## The difference

Bit 3 of the minor class selects the arm: clear is accuracy, set is damage. The two forms agree everywhere except the top of each arm.

| minor | arm | DOS | port |
| --- | --- | --- | --- |
| 0 to 6 | accuracy | minor + 1 | same |
| **7** | accuracy | **8** | **0** |
| 8 to 14 | damage | minor - 7 | same |
| **15** | damage | **8** | **0** |

The attack score feeds a 0 to 30 roll needing 16 to hit, in `SkillCheck_seg037_32E6_C` at `0x3419C`, so the accuracy case was worth about 26 points of hit chance.

## It reaches shipped items

Scanning the object lists of the nine UW1 levels in `DATA/LEV.ARK`, 8696 live object records carry 181 class `0x0C` enchantments, of which 6 are minor 7 and 11 are minor 15. So 17 shipped objects were affected, not just a theoretical edge case.

## Checked

The byte sequences above were read out of the shipped `UW.EXE`.

There is no automated test and I have not tried to observe this in play: a change in hit probability is not visually distinguishable in a reasonable number of attacks. The shipped item count above is offered instead, as evidence that the corrected path is actually reachable.
