### PR TITLE
Play the impact sound when a swing meets terrain

### DIFF
--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -767,27 +767,33 @@ namespace Underworld
                 // passed roughly one swing in twelve. See issue #111.
                 if (((MotionCalcArray.UnkC_terrain | MotionCalcArray.UnkE) & 0x300) != 0)
                 {
-                    // The weapon met terrain rather than an object. DOS spawns an impact
-                    // animation here and, when the attacker is the player, plays sound
-                    // effect 7 at the impact point: UW.EXE 0x247CD tests CurrentAttacker
-                    // against 1 and skips the sound for anyone else. An NPC hitting a wall
-                    // is silent.
+                    // The weapon met terrain rather than an object. DOS restores the
+                    // calculation array's x and y to the attacker's own tile and fine
+                    // coordinates, discarding the projected point GetCoordinateInDirection
+                    // left there, then calls SpawnImpactAnimo_seg022_2D2 with the attacker's
+                    // heading and the same weapon reach.
                     //
-                    // Only the sound is done here. The animation allocates an object and
-                    // links it into the tile's list, which is a larger change. See #111.
+                    // SpawnImpactAnimo walks outward from that start point one unit at a
+                    // time, up to reach+1 steps, and stops at the first step whose terrain
+                    // flags are set. There it plays sound effect 7 and spawns the impact
+                    // animation. The sound is played only when the attacker is the player:
+                    // UW.EXE 0x247CD tests CurrentAttacker against 1, so an NPC hitting a
+                    // wall is silent.
+                    //
+                    // Only the sound is done here, and it is played at the start of that
+                    // walk rather than at the step that stops it. The offset is under one
+                    // tile, but it is not where DOS puts it. The walk belongs with the
+                    // animation, which allocates an object and links it into the tile's
+                    // list. Both are left for their own change. See #111.
                     if (AttackingCharacter.index == 1)
                     {
-                        // At the ATTACKER, not at the weapon reach point. DOS rebuilds the
-                        // calculation array's x and y from the attacker object's own tile
-                        // and fine coordinates in the block just before the call, so the
-                        // projected point GetCoordinateInDirection left there is discarded.
                         UWsoundeffects.PlaySoundEffectAtCoordinate(
                             effectNo: 7,
                             packedX: (AttackingCharacter.tileX << 3) + AttackingCharacter.xpos,
                             packedY: (AttackingCharacter.tileY << 3) + AttackingCharacter.ypos,
                             volDelta: 0);
                     }
-                    Debug.Print("Todo SpawnImpactAnimo() animation half");
+                    Debug.Print("Todo SpawnImpactAnimo() walk and animation halves");
                 }
 
             }

