### PR TITLE
Make the player wait between casts, as DOS does

### DIFF
--- a/src/magic/runicmagic.cs
+++ b/src/magic/runicmagic.cs
@@ -259,8 +259,19 @@ namespace Underworld
         /// </summary>
         static bool SpellCastIntervalHasElapsed()
         {
-            long due = (uint)LastSpellCastClock_dseg_5c99_16E3 + SpellCastDelay_dseg_5c99_16E2;
-            return (uint)playerdat.ClockValue >= due;
+            uint now = (uint)playerdat.ClockValue;
+            uint last = (uint)LastSpellCastClock_dseg_5c99_16E3;
+            if (last > now)
+            {
+                // DOS cannot reach a stored clock later than the current one, because
+                // ResetMap_ovr109_2AB zeroes it at ovr109_4A7 whenever the map is reset.
+                // The port holds this in a static that outlives a game, so loading an
+                // earlier save after casting would leave a stamp in the future and block
+                // casting until the clock caught up, which could be hours of game time.
+                // Treating that as elapsed arrives where DOS's reset arrives.
+                return true;
+            }
+            return now >= (long)last + SpellCastDelay_dseg_5c99_16E2;
         }
 
         /// <summary>

--- a/src/magic/runicmagic.cs
+++ b/src/magic/runicmagic.cs
@@ -236,12 +236,69 @@ namespace Underworld
                 );
         }
 
