### PR TITLE
Play the sounds DOS plays on a hit, a miss and an impact

### DIFF
--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -263,10 +263,17 @@ namespace Underworld
                 }
                 else
                 {
-                    // a miss. The impact sound belongs here, not before the test: this
-                    // routine's zero argument means "no defender found" in DOS, while the
-                    // port's attackresult is zero on a HIT, so calling it unconditionally
-                    // played the swing-and-miss sound on every successful hit. See #108.
+                    // a miss. The impact sound belongs here, not before the test. DOS
+                    // agrees with the port that zero from CalculateAttackResults is a hit:
+                    // at seg022_230E_E30 it does or ax,ax and jumps to the damage path on
+                    // zero, and that path plays nothing. It reaches this routine only from
+                    // the two miss paths, passing the nonzero result here and a literal
+                    // zero from the no-defender path. Calling it before the test played the
+                    // no-defender whiff on every successful hit. See #108.
+                    //
+                    // DOS calls DamageObject first and sounds afterwards, at
+                    // seg022_230E_E5A and seg022_230E_E62. The order is kept as the port
+                    // had it, since nothing here depends on it and the swap is untested.
                     CombatMissImpactSound(attackresult);
                     damage.DamageObject(
                         objToDamage: DefendingCharacter,

--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -255,7 +255,6 @@ namespace Underworld
 
                 AttackScoreFlankingBonus = CalcFlankingBonus();
                 var attackresult = CalcAttackResults();
-                CombatMissImpactSound(attackresult);
                 if (attackresult == 0)
                 {
                     //A hit
@@ -264,7 +263,11 @@ namespace Underworld
                 }
                 else
                 {
-                    // a miss
+                    // a miss. The impact sound belongs here, not before the test: this
+                    // routine's zero argument means "no defender found" in DOS, while the
+                    // port's attackresult is zero on a HIT, so calling it unconditionally
+                    // played the swing-and-miss sound on every successful hit. See #108.
+                    CombatMissImpactSound(attackresult);
                     damage.DamageObject(
                         objToDamage: DefendingCharacter,
                         basedamage: 0,
@@ -345,30 +348,21 @@ namespace Underworld
                     }
                 }
 
-                //TODO: UW1 may have different values.
-                var effectVar8 = 0;
-                //Seg24_E37
-                if (var6 != 1)
+                // The two games decide 7 versus 8 differently, and this was UW2's rule for
+                // both. UW1 gives 7 only when both classifications are 1 (UW.EXE 0x25122);
+                // UW2 also gives 7 when the first is 2 and the second is 1 (UW2.EXE
+                // 0x269F7). See issue #108.
+                int effectVar8;
+                if (_RES == GAME_UW2)
                 {
-                    if (var6 == 2)
-                    {
-                        if (var7 == 1)
-                        {
-                            effectVar8 = 7;
-                        }
-                        else
-                        {
-                            effectVar8 = 8;
-                        }
-                    }
-                    else
-                    {
-                        effectVar8 = 8;
-                    }
+                    // 7 when the first is 1, or when it is 2 and the second is 1.
+                    effectVar8 = (var6 == 1 || (var6 == 2 && var7 == 1)) ? 7 : 8;
                 }
                 else
                 {
-                    effectVar8 = 7;
+                    // UW1 needs both to be 1: the second cmp is only reached when the
+                    // first matched, and either mismatch falls through to 8.
+                    effectVar8 = (var6 == 1 && var7 == 1) ? 7 : 8;
                 }
                 UWsoundeffects.PlaySoundEffectAtObject((byte)effectVar8, DefendingCharacter, 0);
             }

--- a/src/interaction/combat/combat_missile.cs
+++ b/src/interaction/combat/combat_missile.cs
@@ -115,9 +115,11 @@ namespace Underworld
                 //sound effect at player position
                 UWsoundeffects.PlaySoundEffectAtAvatar(UWsoundeffects.SoundEffectHit1, pan: 0x40, velocityOffset: 0);
             }
