### PR TITLE
Give UW1 its own collision path, not UW2's

### DIFF
--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -78,7 +78,12 @@ namespace Underworld
             }
             else
             {//seg031_2CFA_E28:
-                var volume = (byte)((Math.Abs(MotionParams.unk_a_pitch) / 0xA) + ((si_mass - 600) / 32) - 40);//now reused as volume?/
+                // 0x32, not 32. DOS divides by 32h in both games: mov bx,32h then
+                // idiv bx, at seg030_2B26_D98 in UW1 and seg031_2CFA_E43 in UW2. The
+                // other two constants in this expression were transcribed as 0xA and 40,
+                // so this one looks like a hex digit that lost its prefix. It makes the
+                // mass term of the collision sound volume louder than DOS by a third.
+                var volume = (byte)((Math.Abs(MotionParams.unk_a_pitch) / 0xA) + ((si_mass - 600) / 0x32) - 40);//now reused as volume?/
                 //Debug.Print($"play sound effect {soundeffect} at {MotionParams.x_0 >> 5} {MotionParams.y_2 >> 5}");
                 UWsoundeffects.PlaySoundEffectAtCoordinate(effectNo: 0xF, packedX: MotionParams.x_0 >> 5, packedY: MotionParams.y_2 >> 5, volDelta: volume);
                 var di_collisionresult = CollideObjects_seg030_2BB7_1CE(MotionParams, UWMotionParamArray.ACollisionIndex_dseg_67d6_416, MotionCalcArray.MotionArrayObjectIndexA_base);

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -127,14 +127,22 @@ namespace Underworld
 
                         var6 = MotionParams.momentum_14;
 
+                        // UW2 only. UW1's DoCollision_seg030_2B26_C93 goes from
+                        // test si,4 / jnz seg030_2B26_DFF straight into the damped
+                        // arithmetic below. There is no exact reflection anywhere in it,
+                        // so a UW1 bounce always damps. The TODO that used to sit here
+                        // guessed as much; it is confirmed. See #105.
                         if (
-                            (MotionParams.index_20 == 1) && ((playerdat.MagicalMotionAbilities & 0x20) == 0x20)
-                            ||
-                            (MotionParams.unk_16_relatedtoPitch == 0xF)
+                            (_RES == GAME_UW2)
+                            &&
+                            (
+                                (MotionParams.index_20 == 1) && ((playerdat.MagicalMotionAbilities & 0x20) == 0x20)
+                                ||
+                                (MotionParams.unk_16_relatedtoPitch == 0xF)
+                            )
                         )
                         {
                             //Bouncing_seg031_2CFA_EE2:
-                            //TODO: it looks like this code is not present in UW1. Determine if this will cause issues?
                             MotionParams.unk_a_pitch = (short)-MotionParams.unk_a_pitch;
                         }
                         else
@@ -154,8 +162,12 @@ namespace Underworld
                             }
                         }
 
-                        //seg031_2CFA_F63:
+                        // seg031_2CFA_F63, UW2 only. UW1 reaches the var3 test directly:
+                        // seg030_2B26_E86 is cmp [bp+var_3],0 with nothing before it, so
+                        // there is no index or handler test and no speed reduction.
                         if (
+                            (_RES == GAME_UW2)
+                            &&
                             (MotionParams.index_20 != 1)
                             &&
                             ((SpecialMotionHandler.table01 & 0x1000) == 0x1000)
@@ -258,14 +270,20 @@ namespace Underworld
                             }
                         }
 