--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -759,7 +759,13 @@ namespace Underworld
             {
                 //seg024_24E9_65C:
                 motion.ProcessMotionTileHeights_seg028_2941_385(0);
-                if (((MotionCalcArray.UnkC_terrain_base | MotionCalcArray.UnkE_base) & 0x300) != 0)
+                // The CURRENT calculation array, not the base one. DOS reads
+                // CurrentCalculationArrayPTR +0x0C and +0x0E right after the call, and
+                // ProcessMotionTileHeights writes those same working fields. The _base
+                // properties address a different buffer that the routine never touches, so
+                // this test was reading whatever an earlier calculation had left there and
+                // passed roughly one swing in twelve. See issue #111.
+                if (((MotionCalcArray.UnkC_terrain | MotionCalcArray.UnkE) & 0x300) != 0)
                 {
                     // The weapon met terrain rather than an object. DOS spawns an impact
                     // animation here and, when the attacker is the player, plays sound
@@ -771,10 +777,14 @@ namespace Underworld
                     // links it into the tile's list, which is a larger change. See #111.
                     if (AttackingCharacter.index == 1)
                     {
+                        // At the ATTACKER, not at the weapon reach point. DOS rebuilds the
+                        // calculation array's x and y from the attacker object's own tile
+                        // and fine coordinates in the block just before the call, so the
+                        // projected point GetCoordinateInDirection left there is discarded.
                         UWsoundeffects.PlaySoundEffectAtCoordinate(
                             effectNo: 7,
-                            packedX: MotionCalcArray.x0,
-                            packedY: MotionCalcArray.y2,
+                            packedX: (AttackingCharacter.tileX << 3) + AttackingCharacter.xpos,
+                            packedY: (AttackingCharacter.tileY << 3) + AttackingCharacter.ypos,
                             volDelta: 0);
                     }
                     Debug.Print("Todo SpawnImpactAnimo() animation half");

--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -773,22 +773,41 @@ namespace Underworld
                     // left there, then calls SpawnImpactAnimo_seg022_2D2 with the attacker's
                     // heading and the same weapon reach.
                     //
-                    // SpawnImpactAnimo walks outward from that start point one unit at a
-                    // time, up to reach+1 steps, and stops at the first step whose terrain
-                    // flags are set. There it plays sound effect 7 and spawns the impact
-                    // animation. The sound is played only when the attacker is the player:
-                    // UW.EXE 0x247CD tests CurrentAttacker against 1, so an NPC hitting a
-                    // wall is silent.
+                    // SpawnImpactAnimo is a walk. It tests the terrain flags where it
+                    // stands, and where they are clear it steps one unit along the heading
+                    // and tests again, covering positions 0 to reach. Position 0 is the
+                    // attacker's own, so DOS can sound there; the last position it steps to
+                    // is never tested. It plays the sound and spawns the animation at the
+                    // first tested position whose flags are set.
                     //
-                    // Only the sound is done here, and it is played at the start of that
-                    // walk rather than at the step that stops it. The offset is under one
-                    // tile, but it is not where DOS puts it. The walk belongs with the
-                    // animation, which allocates an object and links it into the tile's
-                    // list. Both are left for their own change. See #111.
+                    // Both games play only when the attacker is the player, so an NPC
+                    // hitting a wall is silent: seg022_230E_3BA in UW1, seg024_24E9_3B3 in
+                    // UW2. They choose the effect differently. UW1 always plays 7. UW2
+                    // plays 7 when the player's weapon sound class is 1 or 2 and 8
+                    // otherwise, at seg024_24E9_3BF.
+                    //
+                    // PlayerWeaponSound is still a placeholder pinned to 1 in
+                    // combat_input.cs, so the UW2 arm always yields 7 today. It is written
+                    // out anyway so it comes right on its own when that is derived from the
+                    // weapon.
+                    //
+                    // Not done here. The sound plays at the start of the walk rather than
+                    // at the step that stops it, under a tile short of DOS. UW2 also sets
+                    // ImpactSkipSound at seg024_24E9_3BA, which suppresses the whiff that
+                    // CombatMissImpactSound would otherwise play straight after this; that
+                    // belongs with the change to that routine. And DOS plays nothing at all
+                    // when the impact object cannot be allocated, because the sound sits
+                    // after PrepareNewObjectProps in the routine. The walk, the animation
+                    // and the skip flag are left for their own change. See #111.
                     if (AttackingCharacter.index == 1)
                     {
+                        int impactEffect = 7;
+                        if (_RES == GAME_UW2)
+                        {
+                            impactEffect = (PlayerWeaponSound == 1 || PlayerWeaponSound == 2) ? 7 : 8;
+                        }
                         UWsoundeffects.PlaySoundEffectAtCoordinate(
-                            effectNo: 7,
+                            effectNo: (byte)impactEffect,
                             packedX: (AttackingCharacter.tileX << 3) + AttackingCharacter.xpos,
                             packedY: (AttackingCharacter.tileY << 3) + AttackingCharacter.ypos,
                             volDelta: 0);

--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -761,7 +761,23 @@ namespace Underworld
                 motion.ProcessMotionTileHeights_seg028_2941_385(0);
                 if (((MotionCalcArray.UnkC_terrain_base | MotionCalcArray.UnkE_base) & 0x300) != 0)
                 {
-                    Debug.Print("Todo SpawnImpactAnimo()");
+                    // The weapon met terrain rather than an object. DOS spawns an impact
+                    // animation here and, when the attacker is the player, plays sound
+                    // effect 7 at the impact point: UW.EXE 0x247CD tests CurrentAttacker
+                    // against 1 and skips the sound for anyone else. An NPC hitting a wall
+                    // is silent.
+                    //
+                    // Only the sound is done here. The animation allocates an object and
+                    // links it into the tile's list, which is a larger change. See #111.
+                    if (AttackingCharacter.index == 1)
+                    {
+                        UWsoundeffects.PlaySoundEffectAtCoordinate(
+                            effectNo: 7,
+                            packedX: MotionCalcArray.x0,
+                            packedY: MotionCalcArray.y2,
+                            volDelta: 0);
+                    }
+                    Debug.Print("Todo SpawnImpactAnimo() animation half");
                 }
 
             }


### PR DESCRIPTION
Closes #111.

Swinging a weapon at a wall in DOS makes a sound. In the port it made none. Two faults, one on top of the other.

## The terrain test read a buffer nothing writes

`checkAttackHit` tested `MotionCalcArray.UnkC_terrain_base` and `UnkE_base`. Those address `base_dseg_25c4`. `ProcessMotionTileHeights_seg028_2941_385` does not write there: it writes `UnkC_terrain` at `motion_calc.cs:498` and `UnkE` at `:357`, both through `PtrToMotionCalc`, which `checkAttackHit` points at a fresh array of its own at `combat.cs:718`.

So the test was reading whatever an earlier motion calculation had left behind. It is not that the base buffer is never written at all, it is that this routine does not write it: the movement path reaches it because `CopyMotionValsToAnotherArray_seg031_2CFA_93` points `PtrToMotionCalc` at it (`motion_calc.cs:305`).

That matches DOS, where the calculation array is a local frame buffer rather than a global. `CheckForAttackHit_seg022_466` points it at its own stack:

```asm
lea   ax,[bp-1Ch]
mov   CurrentCalculationArrayPTR,ax
```

and reads the flags back out of it at `seg022_230E_641`:

```asm
push  0
call  ProcessMotionTileHeights_seg026_379
inc   sp
inc   sp
mov   bx,CurrentCalculationArrayPTR
mov   ax,[bx+0Ch]
or    ax,[bx+0Eh]
test  ax,300h
jz    short seg022_230E_6B3
```

Those are the same two fields the port exposes as `UnkC_terrain` and `UnkE`.

Measured in the running port. Instrumented and swung at a wall twelve times, the old test passed once. Two swings a single unit of position apart behaved differently, which looked like geometric sensitivity and was stale state. With the working array the branch fires on four swings in five, the fifth being a swing that did not face the wall.

## The branch printed a TODO instead of making a sound

Past the test, DOS restores the calculation array's x and y to the attacker's own coordinates, discarding the projected reach point `GetCoordinateInDirection` left there earlier in the routine. At `seg022_230E_65C`, for x:

```asm
les   bx,[bp-4]          ; the attacker object
mov   ax,es:[bx+16h]
and   ax,0FC00h
shr   ax,0Ah             ; tile x
shl   ax,3
mov   dx,es:[bx+2]
and   dx,0E000h
shr   dx,0Dh             ; fine x
add   ax,dx
mov   bx,CurrentCalculationArrayPTR
mov   [bx],ax
```

and the same shape for y from `es:[bx+16h] & 3F0h >> 4` and `es:[bx+2] & 1C00h >> 0Ah`. That packing is `(tile << 3) + fine`, which is what the port passes.

It then calls `SpawnImpactAnimo_seg022_2D2` with the attacker's heading and the same weapon reach the swing used:

```asm
push  CurrentCalculationArrayPTR
mov   ax,dseg_5c99_2656
add   ax,3
push  ax
push  di                 ; heading
push  cs
call  near ptr SpawnImpactAnimo_seg022_2D2
```

`SpawnImpactAnimo` is a walk, not a single test. It calls `ProcessMotionTileHeights` where it stands and tests the same two flags against `300h`; where they are clear it steps one unit along the heading with `GetCoordinateInDirection` and repeats. It covers positions 0 to reach, so the attacker's own position is tested first and can be the one that sounds, and the last position it steps to is never tested. At the first tested position whose flags are set it plays the sound and spawns the animation.

Both games play the sound only when the attacker is the player, so an NPC hitting a wall is silent. UW1 at `seg022_230E_3BA`:

```asm
cmp   CurrentAttacker_dseg_5c99_2678,1
jnz   short seg022_230E_3D6
push  0                          ; volume delta
mov   bx,CurrentCalculationArrayPTR
push  word ptr [bx+2]            ; y
push  word ptr [bx]              ; x
push  7                          ; sound effect 7
call  LoadSoundAtCoordinate_seg014_1DC5_8AE
add   sp,8
```

The two games choose the effect differently, which the first draft of this change missed. UW1 always plays 7. UW2 tests the player's weapon sound class at `seg024_24E9_3BF`:

```asm
cmp   byte ptr MaybePlayerWeaponSound_dseg_24D6,1
jz    short seg024_24E9_3CD      ; effect 7
cmp   byte ptr MaybePlayerWeaponSound_dseg_24D6,2
jnz   short seg024_24E9_3DC      ; effect 8
```

The change forks on the game. `PlayerWeaponSound` is still a placeholder pinned to 1 in `combat_input.cs:239-240`, so the UW2 arm yields 7 today and nothing audible changes there. It is written out anyway so it comes right on its own when that value is derived from the weapon.

## What is not here

The sound plays at the start of the walk rather than at the position that stops it, so under a tile short of where DOS puts it. Not audible, but not the same point.

The walk is left with the animation, because the animation is what needs the exact point. That half allocates an object through `PrepareNewObjectProps_seg035_3E`, builds it with `ProbablyCreateAnimo_seg044_41E` and links it into the tile's object list with `InsertObjectToList_seg027_2861_5CF`. DOS also plays nothing at all when that allocation fails, because the sound sits after it in the routine; the port always plays.

UW2 sets `ImpactSkipSound_dseg_67d6_356` at `seg024_24E9_3BA` when it sounds here, and `CombatMissImpactSound` tests and clears it. So in UW2 a swing that meets terrain plays the impact sound instead of the whiff, not as well as it. That belongs with the routine that reads the flag rather than here, and is recorded in #112, so a UW2 wall swing will play both until then.

UW1 has no such flag because it genuinely plays both. `ExecuteAttack_seg022_D9C` calls `CombatMissImpactSound` with a literal zero whenever `CheckForAttackHit` returns zero, and zero is what the terrain path returns:

```asm
call  near ptr CheckForAttackHit_seg022_466
cbw
or    ax,ax
jnz   short seg022_230E_DB4
push  0
call  near ptr CombatMissImpactSound_seg022_C29
```

There is one more gap recorded in #111. The terrain branch is only reached when `ScanForCollisions` found no candidates at all, so a swing that passes near a barrel and then hits the wall behind it produces no impact. Whether DOS behaves the same way is unresolved.

## Checked

Read out of `UW1_asm.asm` and `uw2_asm.asm` against the shipped executables. The mnemonics are my reading of them. The two claims the fix rests on were verified at the sites themselves rather than at neighbouring ones: the buffer the flags live in, and the attacker test guarding the sound.

Cross-reviewed. The UW2 fork above came out of that review, along with the correction to how `SpawnImpactAnimo` actually works.

Verified by playing. Swinging at a wall now sounds on every swing that faces it. No test is added: there is no combat coverage in the repository, and this branch needs a live tilemap and the audio stack.