+        /// <summary>
+        /// The interval DOS makes the player wait before the next cast, dseg_5c99_16E2 in
+        /// UW1. Held as a byte because the arithmetic that fills it is byte arithmetic.
+        /// </summary>
+        static byte SpellCastDelay_dseg_5c99_16E2 = 0;
+
+        /// <summary>
+        /// The game clock at the last cast that counted, dseg_5c99_16E3 and 16E5 as a
+        /// 32 bit pair. DOS keeps this in a global rather than in PLAYER.DAT, so it does
+        /// not survive a save and begins at zero, which is what a fresh static gives.
+        /// </summary>
+        static int LastSpellCastClock_dseg_5c99_16E3 = 0;
+
+        /// <summary>
+        /// DOS refuses a cast until the interval from the previous one has run out.
+        /// PlayerAttemptsSpellCast_ovr119_399 does it at ovr119_3CE: it widens the delay
+        /// byte, adds it to the stored clock as a 32 bit value, then compares the player
+        /// clock at PlayerDataPTR+0xCE against the result with ja, jb and jnb, so the
+        /// comparison is unsigned and a cast is allowed the moment the clock reaches the
+        /// threshold. See issue #104.
+        /// </summary>
+        static bool SpellCastIntervalHasElapsed()
+        {
+            long due = (uint)LastSpellCastClock_dseg_5c99_16E3 + SpellCastDelay_dseg_5c99_16E2;
+            return (uint)playerdat.ClockValue >= due;
+        }
+
+        /// <summary>
+        /// Sets the interval and stamps the clock, as DOS does at ovr119_55C:
+        /// shl al,1 then sub al,[bx+3Dh] then shl al,2 then add al,40h, all in a byte,
+        /// then stores the 32 bit clock. UW2 runs the same sequence with 0x80 in place of
+        /// 0x40, at ovr123_58E.
+        ///
+        /// The clock advances 256 units per second, so the floor is a quarter of a second
+        /// in UW1 and half a second in UW2, and each circle above the player's level adds
+        /// four units. The byte arithmetic is kept because it is what DOS does; it does
+        /// not wrap for any level and circle the games can actually reach.
+        /// </summary>
+        static void StartSpellCastInterval(int spellCircle)
+        {
+            byte al = (byte)(spellCircle << 1);
+            al = (byte)(al - playerdat.play_level);
+            al = (byte)(al << 2);
+            al = (byte)(al + (_RES == GAME_UW2 ? 0x80 : 0x40));
+            SpellCastDelay_dseg_5c99_16E2 = al;
+            LastSpellCastClock_dseg_5c99_16E3 = playerdat.ClockValue;
+        }
+
         public static void CastRunicSpell()
         {
             var spell = CurrentSpell();
             if (spell != null)
             {
-                if (spell.TestIfPlayerCanCastSpell())//force this to be true for test and development
+                if (!SpellCastIntervalHasElapsed())
+                {
+                    // Refused. DOS plays effect 0x15 at the avatar with pan 0x40 and
+                    // leaves, at ovr119_3EE. This gate sits ahead of every other test in
+                    // DOS, before it has even read the runes, so it goes ahead of them
+                    // here too.
+                    UWsoundeffects.PlaySoundEffectAtAvatar(effectno: 0x15, pan: 0x40, velocityOffset: 0);
+                    return;
+                }
+                if (spell.TestIfPlayerCanCastSpell())
                 {
                     //apply mana cost
                     playerdat.play_mana = System.Math.Max(0, playerdat.play_mana - spell.ManaCost);
@@ -249,6 +306,14 @@ namespace Underworld
                     Debug.Print($"{spell.spellname}");
                     //do the skill check
                     var chkresult = playerdat.SkillCheck(playerdat.Casting, spell.SpellLevel * 3);
+                    // An ordinary failed incantation does not start the interval. DOS
+                    // tests the skill result at ovr119_518 with jnz and leaves on zero,
+                    // which is Fail, before reaching the code that stamps the clock. A
+                    // critical failure falls through into the backfire and does stamp it.
+                    if (chkresult != playerdat.SkillCheckResult.Fail)
+                    {
+                        StartSpellCastInterval(spell.SpellLevel);
+                    }
                     switch (chkresult)
                     {
                         case playerdat.SkillCheckResult.CritFail:

--- a/src/magic/runicmagic.cs
+++ b/src/magic/runicmagic.cs
@@ -263,12 +263,14 @@ namespace Underworld
             uint last = (uint)LastSpellCastClock_dseg_5c99_16E3;
             if (last > now)
             {
-                // DOS cannot reach a stored clock later than the current one, because
-                // ResetMap_ovr109_2AB zeroes it at ovr109_4A7 whenever the map is reset.
-                // The port holds this in a static that outlives a game, so loading an
-                // earlier save after casting would leave a stamp in the future and block
-                // casting until the clock caught up, which could be hours of game time.
-                // Treating that as elapsed arrives where DOS's reset arrives.
+                // DOS cannot reach a stored clock later than the current one. ovr109_43C
+                // zeroes it, and that runs on a game restore, reached through stub109_61
+                // from RestoreGame_ovr140_44B, and on death through
+                // DeathEndGame_ovr109_4FB. The port holds this in a static that outlives a
+                // game, so loading an earlier save after casting would leave a stamp in
+                // the future and refuse every cast until the clock caught up, which could
+                // be hours of game time. Treating that as elapsed arrives where DOS's
+                // reset arrives, without a hook the port does not have.
                 return true;
             }
             return now >= (long)last + SpellCastDelay_dseg_5c99_16E2;
@@ -280,10 +282,15 @@ namespace Underworld
         /// then stores the 32 bit clock. UW2 runs the same sequence with 0x80 in place of
         /// 0x40, at ovr123_58E.
         ///
-        /// The clock advances 256 units per second, so the floor is a quarter of a second
-        /// in UW1 and half a second in UW2, and each circle above the player's level adds
-        /// four units. The byte arithmetic is kept because it is what DOS does; it does
-        /// not wrap for any level and circle the games can actually reach.
+        /// In full the delay is 8 * circle - 4 * level + 0x40, so each circle adds eight
+        /// units and each character level takes away four. The clock advances 256 units a
+        /// second, which puts the floor at a quarter of a second in UW1 and half in UW2.
+        ///
+        /// The byte width is deliberate and is not a detail. Once the level passes
+        /// 2 * circle + 16 the true value would go negative, and the byte wraps it to a
+        /// large one instead: a level 19 character casting a first circle spell waits 252
+        /// units, near a full second, rather than none at all. DOS does the same, so the
+        /// arithmetic is kept in bytes throughout rather than widened.
         /// </summary>
         static void StartSpellCastInterval(int spellCircle)
         {
@@ -297,18 +304,24 @@ namespace Underworld
 
         public static void CastRunicSpell()
         {
+            if (!SpellCastIntervalHasElapsed())
+            {
+                // Refused. DOS plays effect 0x15 at the avatar with pan 0x40 and leaves,
+                // at ovr119_3EE. The test sits ahead of everything else, before DOS has
+                // even read the runes, so a refused attempt sounds the same whether or not
+                // the runes make a spell. That is why this is ahead of the lookup.
+                UWsoundeffects.PlaySoundEffectAtAvatar(effectno: 0x15, pan: 0x40, velocityOffset: 0);
+                if (_RES == GAME_UW2)
+                {
+                    // UW2 says so as well, at ovr123_3F8: push 0Bh then
+                    // PrintStringFromBlock1. UW1 has no message, only the sound.
+                    uimanager.AddToMessageScroll(GameStrings.GetString(1, 0x0B));
+                }
+                return;
+            }
             var spell = CurrentSpell();
             if (spell != null)
             {
-                if (!SpellCastIntervalHasElapsed())
-                {
-                    // Refused. DOS plays effect 0x15 at the avatar with pan 0x40 and
-                    // leaves, at ovr119_3EE. This gate sits ahead of every other test in
-                    // DOS, before it has even read the runes, so it goes ahead of them
-                    // here too.
-                    UWsoundeffects.PlaySoundEffectAtAvatar(effectno: 0x15, pan: 0x40, velocityOffset: 0);
-                    return;
-                }
                 if (spell.TestIfPlayerCanCastSpell())
                 {
                     //apply mana cost


### PR DESCRIPTION
Closes #104.

Spells could be cast as fast as the runes could be clicked. DOS makes the player wait, for a period that depends on the spell circle and the character level.

## The gate

It is the first thing `PlayerAttemptsSpellCast_ovr119_399` does, at `ovr119_3CE`, ahead of reading the runes and ahead of every mana and level test:

```asm
mov   al,dseg_5c99_16E2      ; the delay
mov   ah,0
cwd
mov   cx,dseg_5c99_16E5      ; the stored clock, high
mov   di,dseg_5c99_16E3      ; the stored clock, low
add   di,ax
adc   cx,dx
cmp   [bx+0D0h],cx           ; the player clock, high
ja    short ovr119_3FE
jb    short ovr119_3EE
cmp   [bx+0CEh],di           ; equal highs, compare low
jnb   short ovr119_3FE
ovr119_3EE:
push  0
push  40h
push  15h
call  PlaySoundEffectAtAvatar_seg014_1DC5_B1B
```

The comparison is unsigned across 32 bits and `jnb` allows the cast the moment the clock reaches the threshold. On refusal it plays effect `0x15` at the avatar with pan `0x40` and leaves.

UW2 does the same and then says so, at `ovr123_3F8`: `push 0Bh` into `PrintStringFromBlock1`, which is "You are not yet ready to cast another spell." UW1 has no message and only the sound.

Because DOS tests this before it has read the runes, a refused attempt sounds the same whether or not the runes make a spell. The gate therefore sits ahead of the spell lookup here, not inside it.

## The interval

Set at `ovr119_55C`, all in a byte:

```asm
mov   al,[bp+SpellLevel_var_1]
shl   al,1                   ; circle * 2
mov   bx,PlayerDataPTR_dseg_5c99_7270
sub   al,[bx+3Dh]            ; minus the character level
shl   al,2
add   al,40h
mov   dseg_5c99_16E2,al
mov   ax,[bx+0D0h]
mov   dx,[bx+0CEh]
mov   dseg_5c99_16E3,dx
mov   dseg_5c99_16E5,ax      ; stamp the clock
```

So `8 * circle - 4 * level + 0x40`. UW2 runs the identical sequence with `0x80` at `ovr123_589`, which @hankmorgan pointed out on the issue and which I then read at the site. The clock advances 256 units a second, so the floor is a quarter of a second in UW1 and half in UW2.

The byte width matters and is kept. Once the level passes `2 * circle + 16` the true value would go negative, and the byte wraps it large instead, so a level 19 character casting a first circle spell waits 252 units rather than none at all.

## When it starts

An ordinary failed incantation does not start it. DOS tests the skill result at `ovr119_518` with `or ax,ax` then `jnz`, and leaves on zero, which is a plain failure, before it reaches the code above. A critical failure falls through the backfire and does start it. The port splits the two the same way.

## One deliberate divergence

DOS holds the delay and the stamp in globals rather than in `PLAYER.DAT`, so the port holds them in statics. DOS also zeroes the stamp in `ovr109_43C`, which runs on a game restore through `stub109_61` from `RestoreGame_ovr140_44B`, and on death through `DeathEndGame_ovr109_4FB`.

The port has no equivalent hook and a static outlives a game. Cast late in one game, load an earlier save, and the stamp would be in the future, refusing every cast until the clock caught up, which could be hours of game time and would point at nothing. So a stamp later than the current clock is treated as elapsed. That is a different mechanism from DOS reaching the same place, and it is commented as such.

## Not in this change

Two things came out of review that belong to their own routines rather than this one.

A failed incantation costs mana in the port and is free in DOS, raised as #119. It sits directly above the code this change touches but predates it.

Object casting has a separate flat cooldown of `0x2FD` units in DOS that the port lacks entirely, raised as #120. The runic interval correctly does not apply to wands and scrolls; DOS gates them with their own timer instead.

## Checked

Read out of `UW1_asm.asm` and `uw2_asm.asm` against the shipped executables. The mnemonics are my reading of them.

Cross-reviewed, which caught the missing UW2 message, the gate sitting inside the spell lookup rather than ahead of it, and two comments of mine that were wrong about where DOS resets the stamp and about whether the byte arithmetic wraps.

No test is added; there is no coverage of the magic code and this needs the game clock and the rune UI. The audible check is that holding down a cast should now be refused with sound `0x15` rather than casting repeatedly, that a failed incantation lets you retry at once, and that UW2 also prints the message.

I have not played it.