-                        //seg031_2CFA_10CA:
-
+                        // seg031_2CFA_10CA, UW2 only. UW1 has no equivalent block: its
+                        // seg030_2B26_FA0 is a bare jmp to seg030_2B26_FD3, which calls
+                        // seg030_2B26_788 and returns. Nothing restores the momentum, and
+                        // nothing saves it either, so var6 is read on the UW2 path alone.
                         if (
+                            (_RES == GAME_UW2)
+                            &&
+                            (
                             (((MotionCalcArray.UnkC_terrain_base & 3) == 3) && ((MotionCalcArray.UnkC_terrain_base & 0xC & 4) != 4))
                             ||
                             (((MotionCalcArray.UnkC_terrain_base & 3) == 3) && ((MotionCalcArray.UnkC_terrain_base & 0xC & 4) == 4) && ((MotionCalcArray.UnkE_base & 0x40) != 0) && ((MotionCalcArray.UnkE_base & 0x800) == 0x800))
                             ||
                             (((MotionCalcArray.UnkC_terrain_base & 3) != 3) && ((MotionCalcArray.UnkE_base & 0x40) != 0) && ((MotionCalcArray.UnkE_base & 0x800) == 0x800))
+                            )
                             )
                         {
                             MotionParams.momentum_14 = (short)var6;

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -279,6 +279,13 @@ namespace Underworld
                         // seg030_2B26_FA0 is a bare jmp to seg030_2B26_FD3, which calls
                         // seg030_2B26_788 and returns. Nothing restores the momentum, and
                         // nothing saves it either, so var6 is read on the UW2 path alone.
+                        //
+                        // The condition itself is NOT faithful and is left as it was found.
+                        // DOS restores when (C & 3) == 3 and bit 2 of C is SET (test ...,4
+                        // then jnz to the restore at seg031_2CFA_10ED), and it SKIPS the
+                        // restore when bit 0x800 of E is set (test ...,800h then jnz to
+                        // seg031_2CFA_10F9). Both read inverted below. UW2 only, so it is
+                        // not fixed here.
                         if (
                             (_RES == GAME_UW2)
                             &&

--- a/src/physics/motion_collisions.cs
+++ b/src/physics/motion_collisions.cs
@@ -50,9 +50,15 @@ namespace Underworld
             {//seg031_2CFA_DDE: 
                 ZeroiseMotionValues_seg031_2CFA_7BF(MotionParams);
                 MotionParams.tilestate25 = 2;
+                // The volume differs as well as the effect. UW1 hardcodes effect 5 and
+                // passes (mass - 600) / 32h as the volume, at seg030_2B26_D61. UW2 picks
+                // the effect from the mass and passes a volume of zero, push 0 at
+                // Plsaysound_seg031_2CFA_E06. The port took UW2's zero for both.
+                int landingVolume = 0;
                 if (_RES != GAME_UW2)
                 {
                     soundeffect = 5;
+                    landingVolume = (si_mass - 600) / 0x32;
                 }
                 else
                 {
@@ -74,7 +80,7 @@ namespace Underworld
                 }
 
                 //Debug.Print($"play sound effect {soundeffect} at {MotionParams.x_0 >> 5} {MotionParams.y_2 >> 5}");
-                UWsoundeffects.PlaySoundEffectAtCoordinate(soundeffect, MotionParams.x_0 >> 5, MotionParams.y_2 >> 5, 0);
+                UWsoundeffects.PlaySoundEffectAtCoordinate(soundeffect, MotionParams.x_0 >> 5, MotionParams.y_2 >> 5, landingVolume);
             }
             else
             {//seg031_2CFA_E28:
@@ -210,14 +216,21 @@ namespace Underworld
                                                     //seg031_2CFA_108C
                                                     if ((MotionCalcArray.UnkE_base & 0x20) == 0)
                                                     {//seg031_2CFA_109E:
-                                                        if ((MotionCalcArray.UnkE_base & 0x40) == 0)
-                                                        {
-                                                            MotionParams.tilestate25 = 1;
-                                                        }
-                                                        else
+                                                        // UW1 has three outcomes here, not
+                                                        // four. seg030_2B26_F72 tests 10h
+                                                        // then 20h and falls through to
+                                                        // tilestate 1 at seg030_2B26_F96.
+                                                        // There is no 40h test and no
+                                                        // tilestate 8 anywhere in the UW1
+                                                        // routine. UW2 adds both.
+                                                        if ((_RES == GAME_UW2) && ((MotionCalcArray.UnkE_base & 0x40) != 0))
                                                         {
                                                             //seg031_2CFA_10AA:
                                                             MotionParams.tilestate25 = 8;
+                                                        }
+                                                        else
+                                                        {
+                                                            MotionParams.tilestate25 = 1;
                                                         }
                                                     }
                                                     else
@@ -266,8 +279,11 @@ namespace Underworld
                                             }
                                         }
                                     }
