### PR TITLE
Refuse a jump while airborne, as DOS does

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -567,7 +567,25 @@ public partial class main : Node3D
 
 		if (Input.IsKeyPressed(Key.J))//jump.
 		{
-			if (playerdat.TileState != 1)//ensure we are not swimming
+			// DOS guards both jump commands with the same pair of tests, at
+			// seg034_2F89_17E for the plain jump and again at seg034_2F89_1AF for the
+			// 6 and 7 input path:
+			//
+			//     test Player_MotionArray_tilestate_25_dseg_5c99_27A5,10h
+			//     jnz  short <no jump>
+			//     mov  bx,PlayerDataPTR_dseg_5c99_7270
+			//     cmp  byte ptr [bx+0B8h],1
+			//     jz   short <no jump>
+			//     mov  MotionCommand_dseg_5c99_75A,7
+			//
+			// It is an airborne exclusion, not a grounded test: bit 0x10 of the motion
+			// array's tilestate byte, which motion_calc.cs returns for a player who is
+			// jumping or on a bridge. There is no test of a grounded bit anywhere.
+			//
+			// The second test is the one already here. TileState holds the translated
+			// motion state that UpdateMotionStateAndSwimming writes, and 1 is the
+			// swimming value.
+			if ((motion.playerMotionParams.tilestate25 & 0x10) == 0 && playerdat.TileState != 1)
 			{
 				if (Input.IsKeyPressed(Key.Shift))
 				{
@@ -577,7 +595,6 @@ public partial class main : Node3D
 				else
 				{
 					//jump
-					//todo: Do a test that the player is grounded.
 					motion.MotionInputPressed = 7;
 				}
 			}


### PR DESCRIPTION
Closes #110.

From `backlog.md`: "ProcessMotionInputs Check that player is grounded when jumping".

DOS does prevent mid air jumping, but not with a grounded test. It excludes the airborne case, and the two are not opposites of each other, so a check written as "the grounded bit is set" would not match.

## What DOS does

Both jump paths apply the same pair of tests. The plain jump at `seg034_2F89_178`:

```asm
mov   MotionCommand_dseg_5c99_75A,1
test  Player_MotionArray_tilestate_25_dseg_5c99_27A5,10h
jnz   short seg034_2F89_1D7          ; airborne, no jump
mov   bx,PlayerDataPTR_dseg_5c99_7270
cmp   byte ptr [bx+0B8h],1
jz    short seg034_2F89_1D7          ; state is 1, no jump
mov   MotionCommand_dseg_5c99_75A,7
```

and the 6 and 7 input path repeats them at `seg034_2F89_1AF`, so the long jump is guarded the same way:

```asm
test  Player_MotionArray_tilestate_25_dseg_5c99_27A5,10h
jnz   short seg034_2F89_1C3
mov   bx,PlayerDataPTR_dseg_5c99_7270
cmp   byte ptr [bx+0B8h],1
jz    short seg034_2F89_1C3
jmp   short seg034_2F89_1D3          ; issue the 6 or 7
seg034_2F89_1C3:
mov   MotionCommand_dseg_5c99_75A,1
```

Bit `0x10` of the motion array's tilestate byte is the airborne flag. `motion_calc.cs:1096` already returns it for a player who is jumping or on a bridge. There is no test of a grounded bit anywhere in either path.

The second test is the one the port already had, written as `playerdat.TileState != 1`. It is the same test: `UpdateMotionStateAndSwimming` writes the translated motion state into that byte and 1 is the swim entry of the translation table.

## The change

The airborne exclusion is added alongside the existing state test, at the level that covers both the jump and the long jump, and the `//todo: Do a test that the player is grounded` comment goes.

```csharp
if ((motion.playerMotionParams.tilestate25 & 0x10) == 0 && playerdat.TileState != 1)
```

## Not reproduced

When DOS refuses the jump it leaves the motion command at 1, ordinary movement, rather than issuing nothing. The port's input layer in `main.cs` is not a port of that routine, and it already sets command 1 from the movement keys in the same frame, so issuing it here would either be redundant or would move the player on a bare jump keypress with stale walk and heading values. Left alone deliberately.

## Checked

Read out of `UW1_asm.asm`. The mnemonics are my reading of them.

Tested by hand in the running port: jumping on the flat is unchanged, and a second jump in mid air or while falling is now refused, as is a mid air long jump.

Worth a second opinion on one case. The port sets the same `0x10` bit for a player standing on a bridge as for one in the air, so a jump from a bridge is now refused. DOS tests that same bit, so refusing is what DOS does, but if that reads wrong in play it is the place to look.

No test is added. This is keyboard input in `main.cs` and there is no coverage of that path.
