### PR TITLE
Feed the impact sound the values DOS feeds it

### DIFF
--- a/src/interaction/combat/combat.cs
+++ b/src/interaction/combat/combat.cs
@@ -314,7 +314,10 @@ namespace Underworld
                 if (DefendingCharacter.index == 1)
                 {
                     //sound is based on body part/armour piece hit
-                    var var5slot = BodyPartHit + 1;
+                    // Masked to two bits, as DOS does: inc al then and al,3 at
+                    // seg022_230E_C9D in UW1 and seg024_24E9_DC5 in UW2. PickBodyHitPoint
+                    // returns 0 to 3, so a hit on part 3 asks for slot 0, not slot 4.
+                    var var5slot = (BodyPartHit + 1) & 3;
                     var ObjectInSlot = playerdat.GetInventorySlotObject(var5slot);
                     if (ObjectInSlot != null)
                     {
@@ -335,7 +338,12 @@ namespace Underworld
                     }
                     else
                     {
-                        var7 = 1;
+                        // Nothing in the slot classifies as 0 in both games, not 1. DOS
+                        // tests the returned object for null and jumps straight to the
+                        // zero: seg022_230E_CBF into seg022_230E_D0E in UW1, and
+                        // seg024_24E9_DE5 into seg024_24E9_E33 in UW2. It is the same
+                        // value an unarmoured slot would reach through the leather list.
+                        var7 = 0;
                     }
                 }
                 else


### PR DESCRIPTION
Fixes two of the three faults in #112. The third is left open on the issue for you to rule on.

`CombatMissImpactSound` picks between impact sounds 7 and 8 from two classifications, one for the attacker and one for the defender. Two of the values fed into that choice were wrong, in both games.

## The armour slot index was not masked

When the defender is the player, DOS looks up the armour in the slot that was hit. It adds one to the body part and masks to two bits.

UW1 at `seg022_230E_C9D`:

```asm
mov   al,byte ptr BodyPartHit_dseg_5c99_2672
inc   al
and   al,3
mov   [bp+var_5],al
```

UW2 at `seg024_24E9_DC5` is identical.

`PickBodyHitPoint` returns 0 to 3, so a hit on body part 3 was reading inventory slot 4 where DOS reads slot 0. That is a different piece of armour, and it feeds straight into the classification.

## An empty slot was classified as 1

DOS tests the looked-up object for null and jumps straight to zero.

UW1 at `seg022_230E_CBF`:

```asm
mov   ax,[bp+var_4]              ; the object in the slot
or    ax,[bp+var_4+2]
jnz   short seg022_230E_CC9      ; something there, go and classify it
jmp   short seg022_230E_D0E
...
seg022_230E_D0E:
mov   [bp+var_7],0
```

UW2 does the same at `seg024_24E9_DE5`, into `seg024_24E9_E33`.

The port used 1. Zero is also where the leather list lands, so in DOS an unarmoured body part sounds the same as a leather-covered one, and in the port it did not.

## When this becomes audible

Neither is audible on `main` as it stands, because the rule in use gives 7 whenever the attacker classification is 1, whatever the defender classification is. They become audible under UW1's own rule, which needs both to be 1. That rule is #113, so the two changes only pay off together, and this branch is off `main` rather than stacked so they can land in either order.

## Not fixed here

The third fault in #112 is that UW1 overwrites `CurrentAttacker` with the attacker's item id before it compares anything, at `seg022_230E_C5F`, so every later comparison in the routine is against an item id rather than an index and the player never reaches a weapon-based branch. The port uses UW2's shape for both games.

Taken literally it means the UW1 impact sound never varies with the player's weapon, since the classification comes from the avatar's own critter table entry and does not change. That looks like a vanilla bug rather than a design, and whether the port should reproduce it is your call rather than mine. I have left it on #112 with the evidence.

## Checked

Read out of `UW1_asm.asm` and `uw2_asm.asm` against the shipped executables. The mnemonics are my reading of them.

No test is added, since there is no combat coverage in the repository. Neither change is reachable by the save tests.