-                                    //seg031_2CFA_10B8:
-                                    if (UWMotionParamArray.dseg_67d6_26A4 == 0)
+                                    // seg031_2CFA_10B8, UW2 only. UW1 jumps straight to
+                                    // seg030_2B26_FD3 from every tilestate store, and
+                                    // nothing after seg030_2B26_D08 writes the speed field
+                                    // at all.
+                                    if ((_RES == GAME_UW2) && (UWMotionParamArray.dseg_67d6_26A4 == 0))
                                     {
                                         MotionParams.speed_12 = 0;
                                     }


### PR DESCRIPTION
Closes #105.

The issue reported one divergence in `DoCollision`. Reading the two routines side by side, and then having the reading attacked in review, there are seven. Six are fixed here and the seventh is raised separately. This is much wider than the issue as written.

The port's routine is `DoCollision_seg031_2CFA_D1F`, named after the UW2 segment address, and it is applied to both games. UW1's equivalent is `DoCollision_seg030_2B26_C93`, and it is a shorter routine.

## The exact reflection

UW2 reflects the pitch outright when the player has the bouncing ability, or when the pitch field is `0xF`, at `Bouncing_seg031_2CFA_EE2`:

```asm
cmp   word ptr [bx+20h],1        ; the object index
jnz   short seg031_2CFA_ED8
mov   al,MagicMotionAbilities_dseg_67d6_D2
mov   ah,0
and   ax,20h
cmp   ax,20h
jz    short Bouncing_seg031_2CFA_EE2
seg031_2CFA_ED8:
cmp   byte ptr [bx+16h],0Fh
jnz   short seg031_2CFA_EF0
Bouncing_seg031_2CFA_EE2:
mov   ax,[bx+0Ah]
neg   ax
mov   [bx+0Ah],ax
```

UW1 has none of it. Once the collision result has bit 2 set it goes straight to the damped arithmetic:

```asm
seg030_2B26_DF6:
test  si,4
jnz   short seg030_2B26_DFF
jmp   seg030_2B26_FA2
seg030_2B26_DFF:
mov   bx,dseg_5c99_284A_MotionParamsArray_initial
cmp   word ptr [bx+0Ah],0        ; straight into var_3 and the damping
```

So a UW1 bounce always damps. The port already carried a TODO on that branch saying it looked absent from UW1. It is.

## The speed reduction

UW2 tests the object index and the motion handler before the landing check, at `seg031_2CFA_F63`:

```asm
cmp   word ptr [bx+20h],1
jz    short seg031_2CFA_F8E
mov   bx,PtrTo26D2MotionHandler_dseg_67d6_26B8
mov   ax,[bx]
and   ax,1000h
cmp   ax,1000h
jnz   short seg031_2CFA_F8E
seg031_2CFA_F7B:
cmp   word ptr [bx+12h],1
jg    short seg031_2CFA_F88
jmp   seg031_2CFA_10CA
seg031_2CFA_F88:
dec   word ptr [bx+12h]
```

UW1 arrives at the equivalent of `F8E` with nothing ahead of it:

```asm
seg030_2B26_E86:
cmp   [bp+var_3],0
jnz   short seg030_2B26_E8F
jmp   seg030_2B26_FA0
```

## The momentum restore

UW2 saves the momentum at `seg031_2CFA_EC2` and puts it back at `seg031_2CFA_10CA` under a set of terrain tests. UW1 does neither. Its tail is:

```asm
seg030_2B26_FA0:
jmp   short seg030_2B26_FD3
...
seg030_2B26_FD3:
push  0
push  cs
call  near ptr seg030_2B26_788
inc   sp
inc   sp
```