-            else
+            else if (!objectHit.IsStatic)
             {
-                //sound effect at hit position.
+                // Mobile defenders only. DOS tests this before playing, so a missile
+                // striking a static object is silent in both games: UW.EXE 0x259A0 calls
+                // the mobile test and skips the sound on a zero result. See issue #108.
                 UWsoundeffects.PlaySoundEffectAtObject(UWsoundeffects.SoundEffectHit2, objectHit, 0);
             }
             AttackerAppliesFinalDamage(


### PR DESCRIPTION
Closes #108.

Three divergences in the combat sounds. The first is audible on every successful melee hit.

## A hit played the miss sound

`CombatMissImpactSound` was called immediately after `CalcAttackResults`, before the result was tested. Its zero argument means "the swing found nobody" in DOS, while the port's `attackresult` is zero on a **hit**, so every landed blow played the swing and miss sound.

DOS passes zero only from the no-defender path, in `ExecuteAttack_seg022_230E:D9C` at `UW.EXE 0x251AC`:

```asm
0E E8 C2 F6     call  CheckForAttackHit
98              cwde
0B C0           or    ax,ax
75 0B           jnz   short found       ; a defender was found, skip this
6A 00           push  0                 ; nobody there
0E E8 7A FE     call  CombatMissImpactSound
```

The call now sits in the miss branch. The port's own no-defender path already passed literal zero and was correct; it is untouched.

## UW1 used UW2's impact rule

After a miss where a defender was present, the routine picks impact sound 7 or 8.

UW1 at `UW.EXE 0x25122` needs **both** classifications to be 1. The second compare is only reached when the first matched, and either mismatch falls through to 8:

```asm
80 7E FA 01     cmp   byte [bp-6],1
75 0C           jne   short eight
80 7E F9 01     cmp   byte [bp-7],1
75 06           jne   short eight
C6 46 F8 07     mov   byte [bp-8],7
EB 04           jmp   short done
C6 46 F8 08     eight: mov byte [bp-8],8
```

UW2 at `UW2.EXE 0x269F7` also accepts first 2 with second 1:

```asm
80 7E FA 01     cmp   byte [bp-6],1
74 0C           je    short seven
80 7E FA 02     cmp   byte [bp-6],2
75 0C           jne   short eight
80 7E F9 01     cmp   byte [bp-7],1
75 06           jne   short eight
```

| first | second | UW1 | UW2 |
| --- | --- | --- | --- |
| 1 | 1 | 7 | 7 |
| 1 | 2 | **8** | 7 |
| 2 | 1 | **8** | 7 |
| anything else | | 8 | 8 |

The rule now branches on the game. UW2 is unchanged.

## Missiles hitting static objects were audible

`MissileAttackHit_seg022_230E:14BF` at `UW.EXE 0x259A0` plays sound 3 at the player, and otherwise asks whether the defender is mobile before playing sound 4:

```asm
FF 76 0E        push  word [bp+0Eh]
FF 76 0C        push  word [bp+0Ch]
9A 52 0A 74 26  call  far 2674:0A52     ; is the defender mobile?
83 C4 04        add   sp,4
0A C0           or    al,al
74 12           jz    short done        ; static, so no sound at all
6A 00           push  0
FF 76 0E FF 76 0C  push word [bp+0Eh] / push word [bp+0Ch]
6A 04           push  4
```

UW2 does the same at `UW2.EXE 0x274F1`.

`TestIfStaticOrMobile_seg027_A52` compares the object's pointer offset against the base of the static array and returns 1 below it, which is the same predicate as an index below `0x100` only because the records are contiguous. That is what the port's `IsStatic` is derived from (`tilemap.cs:655`), so the guard uses it. DOS also returns 0 for a null pointer; the port cannot reach this call with a null defender, since `combat_missile.cs:14` would already have thrown.

## What this does not fix

Cross-review confirmed all three changes against both disassemblies and found three further faults in the same routine, all of them older than this change. They decide the values that the 7 versus 8 rule above is applied to, so the rule being right does not yet make UW1 sound like DOS. An empty armour slot is classified as 1 where DOS uses 0. The armour slot index is not masked to two bits, so a hit on body part 3 reads slot 4 where DOS reads slot 0. And UW1 has no player weapon sound class at all: it overwrites the attacker index with the attacker's item id before it compares anything, while the port takes UW2's shape for both games.

They are raised separately as #112 rather than folded in here.

## Checked

The byte sequences above were read out of the shipped executables. The mnemonics are my reading of them, and the far call targets are shown as encoded, so they are subject to overlay relocation.

**No test covers this, and none is added.** There is no combat coverage in the repository, and the two parts worth hearing can only be checked by playing: a melee hit should no longer carry a whiff, and a missile striking a wall or a crate should be silent while a creature still sounds. The 7 versus 8 rule cannot reasonably be heard, since it turns on material classifications, and rests on the bytes above.

I have not played these; the change rests on the disassembly and on review.