There is no terrain test and no restore, and nothing anywhere in the UW1 routine saves the value in the first place. That is why `var6` has no UW1 counterpart.

## What is left shared

The damped arithmetic itself, because the two games agree on it line for line:

```
q        = -trunc(v / 15)
[+0x26]  = abs((15 - c) * q)
v        = q * c
momentum = c == 0 ? 0 : momentum - momentum * (15 - c) / 30
```

UW1 at `seg030_2B26_E26` onwards and UW2 at `seg031_2CFA_EF4` onwards, including the zero elasticity case that zeroes the momentum rather than scaling it, at `seg030_2B26_E7D` and `seg031_2CFA_F5A`.

## Three more of the same kind

These came out of cross-review, after the three above.

**The NPC landing tilestate.** UW1 has three outcomes at `seg030_2B26_F72`: `test dseg_5c99_2776,10h` gives 2, `test ...,20h` gives 4, and the fall through at `seg030_2B26_F96` gives 1. There is no `40h` test and no tilestate 8 anywhere in the UW1 routine. UW2 adds both at `seg031_2CFA_109E`, so a UW1 NPC landing with that bit set was getting 8 where DOS gives 1.

**The speed zeroing.** `seg031_2CFA_10B8` clears the speed field when the global at `26A4` is zero. UW1 has nothing equivalent: every tilestate store jumps straight to `seg030_2B26_FD3`, and no instruction after `seg030_2B26_D08` writes the speed field at all.

**The landing sound volume.** UW1 hardcodes effect 5 and passes `(mass - 600) / 32h` as the volume, computed at `seg030_2B26_D61`. UW2 picks the effect from the mass and passes a volume of zero, `push 0` at `Plsaysound_seg031_2CFA_E06`. The port already forked the effect but passed UW2's zero for both, so UW1 lost its volume term.

## One divergence deliberately not fixed here

The entry condition to the whole first branch also differs. UW1 does `mov ax,1` then `test dseg_5c99_2774,ax`, a bit test, so terrain 1 and 3 both enter, and it uses `jge` to skip, so it settles only when the pitch is strictly negative. UW2 requires `(C & 3) == 1` and settles at pitch `<= 0`, which is what the port has for both.

That one decides whether a landing takes the settle path at all rather than what happens once it has, so getting it wrong moves objects between two quite different code paths. It is raised on its own as #117 so it can be tried in play rather than changed on the disassembly alone.

## Something recorded, not fixed

The terrain condition inside the momentum restore does not match the assembly it sits under. DOS restores when `(C & 3) == 3` and bit 2 of `C` is **set**, `test ...,4` then `jnz` to the restore at `seg031_2CFA_10ED`, and it **skips** the restore when bit `0x800` of `E` is set, `test ...,800h` then `jnz` to `seg031_2CFA_10F9`. Both read inverted in the port. It is older than this branch and it is UW2 only now that the block is gated, so it is described in a comment rather than changed.

## A second, unrelated commit

While reading the routine: the collision sound volume divides the mass term by decimal `32` where both games divide by `32h`.

```asm
mov   ax,[bp+Mass_var_2]
add   ax,0FDA8h          ; mass - 600
mov   bx,32h
cwd
idiv  bx
```

at `seg030_2B26_D98` in UW1 and `seg031_2CFA_E43` in UW2. The other two constants in the same expression are written `0xA` and `40`, both correct, so this reads as a hex prefix that went missing rather than a choice. It makes the mass contribution about half again what DOS uses, so heavy objects land louder than they should.

It is in its own commit and can be dropped on its own if you would rather it went separately.

## Checked

Read out of `UW1_asm.asm` and `uw2_asm.asm`. The mnemonics are my reading of them.

No test is added; there is no physics coverage in the repository. The visible check is to throw something at a wall in UW1 and watch whether it comes back or drops, and to confirm UW2 is unchanged.

I widened this well beyond what #105 describes. Three of the six came from my own reading of the two routines and three more from cross-review, which also found the entry condition and the inverted momentum test. If you would rather see any of it as its own issue first, say so and I will split it.
